### PR TITLE
add epsilon to reciprocal

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -151,6 +151,9 @@ mod mil_ops {
     pub const CLIP: &str = "clip";
 }
 
+// Default epsilon value used by several CoreML operations for numerical stability.
+const DEFAULT_EPSILON: f32 = 1e-45;
+
 #[derive(Default)]
 pub struct CoremlMlProgramConverter;
 
@@ -1123,12 +1126,23 @@ impl CoremlMlProgramConverter {
 
             // Unary operations: x
             "relu" | "sigmoid" | "tanh" | "abs" | "ceil" | "floor" | "roundeven" | "sign"
-            | "identity" | "exp" | "sqrt" | "reciprocal" | "sin" | "cos" | "tan" | "asin"
-            | "acos" | "atan" | "sinh" | "cosh" | "asinh" | "acosh" | "atanh" | "erf"
-            | "logicalnot" | "softplus" | "softsign" => {
+            | "identity" | "exp" | "sqrt" | "sin" | "cos" | "tan" | "asin" | "acos" | "atan"
+            | "sinh" | "cosh" | "asinh" | "acosh" | "atanh" | "erf" | "logicalnot" | "softplus"
+            | "softsign" => {
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
+            }
+
+            "reciprocal" => {
+                if !input_names.is_empty() {
+                    inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
+                }
+                // Reciprocal requires epsilon parameter (default to 1e-45 for numerical stability)
+                inputs.insert(
+                    "epsilon".to_string(),
+                    Self::create_immediate_float(DEFAULT_EPSILON),
+                );
             }
 
             // Log operation requires epsilon parameter
@@ -1137,7 +1151,10 @@ impl CoremlMlProgramConverter {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
                 // CoreML log requires epsilon parameter (default to 1e-45 for numerical stability)
-                inputs.insert("epsilon".to_string(), Self::create_immediate_float(1e-45));
+                inputs.insert(
+                    "epsilon".to_string(),
+                    Self::create_immediate_float(DEFAULT_EPSILON),
+                );
             }
 
             // Quantization operations: input, scale, zero_point


### PR DESCRIPTION
The reciprocal operation in coreml requires epsilon.

replaces https://github.com/rustnn/rustnn/pull/60