### PR TITLE
Implement linear op for ONNX and CoreML converters

### DIFF
--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -496,7 +496,7 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                 "abs" | "ceil" | "floor" | "neg" | "relu" | "sigmoid" | "tanh" | "exp" | "log"
                 | "sqrt" | "erf" | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh"
                 | "cosh" | "asinh" | "acosh" | "atanh" | "round" | "sign" | "reciprocal"
-                | "softplus" | "softsign" | "softmax" | "gelu" | "identity" | "cast"
+                | "softplus" | "softsign" | "softmax" | "gelu" | "linear" | "identity" | "cast"
                 | "logical_not" | "quantizelinear" | "dequantizelinear" => {
                     input_shapes.first().cloned()
                 }
@@ -881,6 +881,7 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     | "softsign"
                     | "softmax"
                     | "gelu"
+                    | "linear"
                     | "identity"
                     | "hardsigmoid"
                     | "hardswish"


### PR DESCRIPTION
Add WebNN linear (y = alpha * x + beta) support across ONNX and CoreML paths.

ONNX:
- Lower linear to primitive Mul + Add nodes
- Default alpha=1 and beta=0
- Parse finite/non-finite numeric JSON attributes via parse_f64_attr
- Compute in float32 for float16 input and cast back to float16
- Reject unsupported non-float input dtypes for linear

CoreML MLProgram:
- Lower linear to mul + add operations with typed immediate alpha/beta
- Support float32 and float16 input/output
- Reject unsupported non-float input dtypes for linear

Graph import/inference:
- Add linear to unary shape inference and output dtype propagation in webnn_json
