### PR TITLE
Fix gather/gatherElements/gatherND WPT conformance

### DIFF
--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -838,6 +838,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         .or(Some(DataType::Int32)),
                     "expand"
                     | "gather"
+                    | "gatherelements"
+                    | "gathernd"
                     | "concat"
                     | "slice"
                     | "reshape"


### PR DESCRIPTION
Add explicit ONNX lowering for gather family operations to match WebNN behavior and WPT expectations.

- gather: fix output shape inference and always set axis attribute on ONNX Gather
- gatherElements: cast indices to int64, clamp indices to valid range, and emit GatherElements with axis
- gatherND: cast indices to int64, clamp per-axis index components with broadcasted Max/Min, and forward batch_dims when present
- webnn_json: infer output dtype for gatherElements/gatherND from data input (fixes float16 mismatches)
