### PR TITLE
Fix isNaN ONNX lowering and WPT conformance

### DIFF
--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -497,9 +497,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                 | "sqrt" | "erf" | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "sinh"
                 | "cosh" | "asinh" | "acosh" | "atanh" | "round" | "sign" | "reciprocal"
                 | "softplus" | "softsign" | "softmax" | "gelu" | "linear" | "identity" | "cast"
-                | "logical_not" | "quantizelinear" | "dequantizelinear" => {
-                    input_shapes.first().cloned()
-                }
+                | "logical_not" | "isnan" | "isinfinite" | "quantizelinear"
+                | "dequantizelinear" => input_shapes.first().cloned(),
 
                 // Concat
                 "concat" => {
@@ -914,9 +913,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     | "reducesumsquare" => input_types.first().cloned(),
                     "greater" | "greaterorequal" | "less" | "lesser" | "lessorequal"
                     | "lesserorequal" | "equal" | "notequal" | "logical_and" | "logical_or"
-                    | "logical_xor" | "logicaland" | "logicalor" | "logicalxor" | "logicalnot" => {
-                        Some(DataType::Uint8)
-                    }
+                    | "logical_xor" | "logicaland" | "logicalor" | "logicalxor" | "logicalnot"
+                    | "isnan" | "isinfinite" => Some(DataType::Uint8),
                     "where" => input_types
                         .get(1)
                         .cloned()


### PR DESCRIPTION
Implement unary predicate handling for isNaN/isInfinite in ONNX conversion path by emitting bool predicate nodes and casting outputs to uint8 for WebNN compatibility.

Also update webnn_json shape/type inference so isnan/isinfinite keep input shape and infer uint8 output dtype.
