### PR TITLE
Fix casing for argMax and argMin in coreml converter

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1922,7 +1922,7 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            "argMax" | "argMin" => {
+            "argmax" | "argmin" => {
                 // reduce_argmax/reduce_argmin: x, axis, keep_dims
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));


### PR DESCRIPTION
## Summary

Since the match is on the lower case transformation of the operand name, the upper case "argMin" and "argMax" are never matched on and the converted program is missing information, which makes subsequent compilation fails. 

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

I've run into this problem while working on https://github.com/rustnn/rustnn/issues/56
and this was the only way for me to get a subset of `/wpt/tests/webnn/conformance_tests/arg_min_max.https.any.js` to pass on CoreML(I'm assuming the results at https://rustnn.github.io/rustnnpt/ are only testing ONNX?)

