### PR TITLE
Draft: Update converter

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1217,12 +1217,11 @@ impl CoremlMlProgramConverter {
             | Operation::LesserOrEqual { .. }
             | Operation::LogicalAnd { .. }
             | Operation::LogicalOr { .. }
-            | Operation::LogicalXor { .. } => {
-                if input_names.len() >= 2 {
+            | Operation::LogicalXor { .. }
+                if input_names.len() >= 2 => {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                     inputs.insert("y".to_string(), Self::create_argument(&input_names[1]));
                 }
-            }
 
             // MatMul operation: x, y, transpose_x, transpose_y
             // CoreML requires transpose parameters, WebNN doesn't have them so default to false
@@ -1325,11 +1324,10 @@ impl CoremlMlProgramConverter {
             | Operation::Erf { .. }
             | Operation::LogicalNot { .. }
             | Operation::Softplus { .. }
-            | Operation::Softsign { .. } => {
-                if !input_names.is_empty() {
+            | Operation::Softsign { .. }
+                if !input_names.is_empty() => {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
-            }
 
             Operation::Reciprocal { .. } => {
                 if !input_names.is_empty() {
@@ -1355,8 +1353,8 @@ impl CoremlMlProgramConverter {
             }
 
             // Quantization operations: input, scale, zero_point
-            Operation::DequantizeLinear { .. } | Operation::QuantizeLinear { .. } => {
-                if input_names.len() >= 3 {
+            Operation::DequantizeLinear { .. } | Operation::QuantizeLinear { .. }
+                if input_names.len() >= 3 => {
                     inputs.insert("input".to_string(), Self::create_argument(&input_names[0]));
                     inputs.insert("scale".to_string(), Self::create_argument(&input_names[1]));
                     inputs.insert(
@@ -1364,15 +1362,13 @@ impl CoremlMlProgramConverter {
                         Self::create_argument(&input_names[2]),
                     );
                 }
-            }
 
             // Specialized activation: prelu - x, slope (two inputs)
-            Operation::Prelu { .. } => {
-                if input_names.len() >= 2 {
+            Operation::Prelu { .. }
+                if input_names.len() >= 2 => {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                     inputs.insert("alpha".to_string(), Self::create_argument(&input_names[1]));
                 }
-            }
 
             // Specialized activations with alpha parameter: elu, leakyRelu
             Operation::Elu { options, .. } => {
@@ -2068,14 +2064,13 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::Where { .. } => {
+            Operation::Where { .. }
                 // select: cond, a (true_value), b (false_value)
-                if input_names.len() >= 3 {
+                if input_names.len() >= 3 => {
                     inputs.insert("cond".to_string(), Self::create_argument(&input_names[0]));
                     inputs.insert("a".to_string(), Self::create_argument(&input_names[1]));
                     inputs.insert("b".to_string(), Self::create_argument(&input_names[2]));
                 }
-            }
 
             Operation::Pad {
                 beginning_padding,
@@ -2109,14 +2104,13 @@ impl CoremlMlProgramConverter {
                 // WebNN modes: "constant", "edge", "reflection", "symmetric"
             }
 
-            Operation::Gelu { .. } => {
+            Operation::Gelu { .. }
                 // gelu: x (mode is optional, defaults to "EXACT")
-                if !input_names.is_empty() {
+                if !input_names.is_empty() => {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
                 // CoreML GELU supports "EXACT" and "TANH_APPROXIMATION" modes
                 // WebNN GELU has no mode parameter (uses exact by default)
-            }
 
             Operation::Squeeze { options, .. } => {
                 if !input_names.is_empty() {
@@ -2209,9 +2203,9 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::ScatterND { .. } => {
+            Operation::ScatterND { .. }
                 // scatter_nd: data, indices, updates
-                if input_names.len() >= 3 {
+                if input_names.len() >= 3 => {
                     inputs.insert("data".to_string(), Self::create_argument(&input_names[0]));
                     inputs.insert(
                         "indices".to_string(),
@@ -2222,7 +2216,6 @@ impl CoremlMlProgramConverter {
                         Self::create_argument(&input_names[2]),
                     );
                 }
-            }
 
             Operation::Tile { repetitions, .. } => {
                 // tile: x, reps

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -7065,7 +7065,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     });
                 }
 
-                if let Some(new_shape_value) = serde_json::to_value(new_shape).ok() {
+                if let Ok(new_shape_value) = serde_json::to_value(new_shape) {
                     // WebNN expand with newShape can be either:
                     // 1. ONNX Expand (broadcasting-compatible shapes)
                     // 2. ONNX Reshape (arbitrary shape changes)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -3150,7 +3150,7 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        let var_shape: Vec<_> = var_dims.iter().copied().collect();
+        let var_shape: Vec<_> = var_dims;
         let epsilon_const = network
             .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
@@ -3677,7 +3677,7 @@ impl TrtxConverter {
                 reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
             })?;
         let var_shape: Vec<i64> = var_dims;
-        let num_var_el: usize = var_dims.iter().map(|&d| d as usize).product();
+        let num_var_el: usize = var_shape.iter().map(|&d| d as usize).product();
         let input_operand = graph
             .operand(operation.input_operands()[0])
             .ok_or_else(|| GraphError::ConversionFailed {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1045,11 +1045,11 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility (this may reshape tensors if needed)
-        let (mut bc_input0, mut bc_input1) =
+        let (bc_input0, bc_input1) =
             Self::ensure_broadcast_compatible(network, input0, input1, operation.op_type())?;
 
         let layer = network
-            .add_elementwise(&mut bc_input0, &mut bc_input1, op_code)
+            .add_elementwise(&bc_input0, &bc_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elementwise operation: {}", e),
@@ -1092,18 +1092,18 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility
-        let (mut bc_input0, mut bc_input1) =
+        let (bc_input0, bc_input1) =
             Self::ensure_broadcast_compatible(network, input0, input1, operation.op_type())?;
 
         // Comparison operation returns BOOL
         let layer = network
-            .add_elementwise(&mut bc_input0, &mut bc_input1, op_code)
+            .add_elementwise(&bc_input0, &bc_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add comparison operation: {}", e),
             })?;
 
-        let mut bool_output =
+        let bool_output =
             layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1112,7 +1112,7 @@ impl TrtxConverter {
                 })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
-        let output = Self::cast_to_float32(network, &mut bool_output)?;
+        let output = Self::cast_to_float32(network, &bool_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1151,16 +1151,14 @@ impl TrtxConverter {
         let bool_input1 = Self::cast_to_bool(network, &bc_input1)?;
 
         // Perform logical operation on BOOL
-        let mut bool_input0 = bool_input0;
-        let mut bool_input1 = bool_input1;
         let layer = network
-            .add_elementwise(&mut bool_input0, &mut bool_input1, op_code)
+            .add_elementwise(&bool_input0, &bool_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add logical operation: {}", e),
             })?;
 
-        let mut bool_output =
+        let bool_output =
             layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1169,7 +1167,7 @@ impl TrtxConverter {
                 })?;
 
         // Cast BOOL output back to Float32
-        let output = Self::cast_to_float32(network, &mut bool_output)?;
+        let output = Self::cast_to_float32(network, &bool_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1194,7 +1192,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let mut not_input = if graph
+        let not_input = if graph
             .constant_operand_ids_to_handles
             .contains_key(&input_id)
         {
@@ -1244,13 +1242,13 @@ impl TrtxConverter {
         };
 
         let layer = network
-            .add_unary(&mut not_input, UnaryOperation::kNOT.into())
+            .add_unary(&not_input, UnaryOperation::kNOT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add logical NOT: {}", e),
             })?;
 
-        let mut not_output =
+        let not_output =
             layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1258,7 +1256,7 @@ impl TrtxConverter {
                     reason: format!("Failed to get layer output: {}", e),
                 })?;
 
-        let output = Self::cast_to_float32(network, &mut not_output)?;
+        let output = Self::cast_to_float32(network, &not_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1362,7 +1360,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for elu: {}", e),
             })?;
-        let mut relu_output =
+        let relu_output =
             relu_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1371,12 +1369,12 @@ impl TrtxConverter {
                 })?;
 
         let exp_layer = network
-            .add_unary(input, UnaryOperation::kEXP.into())
+            .add_unary(input, UnaryOperation::kEXP)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add exp for elu: {}", e),
             })?;
-        let mut exp_output =
+        let exp_output =
             exp_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1385,12 +1383,12 @@ impl TrtxConverter {
                 })?;
 
         let one_const = network
-            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create one constant for elu: {}", e),
             })?;
-        let mut one_tensor =
+        let one_tensor =
             one_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1398,20 +1396,16 @@ impl TrtxConverter {
                     reason: format!("Failed to get one constant output: {}", e),
                 })?;
 
-        let (mut bc_exp, mut bc_one) = Self::ensure_broadcast_compatible(
-            network,
-            &mut exp_output,
-            &mut one_tensor,
-            "elu_exp_sub",
-        )?;
+        let (bc_exp, bc_one) =
+            Self::ensure_broadcast_compatible(network, &exp_output, &one_tensor, "elu_exp_sub")?;
 
         let exp_minus_1_layer = network
-            .add_elementwise(&mut bc_exp, &mut bc_one, ElementWiseOperation::kSUB)
+            .add_elementwise(&bc_exp, &bc_one, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract 1 for elu: {}", e),
             })?;
-        let mut exp_minus_1 =
+        let exp_minus_1 =
             exp_minus_1_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1420,12 +1414,12 @@ impl TrtxConverter {
                 })?;
 
         let zero_const = network
-            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create zero constant for elu: {}", e),
             })?;
-        let mut zero_tensor =
+        let zero_tensor =
             zero_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1433,20 +1427,16 @@ impl TrtxConverter {
                     reason: format!("Failed to get zero constant output: {}", e),
                 })?;
 
-        let (mut bc_em1, mut bc_zero) = Self::ensure_broadcast_compatible(
-            network,
-            &mut exp_minus_1,
-            &mut zero_tensor,
-            "elu_min",
-        )?;
+        let (bc_em1, bc_zero) =
+            Self::ensure_broadcast_compatible(network, &exp_minus_1, &zero_tensor, "elu_min")?;
 
         let neg_part_layer = network
-            .add_elementwise(&mut bc_em1, &mut bc_zero, ElementWiseOperation::kMIN)
+            .add_elementwise(&bc_em1, &bc_zero, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min for elu: {}", e),
             })?;
-        let mut neg_part =
+        let neg_part =
             neg_part_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1455,12 +1445,12 @@ impl TrtxConverter {
                 })?;
 
         let alpha_const = network
-            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create alpha constant for elu: {}", e),
             })?;
-        let mut alpha_tensor =
+        let alpha_tensor =
             alpha_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1468,20 +1458,16 @@ impl TrtxConverter {
                     reason: format!("Failed to get alpha constant output: {}", e),
                 })?;
 
-        let (mut bc_neg, mut bc_alpha) = Self::ensure_broadcast_compatible(
-            network,
-            &mut neg_part,
-            &mut alpha_tensor,
-            "elu_scale",
-        )?;
+        let (bc_neg, bc_alpha) =
+            Self::ensure_broadcast_compatible(network, &neg_part, &alpha_tensor, "elu_scale")?;
 
         let scaled_neg_layer = network
-            .add_elementwise(&mut bc_neg, &mut bc_alpha, ElementWiseOperation::kPROD)
+            .add_elementwise(&bc_neg, &bc_alpha, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to multiply by alpha for elu: {}", e),
             })?;
-        let mut scaled_neg =
+        let scaled_neg =
             scaled_neg_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1489,15 +1475,11 @@ impl TrtxConverter {
                     reason: format!("Failed to get scaled neg output: {}", e),
                 })?;
 
-        let (mut bc_relu, mut bc_scaled) = Self::ensure_broadcast_compatible(
-            network,
-            &mut relu_output,
-            &mut scaled_neg,
-            "elu_add",
-        )?;
+        let (bc_relu, bc_scaled) =
+            Self::ensure_broadcast_compatible(network, &relu_output, &scaled_neg, "elu_add")?;
 
         let final_layer = network
-            .add_elementwise(&mut bc_relu, &mut bc_scaled, ElementWiseOperation::kSUM)
+            .add_elementwise(&bc_relu, &bc_scaled, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elu parts: {}", e),
@@ -1530,12 +1512,13 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let layer = network.add_unary(input, unary_op.into()).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to add unary operation: {}", e),
-            }
-        })?;
+        let layer =
+            network
+                .add_unary(input, unary_op)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add unary operation: {}", e),
+                })?;
 
         // Extract output tensor from layer
         let output = layer
@@ -1599,7 +1582,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("LeakyReLU: failed to add alpha constant: {}", e),
             })?;
-        let mut alpha_tensor =
+        let alpha_tensor =
             alpha_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1614,7 +1597,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for leaky relu: {}", e),
             })?;
-        let mut relu_output =
+        let relu_output =
             relu_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1624,12 +1607,12 @@ impl TrtxConverter {
 
         // min(0, x) = x - relu(x)
         let neg_part_layer = network
-            .add_elementwise(input, &mut relu_output, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &relu_output, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get min(0,x) for leaky relu: {}", e),
             })?;
-        let mut neg_part =
+        let neg_part =
             neg_part_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1639,16 +1622,12 @@ impl TrtxConverter {
 
         // alpha * min(0, x)
         let scaled_neg_layer = network
-            .add_elementwise(
-                &mut neg_part,
-                &mut alpha_tensor,
-                ElementWiseOperation::kPROD,
-            )
+            .add_elementwise(&neg_part, &alpha_tensor, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale neg part for leaky relu: {}", e),
             })?;
-        let mut scaled_neg =
+        let scaled_neg =
             scaled_neg_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1658,11 +1637,7 @@ impl TrtxConverter {
 
         // relu(x) + alpha * min(0, x)
         let final_layer = network
-            .add_elementwise(
-                &mut relu_output,
-                &mut scaled_neg,
-                ElementWiseOperation::kSUM,
-            )
+            .add_elementwise(&relu_output, &scaled_neg, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add leaky relu parts: {}", e),
@@ -1712,7 +1687,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for prelu: {}", e),
             })?;
-        let mut relu_output =
+        let relu_output =
             relu_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1727,7 +1702,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add second relu: {}", e),
             })?;
-        let mut zero_output =
+        let zero_output =
             zero_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1737,12 +1712,12 @@ impl TrtxConverter {
 
         // x - relu(x) = min(0, x)
         let neg_part_layer = network
-            .add_elementwise(input, &mut zero_output, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &zero_output, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract for prelu: {}", e),
             })?;
-        let mut neg_part =
+        let neg_part =
             neg_part_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1752,12 +1727,12 @@ impl TrtxConverter {
 
         // slope * min(0, x)
         let scaled_neg_layer = network
-            .add_elementwise(&mut neg_part, slope, ElementWiseOperation::kPROD)
+            .add_elementwise(&neg_part, slope, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale negative part: {}", e),
             })?;
-        let mut scaled_neg =
+        let scaled_neg =
             scaled_neg_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1767,11 +1742,7 @@ impl TrtxConverter {
 
         // Final: relu + slope * neg_part
         let final_layer = network
-            .add_elementwise(
-                &mut relu_output,
-                &mut scaled_neg,
-                ElementWiseOperation::kSUM,
-            )
+            .add_elementwise(&relu_output, &scaled_neg, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add prelu parts: {}", e),
@@ -1866,19 +1837,19 @@ impl TrtxConverter {
             ),
         };
         let alpha_const = network
-            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add alpha constant: {}", e),
             })?;
         let beta_const = network
-            .add_small_constant_copied(&broadcast_shape, &beta_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &beta_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add beta constant: {}", e),
             })?;
         let zero_const = network
-            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add zero constant: {}", e),
@@ -1890,28 +1861,28 @@ impl TrtxConverter {
                 reason: format!("HardSigmoid: failed to add one constant: {}", e),
             })?;
 
-        let mut alpha_out =
+        let alpha_out =
             alpha_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: alpha const output: {}", e),
                 })?;
-        let mut beta_out =
+        let beta_out =
             beta_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: beta const output: {}", e),
                 })?;
-        let mut zero_out =
+        let zero_out =
             zero_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: zero const output: {}", e),
                 })?;
-        let mut one_out =
+        let one_out =
             one_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1921,24 +1892,24 @@ impl TrtxConverter {
 
         // linear = alpha * x + beta
         let ax = network
-            .add_elementwise(input, &mut alpha_out, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &alpha_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: alpha*x: {}", e),
             })?;
-        let mut linear = ax
+        let linear = ax
             .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear get output: {}", e),
             })?;
         let linear_plus_beta = network
-            .add_elementwise(&mut linear, &mut beta_out, ElementWiseOperation::kSUM)
+            .add_elementwise(&linear, &beta_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear+beta: {}", e),
             })?;
-        let mut linear_out =
+        let linear_out =
             linear_plus_beta
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1948,19 +1919,19 @@ impl TrtxConverter {
 
         // clamp(linear, 0, 1) = max(0, min(1, linear))
         let min1 = network
-            .add_elementwise(&mut linear_out, &mut one_out, ElementWiseOperation::kMIN)
+            .add_elementwise(&linear_out, &one_out, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: min(1, linear): {}", e),
             })?;
-        let mut min1_out =
-            min1.get_output(network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSigmoid: min1 output: {}", e),
-                })?;
+        let min1_out = min1
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSigmoid: min1 output: {}", e),
+            })?;
         let output_layer = network
-            .add_elementwise(&mut zero_out, &mut min1_out, ElementWiseOperation::kMAX)
+            .add_elementwise(&zero_out, &min1_out, ElementWiseOperation::kMAX)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: max(0, ...): {}", e),
@@ -2029,13 +2000,13 @@ impl TrtxConverter {
             ),
         };
         let three_const = network
-            .add_small_constant_copied(&broadcast_shape, &three_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &three_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 3 constant: {}", e),
             })?;
         let six_const = network
-            .add_small_constant_copied(&broadcast_shape, &six_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &six_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 6 constant: {}", e),
@@ -2047,21 +2018,21 @@ impl TrtxConverter {
                 reason: format!("HardSwish: failed to add zero constant: {}", e),
             })?;
 
-        let mut three_out =
+        let three_out =
             three_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: 3 const output: {}", e),
                 })?;
-        let mut six_out =
+        let six_out =
             six_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: 6 const output: {}", e),
                 })?;
-        let mut zero_out =
+        let zero_out =
             zero_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -2071,12 +2042,12 @@ impl TrtxConverter {
 
         // Spec: div(mul(input, max(0, min(6, add(input, 3)))), 6)
         let x_plus_3 = network
-            .add_elementwise(input, &mut three_out, ElementWiseOperation::kSUM)
+            .add_elementwise(input, &three_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: add(input, 3): {}", e),
             })?;
-        let mut x_plus_3_out =
+        let x_plus_3_out =
             x_plus_3
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -2084,37 +2055,36 @@ impl TrtxConverter {
                     reason: format!("HardSwish: x+3 output: {}", e),
                 })?;
         let min6 = network
-            .add_elementwise(&mut six_out, &mut x_plus_3_out, ElementWiseOperation::kMIN)
+            .add_elementwise(&six_out, &x_plus_3_out, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: min(6, x+3): {}", e),
             })?;
-        let mut min6_out =
-            min6.get_output(network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSwish: min6 output: {}", e),
-                })?;
+        let min6_out = min6
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSwish: min6 output: {}", e),
+            })?;
         let inner = network
-            .add_elementwise(&mut zero_out, &mut min6_out, ElementWiseOperation::kMAX)
+            .add_elementwise(&zero_out, &min6_out, ElementWiseOperation::kMAX)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: max(0, ...): {}", e),
             })?;
-        let mut inner_out =
-            inner
-                .get_output(network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSwish: inner output: {}", e),
-                })?;
+        let inner_out = inner
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSwish: inner output: {}", e),
+            })?;
         let x_times_inner = network
-            .add_elementwise(input, &mut inner_out, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &inner_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: mul(input, inner): {}", e),
             })?;
-        let mut x_times_inner_out =
+        let x_times_inner_out =
             x_times_inner
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -2122,11 +2092,7 @@ impl TrtxConverter {
                     reason: format!("HardSwish: x*inner output: {}", e),
                 })?;
         let output_layer = network
-            .add_elementwise(
-                &mut x_times_inner_out,
-                &mut six_out,
-                ElementWiseOperation::kDIV,
-            )
+            .add_elementwise(&x_times_inner_out, &six_out, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: div(..., 6): {}", e),
@@ -2316,21 +2282,17 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
+                let reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to get reshape output: {}", e),
                     }
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
-                let mut scale_tensor =
+                let scale_tensor =
                     Self::add_dq_scale_constant_helper(network, "int8->float32 cast")?;
                 let mut dq_layer = network
-                    .add_dequantize(
-                        &mut reshaped_4d,
-                        &mut scale_tensor,
-                        TrtDataType::kFLOAT.into(),
-                    )
+                    .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
@@ -2378,27 +2340,22 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
+                let reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to get reshape output: {}", e),
                     }
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
-                let mut scale_tensor =
-                    Self::add_dq_scale_constant_helper(network, "int8->int32 cast")?;
+                let scale_tensor = Self::add_dq_scale_constant_helper(network, "int8->int32 cast")?;
                 let mut dq_layer = network
-                    .add_dequantize(
-                        &mut reshaped_4d,
-                        &mut scale_tensor,
-                        TrtDataType::kFLOAT.into(),
-                    )
+                    .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->int32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_int32");
-                let mut dq_out =
+                let dq_out =
                     dq_layer
                         .get_output(network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
@@ -2408,7 +2365,7 @@ impl TrtxConverter {
                 let _ = dq_out.set_name(network, "cast_flat_dq_int32");
                 let mut cast_layer =
                     network
-                        .add_cast(&mut dq_out, TrtDataType::kINT32)
+                        .add_cast(&dq_out, TrtDataType::kINT32)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to add cast to INT32: {}", e),
@@ -2474,7 +2431,7 @@ impl TrtxConverter {
 
         // Create quantize layer - output type is INT8 for quantization
         let layer = network
-            .add_quantize(input, scale, TrtDataType::kINT8.into())
+            .add_quantize(input, scale, TrtDataType::kINT8)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add quantize layer: {}", e),
@@ -2519,7 +2476,7 @@ impl TrtxConverter {
 
         // Create dequantize layer - output type is FLOAT for dequantization
         let layer = network
-            .add_dequantize(input, scale, TrtDataType::kFLOAT.into())
+            .add_dequantize(input, scale, TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add dequantize layer: {}", e),
@@ -2572,10 +2529,7 @@ impl TrtxConverter {
             });
         }
 
-        let window: [i64; 2] = [
-            input_dims[2].try_into().unwrap(),
-            input_dims[3].try_into().unwrap(),
-        ];
+        let window: [i64; 2] = [input_dims[2], input_dims[3]];
 
         let layer = network
             .add_pooling(input, pool_type, &window)
@@ -2637,13 +2591,13 @@ impl TrtxConverter {
 
         let layer = if rank0 == rank1 {
             network.add_matrix_multiply(
-                &input0,
+                input0,
                 MatrixOperation::kNONE,
                 input1,
                 MatrixOperation::kNONE,
             )
         } else if rank0 < rank1 {
-            let reshape_dims: Vec<i64> = dims0.iter().copied().collect();
+            let reshape_dims: Vec<i64> = dims0.to_vec();
             let rank_diff = rank1 - rank0;
             let mut new_shape: Vec<i64> = vec![1; rank_diff];
             new_shape.extend(reshape_dims);
@@ -2660,7 +2614,7 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
                 })?;
-            let mut reshaped0 =
+            let reshaped0 =
                 shuffle
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -2668,13 +2622,13 @@ impl TrtxConverter {
                         reason: format!("Matmul: shuffle output: {}", e),
                     })?;
             network.add_matrix_multiply(
-                &mut reshaped0,
+                &reshaped0,
                 MatrixOperation::kNONE,
                 input1,
                 MatrixOperation::kNONE,
             )
         } else {
-            let reshape_dims: Vec<i64> = dims1.iter().copied().collect();
+            let reshape_dims: Vec<i64> = dims1.to_vec();
             let rank_diff = rank0 - rank1;
             let mut new_shape: Vec<i64> = vec![1; rank_diff];
             new_shape.extend(reshape_dims);
@@ -2691,7 +2645,7 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
                 })?;
-            let mut reshaped1 =
+            let reshaped1 =
                 shuffle
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -2701,7 +2655,7 @@ impl TrtxConverter {
             network.add_matrix_multiply(
                 input0,
                 MatrixOperation::kNONE,
-                &mut reshaped1,
+                &reshaped1,
                 MatrixOperation::kNONE,
             )
         }
@@ -2830,7 +2784,7 @@ impl TrtxConverter {
             perm[rank - 1] = axis_idx as i32;
             let mut shuffle2 =
                 network
-                    .add_shuffle(&mut result)
+                    .add_shuffle(&result)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add second shuffle for {}: {}", op_name, e),
@@ -2931,12 +2885,13 @@ impl TrtxConverter {
         )?;
 
         // Step 3: sqrt(variance + epsilon)
-        let mut sqrt_var_layer = network
-            .add_unary(&var_bc, UnaryOperation::kSQRT.into())
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to add sqrt for batch norm: {}", e),
-            })?;
+        let mut sqrt_var_layer =
+            network
+                .add_unary(&var_bc, UnaryOperation::kSQRT)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add sqrt for batch norm: {}", e),
+                })?;
         let _ = sqrt_var_layer.set_name(network, "batch_norm_sqrt_var");
 
         let sqrt_var =
@@ -3195,7 +3150,7 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        let var_shape: Vec<_> = var_dims.iter().map(|&d| d as i64).collect();
+        let var_shape: Vec<_> = var_dims.iter().copied().collect();
         let epsilon_const = network
             .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
@@ -3225,13 +3180,13 @@ impl TrtxConverter {
 
         // sqrt(variance + epsilon)
         let sqrt_layer = network
-            .add_unary(&var_plus_eps_out, UnaryOperation::kSQRT.into())
+            .add_unary(&var_plus_eps_out, UnaryOperation::kSQRT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for instance norm: {}", e),
             })?;
 
-        let mut std_dev =
+        let std_dev =
             sqrt_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3241,7 +3196,7 @@ impl TrtxConverter {
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
-            .add_elementwise(&x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
+            .add_elementwise(&x_minus_mean, &std_dev, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for instance norm: {}", e),
@@ -3456,14 +3411,14 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),
                     })?;
-                let mut bias_bc = bias_shuffle.get_output(network, 0).map_err(|e| {
+                let bias_bc = bias_shuffle.get_output(network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
                     }
                 })?;
                 let add_layer = network
-                    .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to add bias: {}", e),
@@ -3600,7 +3555,7 @@ impl TrtxConverter {
                         _ => (0..num_el).flat_map(|_| 1.0f32.to_le_bytes()).collect(),
                     };
                     let ones_const = network
-                        .add_small_constant_copied(&input_dims, &ones_bytes, zero_dtype.clone())
+                        .add_small_constant_copied(&input_dims, &ones_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3608,7 +3563,7 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    let mut ones_tensor = ones_const.get_output(network, 0).map_err(|e| {
+                    let ones_tensor = ones_const.get_output(network, 0).map_err(|e| {
                         GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: ones const output: {}", e),
@@ -3617,7 +3572,7 @@ impl TrtxConverter {
                     let (bias_bc, _) = Self::ensure_broadcast_compatible(
                         network,
                         bias,
-                        &mut ones_tensor,
+                        &ones_tensor,
                         "layer_norm_axes_empty_bias",
                     )?;
                     bias_bc
@@ -3721,7 +3676,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
             })?;
-        let var_shape: Vec<i64> = var_dims.iter().map(|&d| d as i64).collect();
+        let var_shape: Vec<i64> = var_dims;
         let num_var_el: usize = var_dims.iter().map(|&d| d as usize).product();
         let input_operand = graph
             .operand(operation.input_operands()[0])
@@ -3922,7 +3877,7 @@ impl TrtxConverter {
             )?;
             if is_bias_1 {
                 let add_layer = network
-                    .add_elementwise(&mut result, &opt_1_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add bias: {}", e),
@@ -3936,7 +3891,7 @@ impl TrtxConverter {
                         })?;
             } else {
                 let mul_layer = network
-                    .add_elementwise(&mut result, &opt_1_bc, ElementWiseOperation::kPROD)
+                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kPROD)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add scale: {}", e),
@@ -3959,11 +3914,10 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Bias operand {} not found", operation.input_operands()[2]),
                 })?;
-            let mut bias_bc =
-                reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
+            let bias_bc = reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
 
             let add_layer = network
-                .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
+                .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
@@ -4078,7 +4032,7 @@ impl TrtxConverter {
             })?;
 
         let abs_layer = network
-            .add_unary(input, UnaryOperation::kABS.into())
+            .add_unary(input, UnaryOperation::kABS)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add abs for L1: {}", e),
@@ -4159,7 +4113,7 @@ impl TrtxConverter {
             .map(|o| o.descriptor.data_type)
             .unwrap_or(DataType::Float32);
 
-        let mut input_copy = network
+        let input_copy = network
             .add_identity(input)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -4171,13 +4125,13 @@ impl TrtxConverter {
                 reason: format!("Failed to get identity output for L2: {}", e),
             })?;
         let square_layer = network
-            .add_elementwise(input, &mut input_copy, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add square for L2: {}", e),
             })?;
 
-        let mut square_output =
+        let square_output =
             square_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -4201,7 +4155,7 @@ impl TrtxConverter {
 
         if axes.is_empty() {
             let sqrt_layer = network
-                .add_unary(&mut square_output, UnaryOperation::kSQRT.into())
+                .add_unary(&square_output, UnaryOperation::kSQRT)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ReduceL2 axes=[] sqrt: {}", e),
@@ -4226,10 +4180,10 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         // Always reduce in float32 to avoid overflow (sum of squares can exceed float16 range).
-        let mut to_reduce = Self::cast_to_float32(network, &square_output)?;
+        let to_reduce = Self::cast_to_float32(network, &square_output)?;
         let sum_layer = network
             .add_reduce(
-                &mut to_reduce,
+                &to_reduce,
                 ReduceOperation::kSUM.into(),
                 Axes(axes_mask),
                 keep_dims,
@@ -4248,7 +4202,7 @@ impl TrtxConverter {
                 })?;
 
         let sqrt_layer = network
-            .add_unary(&sum_output, UnaryOperation::kSQRT.into())
+            .add_unary(&sum_output, UnaryOperation::kSQRT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for L2: {}", e),
@@ -4302,7 +4256,7 @@ impl TrtxConverter {
 
         if axes.is_empty() {
             let log_layer = network
-                .add_unary(input, UnaryOperation::kLOG.into())
+                .add_unary(input, UnaryOperation::kLOG)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ReduceLogSum axes=[] log: {}", e),
@@ -4338,7 +4292,7 @@ impl TrtxConverter {
                 reason: format!("Failed to add reduce for LogSum: {}", e),
             })?;
 
-        let mut sum_output =
+        let sum_output =
             sum_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -4348,7 +4302,7 @@ impl TrtxConverter {
 
         // Then log
         let log_layer = network
-            .add_unary(&mut sum_output, UnaryOperation::kLOG.into())
+            .add_unary(&sum_output, UnaryOperation::kLOG)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add log for LogSum: {}", e),
@@ -4382,13 +4336,13 @@ impl TrtxConverter {
             })?;
 
         let exp_layer = network
-            .add_unary(input, UnaryOperation::kEXP.into())
+            .add_unary(input, UnaryOperation::kEXP)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add exp for LogSumExp: {}", e),
             })?;
 
-        let mut exp_output =
+        let exp_output =
             exp_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -4439,7 +4393,7 @@ impl TrtxConverter {
 
         let sum_layer = network
             .add_reduce(
-                &mut exp_output,
+                &exp_output,
                 ReduceOperation::kSUM.into(),
                 Axes(axes_mask),
                 keep_dims,
@@ -4449,7 +4403,7 @@ impl TrtxConverter {
                 reason: format!("Failed to add reduce for LogSumExp: {}", e),
             })?;
 
-        let mut sum_output =
+        let sum_output =
             sum_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -4459,7 +4413,7 @@ impl TrtxConverter {
 
         // Finally log
         let log_layer = network
-            .add_unary(&mut sum_output, UnaryOperation::kLOG.into())
+            .add_unary(&sum_output, UnaryOperation::kLOG)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add log for LogSumExp: {}", e),
@@ -4492,7 +4446,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let mut input_copy = network
+        let input_copy = network
             .add_identity(input)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -4504,13 +4458,13 @@ impl TrtxConverter {
                 reason: format!("Failed to get identity output for SumSquare: {}", e),
             })?;
         let square_layer = network
-            .add_elementwise(input, &mut input_copy, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add square for SumSquare: {}", e),
             })?;
 
-        let mut square_output =
+        let square_output =
             square_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -4542,7 +4496,7 @@ impl TrtxConverter {
 
         let layer = network
             .add_reduce(
-                &mut square_output,
+                &square_output,
                 ReduceOperation::kSUM.into(),
                 Axes::from_slice(&axes),
                 keep_dims,
@@ -5026,7 +4980,7 @@ impl TrtxConverter {
                     })?;
 
             // Create a vector of references to the same tensor, repeated 'reps' times
-            let t: &trtx::Tensor<'network> = &*current_tensor;
+            let t: &trtx::Tensor<'network> = current_tensor;
             let tensors_to_concat: Vec<&trtx::Tensor<'network>> = (0..reps).map(|_| t).collect();
 
             // Concatenate along this axis
@@ -5288,7 +5242,7 @@ impl TrtxConverter {
                 })?;
 
         let not_layer = network
-            .add_unary(&equal_output, UnaryOperation::kNOT.into())
+            .add_unary(&equal_output, UnaryOperation::kNOT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add NOT layer: {}", e),
@@ -6408,7 +6362,7 @@ impl TrtxConverter {
             let mut output_shape = input_dims.clone();
             for (i, (&pre, &post)) in pre_padding.iter().zip(post_padding.iter()).enumerate() {
                 if i < output_shape.len() {
-                    output_shape[i] += (pre as i64) + (post as i64);
+                    output_shape[i] += pre + post;
                 }
             }
 
@@ -6674,7 +6628,7 @@ impl TrtxConverter {
             } else {
                 // beta == 1.0: add C directly
                 let add_layer = network
-                    .add_elementwise(&mut result, input_c, ElementWiseOperation::kSUM)
+                    .add_elementwise(&result, input_c, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add C to result: {}", e),
@@ -7696,7 +7650,7 @@ impl TrtxConverter {
             })?;
 
         let window: [i64; 2] = [
-            window_size.get(0).copied().unwrap_or(2) as i64,
+            window_size.first().copied().unwrap_or(2) as i64,
             window_size.get(1).copied().unwrap_or(2) as i64,
         ];
 
@@ -8068,7 +8022,7 @@ impl TrtxConverter {
 
         // NaN is the only value where x != x is true
         // Use elementwise EQUAL operation with itself, then negate
-        let mut input_copy = network
+        let input_copy = network
             .add_identity(input_tensor)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -8080,13 +8034,13 @@ impl TrtxConverter {
                 reason: format!("Failed to get identity output for isNaN: {}", e),
             })?;
         let layer = network
-            .add_elementwise(input_tensor, &mut input_copy, ElementWiseOperation::kEQUAL)
+            .add_elementwise(input_tensor, &input_copy, ElementWiseOperation::kEQUAL)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create EQUAL layer for isNaN: {}", e),
             })?;
 
-        let mut equal_output =
+        let equal_output =
             layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8096,7 +8050,7 @@ impl TrtxConverter {
 
         // Negate the result (isNaN = NOT(x == x))
         let not_layer = network
-            .add_unary(&mut equal_output, UnaryOperation::kNOT)
+            .add_unary(&equal_output, UnaryOperation::kNOT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create NOT layer for isNaN: {}", e),
@@ -8135,7 +8089,7 @@ impl TrtxConverter {
         // Check if abs(x) == infinity
         // First compute abs(x)
         let abs_layer = network
-            .add_unary(input_tensor, UnaryOperation::kABS.into())
+            .add_unary(input_tensor, UnaryOperation::kABS)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ABS layer for isInfinite: {}", e),
@@ -8204,7 +8158,7 @@ impl TrtxConverter {
 
         // TensorRT's kROUND already uses round-to-nearest-even (banker's rounding) by default
         let layer = network
-            .add_unary(input_tensor, UnaryOperation::kROUND.into())
+            .add_unary(input_tensor, UnaryOperation::kROUND)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ROUND layer: {}", e),
@@ -8231,7 +8185,7 @@ impl TrtxConverter {
     ) -> Result<(), GraphError> {
         let data_id = operation.input_operands()[0];
         let indices_id = operation.input_operands()[1];
-        let mut data_tensor =
+        let data_tensor =
             tensor_map
                 .remove(&data_id)
                 .ok_or_else(|| GraphError::ConversionFailed {
@@ -8239,7 +8193,7 @@ impl TrtxConverter {
                     reason: format!("Data operand {} not found", data_id),
                 })?;
 
-        let mut indices_tensor =
+        let indices_tensor =
             tensor_map
                 .remove(&indices_id)
                 .ok_or_else(|| GraphError::ConversionFailed {
@@ -8256,7 +8210,7 @@ impl TrtxConverter {
 
         // Create gather layer with ELEMENT mode
         let mut layer = network
-            .add_gather(&mut data_tensor, &mut indices_tensor, axis)
+            .add_gather(&data_tensor, &indices_tensor, axis)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create gather layer: {}", e),
@@ -8292,7 +8246,7 @@ impl TrtxConverter {
             })?;
 
         // Step 1: Square the input (x^2)
-        let mut input_copy = network
+        let input_copy = network
             .add_identity(input_tensor)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -8304,13 +8258,13 @@ impl TrtxConverter {
                 reason: format!("Failed to get identity output for l2Pool2d: {}", e),
             })?;
         let square_layer = network
-            .add_elementwise(input_tensor, &mut input_copy, ElementWiseOperation::kPROD)
+            .add_elementwise(input_tensor, &input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create square layer for l2Pool2d: {}", e),
             })?;
 
-        let mut squared =
+        let squared =
             square_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8334,13 +8288,13 @@ impl TrtxConverter {
         ];
 
         let pool_layer = network
-            .add_pooling(&mut squared, PoolingType::kAVERAGE, &window)
+            .add_pooling(&squared, PoolingType::kAVERAGE, &window)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
             })?;
 
-        let mut pooled =
+        let pooled =
             pool_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8350,7 +8304,7 @@ impl TrtxConverter {
 
         // Step 3: Take square root
         let sqrt_layer = network
-            .add_unary(&mut pooled, UnaryOperation::kSQRT.into())
+            .add_unary(&pooled, UnaryOperation::kSQRT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create sqrt layer for l2Pool2d: {}", e),
@@ -8502,9 +8456,9 @@ impl TrtxConverter {
                 reason: format!("Failed to create axis constant: {}", e),
             })?;
 
-        let mut axis_tensor =
+        let axis_tensor =
             axis_constant
-                .get_output(&network, 0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get axis constant output: {}", e),
@@ -8514,7 +8468,7 @@ impl TrtxConverter {
         let layer = network
             .add_cumulative_with_axis_tensor(
                 input_tensor,
-                &mut axis_tensor,
+                &axis_tensor,
                 trtx::CumulativeOperation::kSUM,
                 exclusive,
                 reverse,
@@ -8525,7 +8479,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&network, 0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cumulative sum output: {}", e),
@@ -8616,7 +8570,7 @@ impl TrtxConverter {
                 reason: format!("Failed to add constant mask for triangular: {}", e),
             })?;
 
-        let mut mask_tensor =
+        let mask_tensor =
             mask_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8626,7 +8580,7 @@ impl TrtxConverter {
 
         // Multiply input by mask (elementwise)
         let multiply_layer = network
-            .add_elementwise(input_tensor, &mut mask_tensor, ElementWiseOperation::kPROD)
+            .add_elementwise(input_tensor, &mask_tensor, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elementwise multiply for triangular: {}", e),
@@ -8634,7 +8588,7 @@ impl TrtxConverter {
 
         let output =
             multiply_layer
-                .get_output(&network, 0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get triangular output: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -28,12 +28,9 @@ use half::f16;
 use super::{ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
-use crate::graph::{DataType, GraphInfo, OperandKind, Operation, get_static_or_max_size};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
-use trtx::network::Layer;
-use trtx::network::Layer;
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
     PoolingType, ReduceOperation, ResizeMode, ScatterMode, TopKOperation, UnaryOperation,
@@ -304,9 +301,9 @@ impl TrtxConverter {
     fn build_network<'network>(
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
-    ) -> Result<Vec<Vec<u8>>, GraphError> {
+        temp_weights: &'network mut Vec<Vec<u8>>,
+    ) -> Result<(), GraphError> {
         let mut tensor_map: HashMap<u32, trtx::Tensor<'network>> = HashMap::new();
-        let mut temp_weights: Vec<Vec<u8>> = Vec::new(); // Storage for temporary constants
         let promoted_constants: HashSet<u32> = HashSet::new();
         let constants_stored_flat: HashSet<u32> = HashSet::new();
 
@@ -322,7 +319,7 @@ impl TrtxConverter {
                     .collect();
                 let name = operand.name.as_deref().unwrap_or("input");
 
-                let mut tensor = network.add_input(name, dtype, &dims).map_err(|e| {
+                let tensor = network.add_input(name, dtype, &dims).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add input {}: {}", name, e),
@@ -390,10 +387,10 @@ impl TrtxConverter {
                 // TensorRT add_constant does not support kINT64; convert Int64 constants to Int32.
                 let promote_int64 = operand.descriptor.data_type == DataType::Int64;
 
-                let (trt_dtype, data_to_use, add_dims): (TrtDataType, &[u8], Vec<i32>) =
+                let (trt_dtype, data_to_use, add_dims): (TrtDataType, Vec<u8>, Vec<i64>) =
                     if use_int8_constant {
                         // Pass raw bytes; type kINT8 (Uint8 same bits for 0/1, no conversion)
-                        (TrtDataType::kINT8, data, dims.clone())
+                        (TrtDataType::kINT8, data.to_vec(), dims.clone())
                     } else if promote_int64 {
                         let int32_bytes: Vec<u8> = data
                             .chunks_exact(8)
@@ -401,22 +398,17 @@ impl TrtxConverter {
                                 (i64::from_le_bytes(chunk.try_into().unwrap()) as i32).to_le_bytes()
                             })
                             .collect();
-                        temp_weights.push(int32_bytes);
-                        (
-                            TrtDataType::kINT32,
-                            temp_weights.last().unwrap().as_slice(),
-                            dims.clone(),
-                        )
+                        (TrtDataType::kINT32, int32_bytes, dims.clone())
                     } else {
                         (
                             Self::webnn_to_trt_dtype(operand.descriptor.data_type)?,
-                            data,
+                            data.to_vec(),
                             dims.clone(),
                         )
                     };
 
                 let layer = network
-                    .add_constant(&add_dims, data_to_use, trt_dtype)
+                    .add_small_constant_copied(&add_dims, &data_to_use, trt_dtype)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add constant (operand {}): {}", operand_id, e),
@@ -435,12 +427,12 @@ impl TrtxConverter {
         }
 
         // Step 3: Add operations
-        for operation in &graph.operations {
+        for operation in graph.operations.iter() {
             Self::add_operation(
                 graph,
                 network,
                 &mut tensor_map,
-                &mut temp_weights,
+                temp_weights,
                 &promoted_constants,
                 &constants_stored_flat,
                 operation,
@@ -466,18 +458,18 @@ impl TrtxConverter {
             }
         }
 
-        Ok(temp_weights)
+        Ok(())
     }
 
     /// Add a single operation to the network
     fn add_operation<'network>(
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
-        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
-        temp_weights: &mut Vec<Vec<u8>>,
-        promoted_constants: &HashSet<u32>,
-        constants_stored_flat: &HashSet<u32>,
-        operation: &Operation,
+        tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
+        promoted_constants: &'_ HashSet<u32>,
+        constants_stored_flat: &'_ HashSet<u32>,
+        operation: &'_ Operation,
     ) -> Result<(), GraphError> {
         let op_type = operation.op_type();
 
@@ -543,7 +535,7 @@ impl TrtxConverter {
             "tanh" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kTANH)?
             }
-            "elu" => Self::add_elu_op(graph, network, tensor_map, operation, temp_weights)?,
+            "elu" => Self::add_elu_op(graph, network, tensor_map, operation)?,
             "softsign" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kSOFTSIGN)?
             }
@@ -627,13 +619,9 @@ impl TrtxConverter {
             "instanceNormalization" => {
                 Self::add_instance_normalization_op(graph, network, tensor_map, operation)?
             }
-            "layerNormalization" => Self::add_layer_normalization_op(
-                graph,
-                network,
-                tensor_map,
-                operation,
-                temp_weights,
-            )?,
+            "layerNormalization" => {
+                Self::add_layer_normalization_op(graph, network, tensor_map, operation)?
+            }
 
             // Reduction operations
             "reduceSum" => {
@@ -662,7 +650,7 @@ impl TrtxConverter {
             "split" => Self::add_split_op(network, tensor_map, operation)?,
             "squeeze" => Self::add_squeeze_op(network, tensor_map, operation)?,
             "unsqueeze" => Self::add_unsqueeze_op(network, tensor_map, operation)?,
-            "expand" => Self::add_expand_op(graph, network, tensor_map, operation, temp_weights)?,
+            "expand" => Self::add_expand_op(graph, network, tensor_map, operation)?,
             "tile" => Self::add_tile_op(network, tensor_map, operation)?,
 
             // Comparison operations (return Float32 with 0.0/1.0 values)
@@ -718,7 +706,7 @@ impl TrtxConverter {
             }
 
             // Indexing/Gathering operations
-            "gather" => Self::add_gather_op(graph, network, tensor_map, operation, temp_weights)?,
+            "gather" => Self::add_gather_op(graph, network, tensor_map, operation)?,
             "gatherND" => Self::add_gather_nd_op(network, tensor_map, operation)?,
             "scatterElements" => Self::add_scatter_elements_op(network, tensor_map, operation)?,
             "scatterND" => Self::add_scatter_nd_op(network, tensor_map, operation)?,
@@ -733,17 +721,13 @@ impl TrtxConverter {
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
             "concat" => Self::add_concat_op(network, tensor_map, operation)?,
             "isNaN" => Self::add_is_nan_op(network, tensor_map, operation)?,
-            "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation, temp_weights)?,
+            "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation)?,
             "roundEven" => Self::add_round_even_op(network, tensor_map, operation)?,
             "gatherElements" => Self::add_gather_elements_op(network, tensor_map, operation)?,
             "l2Pool2d" => Self::add_l2_pool2d_op(network, tensor_map, operation)?,
             "reverse" => Self::add_reverse_op(graph, network, tensor_map, operation)?,
-            "cumulativeSum" => {
-                Self::add_cumulative_sum_op(graph, network, tensor_map, operation, temp_weights)?
-            }
-            "triangular" => {
-                Self::add_triangular_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "cumulativeSum" => Self::add_cumulative_sum_op(graph, network, tensor_map, operation)?,
+            "triangular" => Self::add_triangular_op(graph, network, tensor_map, operation)?,
             "transpose" => Self::add_transpose_op(graph, network, tensor_map, operation)?,
             "reshape" => Self::add_reshape_op(graph, network, tensor_map, operation)?,
             "resample2d" => Self::add_resample2d_op(network, tensor_map, operation)?,
@@ -1190,7 +1174,7 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
         let input = tensor_map
@@ -1213,11 +1197,11 @@ impl TrtxConverter {
             match operand.descriptor.data_type {
                 DataType::Uint8 | DataType::Int8 => {
                     let data = Self::get_constant_data(graph, input_id)?;
-                    let shape: Vec<i32> = operand
+                    let shape: Vec<i64> = operand
                         .descriptor
                         .shape
                         .iter()
-                        .map(|d| get_static_or_max_size(d) as i32)
+                        .map(|d| get_static_or_max_size(d) as i64)
                         .collect();
                     let n: usize = operand
                         .descriptor
@@ -1317,7 +1301,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1348,7 +1331,7 @@ impl TrtxConverter {
         }
 
         let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1; num_dims];
         let (trt_dtype, one_bytes, zero_bytes, alpha_bytes) = match input_dtype {
             DataType::Float16 => {
                 let one: Vec<u8> = f16::from_f32(1.0).to_bits().to_le_bytes().to_vec();
@@ -1393,13 +1376,8 @@ impl TrtxConverter {
                     reason: format!("Failed to get exp output: {}", e),
                 })?;
 
-        temp_weights.push(one_bytes);
         let one_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create one constant for elu: {}", e),
@@ -1433,13 +1411,8 @@ impl TrtxConverter {
                     reason: format!("Failed to get exp-1 output: {}", e),
                 })?;
 
-        temp_weights.push(zero_bytes);
         let zero_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create zero constant for elu: {}", e),
@@ -1473,13 +1446,8 @@ impl TrtxConverter {
                     reason: format!("Failed to get neg part output: {}", e),
                 })?;
 
-        temp_weights.push(alpha_bytes);
         let alpha_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create alpha constant for elu: {}", e),
@@ -1607,7 +1575,7 @@ impl TrtxConverter {
                 ),
             })?;
         let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1; num_dims];
 
         let (alpha_bytes, alpha_dtype) = match input_operand.descriptor.data_type {
             DataType::Float16 => (
@@ -1618,7 +1586,7 @@ impl TrtxConverter {
         };
 
         let alpha_const = network
-            .add_constant(&broadcast_shape, &alpha_bytes, alpha_dtype)
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LeakyReLU: failed to add alpha constant: {}", e),
@@ -1871,7 +1839,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to get input dimensions: {}", e),
             })?;
-        let broadcast_shape: Vec<i32> = vec![1; input_dims.len()];
+        let broadcast_shape: Vec<i64> = vec![1; input_dims.len()];
         let input_dtype = input_operand.descriptor.data_type;
 
         let (alpha_bytes, beta_bytes, zero_bytes, one_bytes, trt_dtype) = match input_dtype {
@@ -2044,7 +2012,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to get input dimensions: {}", e),
             })?;
-        let broadcast_shape: Vec<i32> = vec![1; input_dims.len()];
+        let broadcast_shape: Vec<i64> = vec![1; input_dims.len()];
         let input_dtype = input_operand.descriptor.data_type;
 
         let three = 3.0f32;
@@ -2387,7 +2355,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_f32");
-                let mut output =
+                let output =
                     dq_layer
                         .get_output(network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
@@ -2465,7 +2433,7 @@ impl TrtxConverter {
                             reason: format!("Failed to add cast to INT32: {}", e),
                         })?;
                 let _ = cast_layer.set_name(network, "cast_flat_cast_int32");
-                let mut output = cast_layer.get_output(network, 0).map_err(|e| {
+                let output = cast_layer.get_output(network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get cast output: {}", e),
@@ -2623,7 +2591,7 @@ impl TrtxConverter {
             });
         }
 
-        let window: [i32; 2] = [
+        let window: [i64; 2] = [
             input_dims[2].try_into().unwrap(),
             input_dims[3].try_into().unwrap(),
         ];
@@ -2750,7 +2718,7 @@ impl TrtxConverter {
                         reason: format!("Matmul: shuffle output: {}", e),
                     })?;
             network.add_matrix_multiply(
-                input0.1,
+                input0,
                 MatrixOperation::kNONE,
                 &mut reshaped1,
                 MatrixOperation::kNONE,
@@ -2953,7 +2921,7 @@ impl TrtxConverter {
 
         // Step 1: x - mean
         let mut sub_layer = network
-            .add_elementwise(input, &mut mean_bc, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mean_bc, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for batch norm: {}", e),
@@ -2990,7 +2958,7 @@ impl TrtxConverter {
             })?;
         let _ = sqrt_var_layer.set_name(network, "batch_norm_sqrt_var");
 
-        let mut sqrt_var =
+        let sqrt_var =
             sqrt_var_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3067,7 +3035,7 @@ impl TrtxConverter {
                     reason: format!("Bias operand {} not found", bias_id),
                 })?;
 
-            let mut bias_bc = Self::reshape_batch_norm_stats_for_broadcast(
+            let bias_bc = Self::reshape_batch_norm_stats_for_broadcast(
                 network,
                 bias,
                 &result,
@@ -3142,7 +3110,12 @@ impl TrtxConverter {
 
         // Compute mean: E[x]
         let mean_layer = network
-            .add_reduce(input, ReduceOperation::kAVG.into(), Axes::new(axes), true)
+            .add_reduce(
+                input,
+                ReduceOperation::kAVG.into(),
+                Axes::from_slice(&axes),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add mean reduce for instance norm: {}", e),
@@ -3157,7 +3130,7 @@ impl TrtxConverter {
 
         // x - mean
         let sub_layer = network
-            .add_elementwise(input, &mut mean, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mean, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for instance norm: {}", e),
@@ -3192,7 +3165,7 @@ impl TrtxConverter {
             .add_reduce(
                 &squared,
                 ReduceOperation::kAVG.into(),
-                Axes::new(axes),
+                Axes::from_slice(&axes),
                 true,
             )
             .map_err(|e| GraphError::ConversionFailed {
@@ -3241,7 +3214,7 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        let var_shape: Vec<i32> = var_dims.iter().map(|&d| d as i32).collect();
+        let var_shape: Vec<_> = var_dims.iter().map(|&d| d as i64).collect();
         let epsilon_const = network
             .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
@@ -3261,7 +3234,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: variance + epsilon: {}", e),
             })?;
-        let mut var_plus_eps_out =
+        let var_plus_eps_out =
             var_plus_eps
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3287,13 +3260,13 @@ impl TrtxConverter {
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
-            .add_elementwise(&mut x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
+            .add_elementwise(&x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for instance norm: {}", e),
             })?;
 
-        let result =
+        let mut result =
             div_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3430,7 +3403,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Layer normalization computes statistics over specified axes
         // Input operands: input, scale (optional), bias (optional)
@@ -3466,10 +3438,8 @@ impl TrtxConverter {
                 ),
                 _ => (0.0f32.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
             };
-            temp_weights.push(zero_bytes);
-            let zero_ref = temp_weights.last().unwrap().as_slice();
             let zero_const = network
-                .add_constant(&[1], zero_ref, zero_dtype)
+                .add_small_constant_copied(&[1], &zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm 0D: failed to add zero constant: {}", e),
@@ -3570,11 +3540,9 @@ impl TrtxConverter {
                     TrtDataType::kFLOAT,
                 ),
             };
-            temp_weights.push(zero_bytes);
-            let zero_ref = temp_weights.last().unwrap().as_slice();
-            let shape_i32: Vec<i32> = input_dims.iter().map(|&d| d as i32).collect();
+            let shape_i64: Vec<i64> = input_dims.iter().map(|&d| d as i64).collect();
             let zero_const = network
-                .add_constant(&shape_i32, zero_ref, zero_dtype.clone())
+                .add_small_constant_copied(&shape_i64, &zero_bytes, zero_dtype.clone())
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm axes=[]: failed to add zeros constant: {}", e),
@@ -3628,10 +3596,8 @@ impl TrtxConverter {
                             (0..num_el).flat_map(|_| v.to_le_bytes()).collect()
                         }
                     };
-                    temp_weights.push(bias_broadcast_bytes);
-                    let bias_ref = temp_weights.last().unwrap().as_slice();
                     let bias_const = network
-                        .add_constant(&shape_i32, bias_ref, zero_dtype)
+                        .add_small_constant_copied(&shape_i64, &bias_broadcast_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3653,10 +3619,8 @@ impl TrtxConverter {
                             .collect(),
                         _ => (0..num_el).flat_map(|_| 1.0f32.to_le_bytes()).collect(),
                     };
-                    temp_weights.push(ones_bytes);
-                    let ones_ref = temp_weights.last().unwrap().as_slice();
                     let ones_const = network
-                        .add_constant(&shape_i32, ones_ref, zero_dtype.clone())
+                        .add_small_constant_copied(&shape_i64, &ones_bytes, zero_dtype.clone())
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3803,10 +3767,8 @@ impl TrtxConverter {
                 TrtDataType::kFLOAT,
             ),
         };
-        temp_weights.push(epsilon_bytes);
-        let epsilon_ref = temp_weights.last().unwrap().as_slice();
         let epsilon_const = network
-            .add_constant(&var_shape, epsilon_ref, epsilon_dtype)
+            .add_small_constant_copied(&var_shape, &epsilon_bytes, epsilon_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to add epsilon constant: {}", e),
@@ -3867,94 +3829,96 @@ impl TrtxConverter {
         // Reshape scale/bias so they broadcast to result. Scale/bias have shape [d_axes[0], d_axes[1], ...]
         // in axis order; result has input shape. Broadcast shape: for each result dim i, use
         // scale_bias dim at that axis position if i is in axes, else 1.
-        let reshape_scale_bias_to_result_rank = |tensor: &trtx::Tensor,
-                                                 result: &trtx::Tensor,
-                                                 op_name: &str,
-                                                 axes: &[u32]|
-         -> Result<trtx::Tensor, GraphError> {
-            let result_dims =
-                result
-                    .dimensions(network)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm {}: result dims: {}", op_name, e),
-                    })?;
-            let tensor_dims =
-                tensor
-                    .dimensions(network)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
-                    })?;
-            if tensor_dims.len() >= result_dims.len() {
-                let id_layer =
-                    network
-                        .add_identity(tensor)
+        let reshape_scale_bias_to_result_rank =
+            |network: &'_ mut trtx::NetworkDefinition<'network>,
+             tensor: &trtx::Tensor,
+             result: &trtx::Tensor,
+             op_name: &str,
+             axes: &[u32]|
+             -> Result<trtx::Tensor<'network>, GraphError> {
+                let result_dims =
+                    result
+                        .dimensions(network)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
-                            reason: format!("LayerNorm {}: identity: {}", op_name, e),
+                            reason: format!("LayerNorm {}: result dims: {}", op_name, e),
                         })?;
-                return id_layer
-                    .get_output(network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm {}: identity output: {}", op_name, e),
+                let tensor_dims =
+                    tensor
+                        .dimensions(network)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
+                        })?;
+                if tensor_dims.len() >= result_dims.len() {
+                    let id_layer =
+                        network
+                            .add_identity(tensor)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("LayerNorm {}: identity: {}", op_name, e),
+                            })?;
+                    return id_layer.get_output(network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm {}: identity output: {}", op_name, e),
+                        }
                     });
-            }
-            let (new_shape, transpose_perm): (Vec<i64>, Option<Vec<i32>>) =
-                if tensor_dims.len() == axes.len() {
-                    let new_shape: Vec<i64> = (0..result_dims.len())
-                        .map(|i| {
-                            let axis = i as u32;
-                            axes.iter()
-                                .position(|&a| a == axis)
-                                .map(|j| tensor_dims[j])
-                                .unwrap_or(1)
-                        })
-                        .collect();
-                    let mut sorted_axes = axes.to_vec();
-                    sorted_axes.sort_unstable();
-                    let needs_transpose = axes != sorted_axes.as_slice();
-                    let transpose_perm: Option<Vec<i32>> = if needs_transpose {
-                        Some(
-                            sorted_axes
-                                .iter()
-                                .map(|&a| {
-                                    axes.iter()
-                                        .position(|&ax| ax == a)
-                                        .expect("axis in sorted_axes")
-                                        as i32
-                                })
-                                .collect(),
-                        )
+                }
+                let (new_shape, transpose_perm): (Vec<i64>, Option<Vec<i32>>) =
+                    if tensor_dims.len() == axes.len() {
+                        let new_shape: Vec<i64> = (0..result_dims.len())
+                            .map(|i| {
+                                let axis = i as u32;
+                                axes.iter()
+                                    .position(|&a| a == axis)
+                                    .map(|j| tensor_dims[j])
+                                    .unwrap_or(1)
+                            })
+                            .collect();
+                        let mut sorted_axes = axes.to_vec();
+                        sorted_axes.sort_unstable();
+                        let needs_transpose = axes != sorted_axes.as_slice();
+                        let transpose_perm: Option<Vec<i32>> = if needs_transpose {
+                            Some(
+                                sorted_axes
+                                    .iter()
+                                    .map(|&a| {
+                                        axes.iter()
+                                            .position(|&ax| ax == a)
+                                            .expect("axis in sorted_axes")
+                                            as i32
+                                    })
+                                    .collect(),
+                            )
+                        } else {
+                            None
+                        };
+                        (new_shape, transpose_perm)
                     } else {
-                        None
+                        let pad = result_dims.len() - tensor_dims.len();
+                        let mut shape: Vec<i64> = vec![1; pad];
+                        shape.extend(tensor_dims.iter().copied());
+                        (shape, None)
                     };
-                    (new_shape, transpose_perm)
-                } else {
-                    let pad = result_dims.len() - tensor_dims.len();
-                    let mut shape: Vec<i64> = vec![1; pad];
-                    shape.extend(tensor_dims.iter().copied());
-                    (shape, None)
-                };
-            let mut shuffle =
-                network
-                    .add_shuffle(tensor)
-                    .map_err(|e| GraphError::ConversionFailed {
+                let mut shuffle =
+                    network
+                        .add_shuffle(tensor)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm {}: shuffle: {}", op_name, e),
+                        })?;
+                if let Some(ref perm) = transpose_perm {
+                    shuffle.set_first_transpose(network, perm);
+                }
+                shuffle.set_reshape_dimensions(network, &new_shape);
+                shuffle
+                    .get_output(network, 0)
+                    .map_err(move |e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("LayerNorm {}: shuffle: {}", op_name, e),
-                    })?;
-            if let Some(ref perm) = transpose_perm {
-                shuffle.set_first_transpose(network, perm);
-            }
-            shuffle.set_reshape_dimensions(network, &new_shape);
-            shuffle
-                .get_output(network, 0)
-                .map_err(move |e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: shuffle output: {}", op_name, e),
-                })
-        };
+                        reason: format!("LayerNorm {}: shuffle output: {}", op_name, e),
+                    })
+            };
 
         // Optional operands are [scale?, bias?] in that order. When len() == 2, the single optional may be scale or bias; use name to distinguish.
         if operation.input_operands().len() > 1 {
@@ -3971,6 +3935,7 @@ impl TrtxConverter {
                 .unwrap_or("");
             let is_bias_1 = name_1.to_lowercase().contains("bias");
             let opt_1_bc = reshape_scale_bias_to_result_rank(
+                network,
                 opt_1,
                 &result,
                 if is_bias_1 { "bias" } else { "scale" },
@@ -4015,7 +3980,8 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Bias operand {} not found", operation.input_operands()[2]),
                 })?;
-            let mut bias_bc = reshape_scale_bias_to_result_rank(bias, &result, "bias", &axes)?;
+            let mut bias_bc =
+                reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
 
             let add_layer = network
                 .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
@@ -4700,7 +4666,7 @@ impl TrtxConverter {
                     sz
                 } else {
                     // ceil(extent / stride) in integers
-                    (*sz + st.abs() - 1) / st.abs()
+                    (sz + st.abs() - 1) / st.abs()
                 }
             })
             .collect();
@@ -4944,7 +4910,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -4953,10 +4918,10 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let new_shape: Vec<i32> = match operation {
+        let new_shape: Vec<i64> = match operation {
             Operation::Expand { new_shape, .. } => new_shape
                 .iter()
-                .map(|d| MLDimension::static_or_max(d) as i32)
+                .map(|d| MLDimension::static_or_max(d) as i64)
                 .collect(),
             _ => {
                 return Err(GraphError::ConversionFailed {
@@ -4965,10 +4930,6 @@ impl TrtxConverter {
                 });
             }
         };
-        let new_shape: Vec<i64> = new_shape
-            .iter()
-            .map(|d| MLDimension::static_or_max(d) as i64)
-            .collect();
 
         if new_shape.is_empty() {
             return Err(GraphError::ConversionFailed {
@@ -5006,11 +4967,8 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        temp_weights.push(ones_data);
-        let ones_ref = temp_weights.last().unwrap().as_slice();
-
         let ones_const = network
-            .add_constant(&new_shape, ones_ref, trt_dtype)
+            .add_small_constant_copied(&new_shape, &ones_data, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ones constant for expand: {}", e),
@@ -5867,7 +5825,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -6308,7 +6265,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let (beginning_padding, ending_padding, opts) = match operation {
+        let (beginning_padding, ending_padding, _opts) = match operation {
             Operation::Pad {
                 beginning_padding,
                 ending_padding,
@@ -6331,8 +6288,9 @@ impl TrtxConverter {
                 });
             }
         };
-        let pre_padding: Vec<i64> = opts.beginning_padding.iter().map(|&u| u as i64).collect();
-        let post_padding: Vec<i64> = opts.ending_padding.iter().map(|&u| u as i64).collect();
+        // TODO: handle opts.mode
+        let pre_padding: Vec<i64> = beginning_padding.iter().map(|&u| u as i64).collect();
+        let post_padding: Vec<i64> = ending_padding.iter().map(|&u| u as i64).collect();
         if pre_padding.is_empty() || post_padding.is_empty() {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -6701,7 +6659,7 @@ impl TrtxConverter {
                         reason: format!("Failed to create beta constant: {}", e),
                     })?;
 
-                let mut beta_tensor = beta_layer.get_output(network, 0).map_err(|e| {
+                let beta_tensor = beta_layer.get_output(network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get beta tensor: {}", e),
@@ -6767,7 +6725,7 @@ impl TrtxConverter {
     fn add_conv2d_op<'network>(
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
-        tensor_map: &'network mut HashMap<u32, trtx::Tensor<'network>>,
+        tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
         temp_weights: &'network mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
@@ -8554,7 +8512,8 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let cum_opts = operation.attributes().as_cumulative_sum();
+        let attr_copy = operation.attributes();
+        let cum_opts = attr_copy.as_cumulative_sum();
         let axis = match operation {
             Operation::CumulativeSum { axis, .. } => *axis as usize,
             _ => 0,
@@ -8627,7 +8586,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8688,17 +8646,13 @@ impl TrtxConverter {
         // Convert mask to bytes
         let mask_bytes: Vec<u8> = mask_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-        // Store mask in temp_weights to keep it alive (critical for weight lifetime)
-        temp_weights.push(mask_bytes);
-        let mask_bytes_ref = temp_weights.last().unwrap();
-
         // Create constant layer with the mask
         let dims: Vec<i64> = shape
             .iter()
             .map(|s| get_static_or_max_size(s) as i64)
             .collect();
         let mask_layer = network
-            .add_constant(&dims, mask_bytes_ref, trtx::DataType::kFLOAT)
+            .add_small_constant_copied(&dims, &mask_bytes, trtx::DataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add constant mask for triangular: {}", e),
@@ -8786,8 +8740,8 @@ impl GraphConverter for TrtxConverter {
             })?;
 
         // Build the network from WebNN graph and capture temporary weights
-        // These weights must stay alive until engine serialization completes
-        let _temp_weights = Self::build_network(graph_info, &mut network)?;
+        let mut temp_weights = Vec::new();
+        Self::build_network(graph_info, &mut network, &mut temp_weights)?;
 
         // Create builder config
         let mut config = builder

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -3304,8 +3304,8 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for scale: {}", e),
                     })?;
-            scale_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape);
-            let mut scale_bc =
+            scale_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape)?;
+            let scale_bc =
                 scale_shuffle
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -3314,7 +3314,7 @@ impl TrtxConverter {
                     })?;
 
             let mul_layer = network
-                .add_elementwise(&mut result, &mut scale_bc, ElementWiseOperation::kPROD)
+                .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add mul for scale: {}", e),
@@ -3345,8 +3345,8 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for bias: {}", e),
                     })?;
-            bias_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape);
-            let mut bias_bc =
+            bias_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape)?;
+            let bias_bc =
                 bias_shuffle
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -3355,7 +3355,7 @@ impl TrtxConverter {
                     })?;
 
             let add_layer = network
-                .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
+                .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
@@ -3521,9 +3521,8 @@ impl TrtxConverter {
                     TrtDataType::kFLOAT,
                 ),
             };
-            let shape_i64: Vec<i64> = input_dims.iter().map(|&d| d as i64).collect();
             let zero_const = network
-                .add_small_constant_copied(&shape_i64, &zero_bytes, zero_dtype.clone())
+                .add_small_constant_copied(&input_dims, &zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm axes=[]: failed to add zeros constant: {}", e),
@@ -3545,7 +3544,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Bias operand {} not found", bias_id),
                         })?;
-                let mut bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bias_id) {
+                let bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bias_id) {
                     // Shuffle cannot change volume. Broadcast by creating a constant filled with the bias value.
                     let bias_data = Self::get_constant_data(graph, bias_id)?;
                     let bias_broadcast_bytes: Vec<u8> = match input_operand.descriptor.data_type {
@@ -3578,7 +3577,7 @@ impl TrtxConverter {
                         }
                     };
                     let bias_const = network
-                        .add_small_constant_copied(&shape_i64, &bias_broadcast_bytes, zero_dtype)
+                        .add_small_constant_copied(&input_dims, &bias_broadcast_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3601,7 +3600,7 @@ impl TrtxConverter {
                         _ => (0..num_el).flat_map(|_| 1.0f32.to_le_bytes()).collect(),
                     };
                     let ones_const = network
-                        .add_small_constant_copied(&shape_i64, &ones_bytes, zero_dtype.clone())
+                        .add_small_constant_copied(&input_dims, &ones_bytes, zero_dtype.clone())
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3624,7 +3623,7 @@ impl TrtxConverter {
                     bias_bc
                 };
                 let add_layer = network
-                    .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: failed to add bias: {}", e),
@@ -3655,23 +3654,22 @@ impl TrtxConverter {
                 reason: format!("Failed to add mean reduce for layer norm: {}", e),
             })?;
 
-        let mut mean =
-            mean_layer
-                .get_output(network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mean output: {}", e),
-                })?;
+        let mean = mean_layer
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get mean output: {}", e),
+            })?;
 
         // x - mean
         let sub_layer = network
-            .add_elementwise(input, &mut mean, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mean, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for layer norm: {}", e),
             })?;
 
-        let mut x_minus_mean =
+        let x_minus_mean =
             sub_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3687,7 +3685,7 @@ impl TrtxConverter {
                 reason: format!("Failed to add square for layer norm: {}", e),
             })?;
 
-        let mut squared =
+        let squared =
             square_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3698,7 +3696,7 @@ impl TrtxConverter {
         // variance = mean((x - mean)^2)
         let var_layer = network
             .add_reduce(
-                &mut squared,
+                &squared,
                 ReduceOperation::kAVG.into(),
                 Axes::from_slice(&axes),
                 true,
@@ -3708,7 +3706,7 @@ impl TrtxConverter {
                 reason: format!("Failed to add variance reduce for layer norm: {}", e),
             })?;
 
-        let mut variance =
+        let variance =
             var_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3754,7 +3752,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to add epsilon constant: {}", e),
             })?;
-        let mut epsilon_out =
+        let epsilon_out =
             epsilon_const
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3762,12 +3760,12 @@ impl TrtxConverter {
                     reason: format!("LayerNorm: epsilon const output: {}", e),
                 })?;
         let var_plus_eps = network
-            .add_elementwise(&mut variance, &mut epsilon_out, ElementWiseOperation::kSUM)
+            .add_elementwise(&variance, &epsilon_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: variance + epsilon: {}", e),
             })?;
-        let mut variance_eps =
+        let variance_eps =
             var_plus_eps
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3777,13 +3775,13 @@ impl TrtxConverter {
 
         // sqrt(variance + epsilon)
         let sqrt_layer = network
-            .add_unary(&mut variance_eps, UnaryOperation::kSQRT.into())
+            .add_unary(&variance_eps, UnaryOperation::kSQRT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for layer norm: {}", e),
             })?;
 
-        let mut std_dev =
+        let std_dev =
             sqrt_layer
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3793,7 +3791,7 @@ impl TrtxConverter {
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
-            .add_elementwise(&mut x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
+            .add_elementwise(&x_minus_mean, &std_dev, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for layer norm: {}", e),
@@ -3890,9 +3888,9 @@ impl TrtxConverter {
                             reason: format!("LayerNorm {}: shuffle: {}", op_name, e),
                         })?;
                 if let Some(ref perm) = transpose_perm {
-                    shuffle.set_first_transpose(network, perm);
+                    shuffle.set_first_transpose(network, perm)?;
                 }
-                shuffle.set_reshape_dimensions(network, &new_shape);
+                shuffle.set_reshape_dimensions(network, &new_shape)?;
                 shuffle
                     .get_output(network, 0)
                     .map_err(move |e| GraphError::ConversionFailed {
@@ -6124,7 +6122,7 @@ impl TrtxConverter {
         // Note: All scalar constants must use shape [1,1,...,1] matching input dims for TensorRT broadcasting
 
         // Step 1: If alpha != 1.0, multiply x by alpha
-        let mut after_multiply = if (alpha - 1.0).abs() > f32::EPSILON {
+        let after_multiply = if (alpha - 1.0).abs() > f32::EPSILON {
             // Create alpha constant with type matching input (Half vs Float) for TensorRT elementwise
             let (alpha_bytes, alpha_dtype) = match input_operand.descriptor.data_type {
                 DataType::Float16 => (
@@ -6141,7 +6139,7 @@ impl TrtxConverter {
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let mut alpha_tensor = alpha_constant.get_output(network, 0).map_err(|e| {
+            let alpha_tensor = alpha_constant.get_output(network, 0).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get alpha constant output: {}", e),
@@ -6197,7 +6195,7 @@ impl TrtxConverter {
                     reason: format!("Failed to create beta constant: {}", e),
                 })?;
 
-            let mut beta_tensor =
+            let beta_tensor =
                 beta_constant
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -428,7 +428,7 @@ impl TrtxConverter {
                     };
 
                 let layer = network
-                    .add_small_constant_copied(&add_dims, &data_to_use, trt_dtype)
+                    .add_constant_owned(&add_dims, data_to_use, trt_dtype)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add constant (operand {}): {}", operand_id, e),
@@ -1223,7 +1223,7 @@ impl TrtxConverter {
                         .map(|&b| if b == 0 { 0u8 } else { 1u8 })
                         .collect();
                     let const_layer = network
-                        .add_small_constant_copied(&shape, &bool_bytes, TrtDataType::kBOOL)
+                        .add_constant_owned(&shape, bool_bytes, TrtDataType::kBOOL)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: failed to add BOOL constant: {}", e),
@@ -1383,7 +1383,7 @@ impl TrtxConverter {
                 })?;
 
         let one_const = network
-            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, one_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create one constant for elu: {}", e),
@@ -1414,7 +1414,7 @@ impl TrtxConverter {
                 })?;
 
         let zero_const = network
-            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create zero constant for elu: {}", e),
@@ -1445,7 +1445,7 @@ impl TrtxConverter {
                 })?;
 
         let alpha_const = network
-            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, alpha_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create alpha constant for elu: {}", e),
@@ -1577,7 +1577,7 @@ impl TrtxConverter {
         };
 
         let alpha_const = network
-            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
+            .add_constant_owned(&broadcast_shape, alpha_bytes, alpha_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LeakyReLU: failed to add alpha constant: {}", e),
@@ -1837,25 +1837,25 @@ impl TrtxConverter {
             ),
         };
         let alpha_const = network
-            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, alpha_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add alpha constant: {}", e),
             })?;
         let beta_const = network
-            .add_small_constant_copied(&broadcast_shape, &beta_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, beta_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add beta constant: {}", e),
             })?;
         let zero_const = network
-            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add zero constant: {}", e),
             })?;
         let one_const = network
-            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, one_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add one constant: {}", e),
@@ -2000,19 +2000,19 @@ impl TrtxConverter {
             ),
         };
         let three_const = network
-            .add_small_constant_copied(&broadcast_shape, &three_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, three_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 3 constant: {}", e),
             })?;
         let six_const = network
-            .add_small_constant_copied(&broadcast_shape, &six_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, six_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 6 constant: {}", e),
             })?;
         let zero_const = network
-            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add zero constant: {}", e),
@@ -2151,9 +2151,8 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         err_prefix: &str,
     ) -> Result<trtx::Tensor<'network>, GraphError> {
-        let scale_one = 1.0f32.to_le_bytes();
         let scale_constant = network
-            .add_small_constant_copied(&[], &scale_one, TrtDataType::kFLOAT)
+            .add_constant_owned(&[], 1.0f32.to_le_bytes().to_vec(), TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{}: {}", err_prefix, e),
@@ -3152,7 +3151,7 @@ impl TrtxConverter {
         };
         let var_shape: Vec<_> = var_dims;
         let epsilon_const = network
-            .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
+            .add_constant_owned(&var_shape, epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to add epsilon constant: {}", e),
@@ -3375,7 +3374,7 @@ impl TrtxConverter {
                 _ => (0.0f32.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
             };
             let zero_const = network
-                .add_small_constant_copied(&[1], &zero_bytes, zero_dtype)
+                .add_constant_owned(&[1], zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm 0D: failed to add zero constant: {}", e),
@@ -3477,7 +3476,7 @@ impl TrtxConverter {
                 ),
             };
             let zero_const = network
-                .add_small_constant_copied(&input_dims, &zero_bytes, zero_dtype)
+                .add_constant_owned(&input_dims, zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm axes=[]: failed to add zeros constant: {}", e),
@@ -3532,7 +3531,7 @@ impl TrtxConverter {
                         }
                     };
                     let bias_const = network
-                        .add_small_constant_copied(&input_dims, &bias_broadcast_bytes, zero_dtype)
+                        .add_constant_owned(&input_dims, bias_broadcast_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3555,7 +3554,7 @@ impl TrtxConverter {
                         _ => (0..num_el).flat_map(|_| 1.0f32.to_le_bytes()).collect(),
                     };
                     let ones_const = network
-                        .add_small_constant_copied(&input_dims, &ones_bytes, zero_dtype)
+                        .add_constant_owned(&input_dims, ones_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3702,7 +3701,7 @@ impl TrtxConverter {
             ),
         };
         let epsilon_const = network
-            .add_small_constant_copied(&var_shape, &epsilon_bytes, epsilon_dtype)
+            .add_constant_owned(&var_shape, epsilon_bytes, epsilon_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to add epsilon constant: {}", e),
@@ -4901,7 +4900,7 @@ impl TrtxConverter {
             }
         };
         let ones_const = network
-            .add_small_constant_copied(&new_shape, &ones_data, trt_dtype)
+            .add_constant_owned(&new_shape, ones_data, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ones constant for expand: {}", e),
@@ -5357,13 +5356,13 @@ impl TrtxConverter {
             .collect();
 
         let min_const = network
-            .add_small_constant_copied(&indices_shape, &min_data, trtx::DataType::kINT32)
+            .add_constant_owned(&indices_shape, min_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp min constant: {}", e),
             })?;
         let max_const = network
-            .add_small_constant_copied(&indices_shape, &max_data, trtx::DataType::kINT32)
+            .add_constant_owned(&indices_shape, max_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp max constant: {}", e),
@@ -5911,7 +5910,7 @@ impl TrtxConverter {
         // Implement clamp as: max(min_value, min(input, max_value))
         // First: min(input, max_value)
         let max_const = network
-            .add_small_constant_copied(&broadcast_shape, &max_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, max_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add max constant: {}", e),
@@ -5942,7 +5941,7 @@ impl TrtxConverter {
 
         // Second: max(min_value, clamped_upper)
         let min_const = network
-            .add_small_constant_copied(&broadcast_shape, &min_bytes, trt_dtype)
+            .add_constant_owned(&broadcast_shape, min_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min constant: {}", e),
@@ -6087,7 +6086,7 @@ impl TrtxConverter {
             };
 
             let alpha_constant = network
-                .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
+                .add_constant_owned(&broadcast_shape, alpha_bytes, alpha_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
@@ -6143,7 +6142,7 @@ impl TrtxConverter {
             };
 
             let beta_constant = network
-                .add_small_constant_copied(&broadcast_shape, &beta_bytes, beta_dtype)
+                .add_constant_owned(&broadcast_shape, beta_bytes, beta_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create beta constant: {}", e),
@@ -6525,7 +6524,7 @@ impl TrtxConverter {
             let alpha_bytes: Vec<u8> = alpha_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
             let alpha_layer = network
-                .add_small_constant_copied(&result_dims, &alpha_bytes, TrtDataType::kFLOAT)
+                .add_constant_owned(&result_dims, alpha_bytes, TrtDataType::kFLOAT)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
@@ -6582,7 +6581,7 @@ impl TrtxConverter {
                 let beta_bytes: Vec<u8> = beta_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
                 let beta_layer = network
-                    .add_small_constant_copied(&c_dims, &beta_bytes, TrtDataType::kFLOAT)
+                    .add_constant_owned(&c_dims, beta_bytes, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to create beta constant: {}", e),
@@ -8104,7 +8103,7 @@ impl TrtxConverter {
                 })?;
 
         let inf_constant = network
-            .add_small_constant_copied(&[1], &f32::INFINITY.to_le_bytes(), TrtDataType::kFLOAT)
+            .add_constant_owned(&[1], f32::INFINITY.to_le_bytes().to_vec(), TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create infinity constant: {}", e),
@@ -8450,7 +8449,7 @@ impl TrtxConverter {
         // Create axis constant tensor (true 0D scalar with shape [])
         // TensorRT requires axisDims.nbDims == 0 for cumulative operations
         let axis_constant = network
-            .add_small_constant_copied(&[], &axis_value.to_le_bytes(), trtx::DataType::kINT32)
+            .add_constant_owned(&[], axis_value.to_le_bytes().to_vec(), trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create axis constant: {}", e),
@@ -8564,7 +8563,7 @@ impl TrtxConverter {
             .map(|s| get_static_or_max_size(s) as i64)
             .collect();
         let mask_layer = network
-            .add_small_constant_copied(&dims, &mask_bytes, trtx::DataType::kFLOAT)
+            .add_constant_owned(&dims, mask_bytes, trtx::DataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add constant mask for triangular: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -36,6 +36,28 @@ use trtx::{
     PoolingType, ReduceOperation, ResizeMode, ScatterMode, TopKOperation, UnaryOperation,
 };
 
+trait WithContext<Value> {
+    fn with_context(self, context: &'static str) -> Result<Value, GraphError>;
+}
+
+impl<T> WithContext<T> for Result<T, trtx::Error> {
+    fn with_context(self, context: &'static str) -> Result<T, GraphError> {
+        self.map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{context}: {e:?}"),
+        })
+    }
+}
+
+impl From<trtx::Error> for GraphError {
+    fn from(value: trtx::Error) -> Self {
+        GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: value.to_string(),
+        }
+    }
+}
+
 /// TensorRT native converter
 pub struct TrtxConverter;
 
@@ -80,7 +102,7 @@ impl TrtxConverter {
     /// Convert float16 bytes to float32 bytes (little-endian). Used when filter is Float16
     /// but TensorRT conv layer expects Float weights.
     fn f16_bytes_to_f32_bytes(data: &[u8]) -> Result<Vec<u8>, GraphError> {
-        if data.len() % 2 != 0 {
+        if !data.len().is_multiple_of(2) {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Float16 data length {} is not even", data.len()),
@@ -296,12 +318,10 @@ impl TrtxConverter {
             })
     }
 
-    /// Build TensorRT network from WebNN graph
-    /// Returns temporary weight storage that must be kept alive until engine is serialized
+    /// Build TensorRT network from WebNN graph.
     fn build_network<'network>(
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let mut tensor_map: HashMap<u32, trtx::Tensor<'network>> = HashMap::new();
         let promoted_constants: HashSet<u32> = HashSet::new();
@@ -432,7 +452,6 @@ impl TrtxConverter {
                 graph,
                 network,
                 &mut tensor_map,
-                temp_weights,
                 &promoted_constants,
                 &constants_stored_flat,
                 operation,
@@ -466,7 +485,6 @@ impl TrtxConverter {
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
         promoted_constants: &'_ HashSet<u32>,
         constants_stored_flat: &'_ HashSet<u32>,
         operation: &'_ Operation,
@@ -547,12 +565,8 @@ impl TrtxConverter {
             }
             "leakyRelu" => Self::add_leaky_relu_op(graph, network, tensor_map, operation)?,
             "prelu" => Self::add_prelu_op(network, tensor_map, operation)?,
-            "hardSigmoid" => {
-                Self::add_hard_sigmoid_op(graph, network, tensor_map, operation, temp_weights)?
-            }
-            "hardSwish" => {
-                Self::add_hard_swish_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "hardSigmoid" => Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?,
+            "hardSwish" => Self::add_hard_swish_op(graph, network, tensor_map, operation)?,
 
             // Unary mathematical operations (use IUnaryLayer)
             // Exponential and logarithmic
@@ -582,7 +596,6 @@ impl TrtxConverter {
                 graph,
                 network,
                 tensor_map,
-                temp_weights,
                 promoted_constants,
                 constants_stored_flat,
                 operation,
@@ -595,9 +608,9 @@ impl TrtxConverter {
             "gemm" => Self::add_gemm_op(graph, network, tensor_map, operation)?,
 
             // Convolution operations
-            "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, temp_weights, operation)?,
+            "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, operation)?,
             "convTranspose2d" => {
-                Self::add_conv_transpose2d_op(graph, network, tensor_map, temp_weights, operation)?
+                Self::add_conv_transpose2d_op(graph, network, tensor_map, operation)?
             }
 
             // Pooling operations
@@ -701,9 +714,7 @@ impl TrtxConverter {
                 operation,
                 ElementWiseOperation::kXOR,
             )?,
-            "logicalNot" => {
-                Self::add_logical_not_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "logicalNot" => Self::add_logical_not_op(graph, network, tensor_map, operation)?,
 
             // Indexing/Gathering operations
             "gather" => Self::add_gather_op(graph, network, tensor_map, operation)?,
@@ -1174,7 +1185,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
         let input = tensor_map
@@ -1214,10 +1224,8 @@ impl TrtxConverter {
                         .take(n)
                         .map(|&b| if b == 0 { 0u8 } else { 1u8 })
                         .collect();
-                    temp_weights.push(bool_bytes);
-                    let ref_bytes = temp_weights.last().unwrap().as_slice();
                     let const_layer = network
-                        .add_constant(&shape, ref_bytes, TrtDataType::kBOOL)
+                        .add_small_constant_copied(&shape, &bool_bytes, TrtDataType::kBOOL)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: failed to add BOOL constant: {}", e),
@@ -1791,7 +1799,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1858,36 +1865,26 @@ impl TrtxConverter {
                 trtx::DataType::kFLOAT,
             ),
         };
-        temp_weights.push(alpha_bytes);
-        temp_weights.push(beta_bytes);
-        temp_weights.push(zero_bytes);
-        temp_weights.push(one_bytes);
-        let idx = temp_weights.len();
-        let alpha_ref = temp_weights[idx - 4].as_slice();
-        let beta_ref = temp_weights[idx - 3].as_slice();
-        let zero_ref = temp_weights[idx - 2].as_slice();
-        let one_ref = temp_weights[idx - 1].as_slice();
-
         let alpha_const = network
-            .add_constant(&broadcast_shape, alpha_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add alpha constant: {}", e),
             })?;
         let beta_const = network
-            .add_constant(&broadcast_shape, beta_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &beta_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add beta constant: {}", e),
             })?;
         let zero_const = network
-            .add_constant(&broadcast_shape, zero_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add zero constant: {}", e),
             })?;
         let one_const = network
-            .add_constant(&broadcast_shape, one_ref, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add one constant: {}", e),
@@ -1988,7 +1985,6 @@ impl TrtxConverter {
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2032,28 +2028,20 @@ impl TrtxConverter {
                 trtx::DataType::kFLOAT,
             ),
         };
-        temp_weights.push(three_bytes);
-        temp_weights.push(six_bytes);
-        temp_weights.push(zero_bytes);
-        let idx = temp_weights.len();
-        let three_ref = temp_weights[idx - 3].as_slice();
-        let six_ref = temp_weights[idx - 2].as_slice();
-        let zero_ref = temp_weights[idx - 1].as_slice();
-
         let three_const = network
-            .add_constant(&broadcast_shape, three_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &three_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 3 constant: {}", e),
             })?;
         let six_const = network
-            .add_constant(&broadcast_shape, six_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &six_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 6 constant: {}", e),
             })?;
         let zero_const = network
-            .add_constant(&broadcast_shape, zero_ref, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add zero constant: {}", e),
@@ -2195,14 +2183,11 @@ impl TrtxConverter {
     /// Helper: DQ(scale=1) with per-tensor (0D) scale. TensorRT only allows scalar or per-channel scale.
     fn add_dq_scale_constant_helper<'network>(
         network: &'_ mut trtx::NetworkDefinition<'network>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
         err_prefix: &str,
     ) -> Result<trtx::Tensor<'network>, GraphError> {
-        let scale_one: Vec<u8> = 1.0f32.to_le_bytes().to_vec();
-        temp_weights.push(scale_one);
-        let scale_ref = temp_weights.last().unwrap();
+        let scale_one = 1.0f32.to_le_bytes();
         let scale_constant = network
-            .add_constant(&[], scale_ref, TrtDataType::kFLOAT)
+            .add_small_constant_copied(&[], &scale_one, TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{}: {}", err_prefix, e),
@@ -2223,7 +2208,6 @@ impl TrtxConverter {
         graph: &GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -2339,11 +2323,8 @@ impl TrtxConverter {
                     }
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
-                let mut scale_tensor = Self::add_dq_scale_constant_helper(
-                    network,
-                    temp_weights,
-                    "int8->float32 cast",
-                )?;
+                let mut scale_tensor =
+                    Self::add_dq_scale_constant_helper(network, "int8->float32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(
                         &mut reshaped_4d,
@@ -2405,7 +2386,7 @@ impl TrtxConverter {
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
                 let mut scale_tensor =
-                    Self::add_dq_scale_constant_helper(network, temp_weights, "int8->int32 cast")?;
+                    Self::add_dq_scale_constant_helper(network, "int8->int32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(
                         &mut reshaped_4d,
@@ -5529,7 +5510,7 @@ impl TrtxConverter {
         // Create gather layer with axis 0 (required by addGather API)
         let mut layer =
             network
-                .add_gather(&input, &indices, 0)
+                .add_gather(input, indices, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add gatherND layer: {}", e),
@@ -5978,7 +5959,7 @@ impl TrtxConverter {
         // Implement clamp as: max(min_value, min(input, max_value))
         // First: min(input, max_value)
         let max_const = network
-            .add_small_constant_copied(&broadcast_shape, &max_bytes, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &max_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add max constant: {}", e),
@@ -6169,7 +6150,7 @@ impl TrtxConverter {
 
             // Multiply: alpha * x
             let mul_layer = network
-                .add_elementwise(input, &mut alpha_tensor, ElementWiseOperation::kPROD)
+                .add_elementwise(input, alpha_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to multiply by alpha: {}", e),
@@ -6226,11 +6207,7 @@ impl TrtxConverter {
 
             // Add: (alpha * x) + beta
             let add_layer = network
-                .add_elementwise(
-                    &mut after_multiply,
-                    &mut beta_tensor,
-                    ElementWiseOperation::kSUM,
-                )
+                .add_elementwise(&after_multiply, &beta_tensor, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add beta: {}", e),
@@ -6612,7 +6589,7 @@ impl TrtxConverter {
 
             // Multiply result by alpha
             let scale_layer = network
-                .add_elementwise(&mut result, &mut alpha_tensor, ElementWiseOperation::kPROD)
+                .add_elementwise(&result, &alpha_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to scale by alpha: {}", e),
@@ -6726,7 +6703,6 @@ impl TrtxConverter {
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -6754,7 +6730,7 @@ impl TrtxConverter {
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("oihw");
-        let (o, _i, h, w): (u32, u32, u32, u32) = match filter_layout {
+        let (o_ch, i_ch, kh, kw): (u32, u32, u32, u32) = match filter_layout {
             "oihw" => (fs[0], fs[1], fs[2], fs[3]),
             "hwio" => (fs[3], fs[2], fs[0], fs[1]),
             "ohwi" => (fs[0], fs[3], fs[1], fs[2]),
@@ -6767,19 +6743,46 @@ impl TrtxConverter {
                 });
             }
         };
-        let num_output_maps = o as i32;
-        let kernel_size: [i32; 2] = [h as i32, w as i32];
+        let num_output_maps = o_ch as i32;
+        let kernel_size: [i32; 2] = [kh as i32, kw as i32];
 
         let filter_constant = graph
             .constant_operand_ids_to_handles
             .contains_key(&filter_id);
 
-        // When filter is non-constant we use ILayer::setInput(1, kernel) / setInput(2, bias); kernel/bias weights must be empty.
-        let (filter_data_to_use, bias_data) = if filter_constant {
+        // Constant filter: owned kernel/bias tensors via add_convolution_owned_weights.
+        // Non-constant filter: setInput(1)/setInput(2) with empty inline weights.
+        let constant_conv_weights: Option<trtx::OwnedConvWeights> = if filter_constant {
             let filter_shape_u32 = filter_operand.descriptor.static_or_max_shape();
             let filter_data = Self::get_constant_data(graph, filter_id)?;
-            // Get optional bias - operand 2 if present.
-            let (bias_temp_index, bias_raw): (Option<usize>, Option<&[u8]>) = match bias_id {
+            let filter_dtype = filter_operand.descriptor.data_type;
+
+            let kernel_values: Vec<u8> = match (filter_dtype, filter_layout) {
+                (DataType::Float16, _) => {
+                    let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
+                    if filter_layout == "oihw" {
+                        f32_bytes
+                    } else {
+                        Self::conv_filter_to_oihw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                    }
+                }
+                (DataType::Float32, "oihw") => filter_data.to_vec(),
+                (DataType::Float32, _) => {
+                    Self::conv_filter_to_oihw(filter_data, filter_layout, &filter_shape_u32)?
+                }
+                _ => {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Conv2d filter data type {:?} not supported (use float32 or float16)",
+                            filter_dtype
+                        ),
+                    });
+                }
+            };
+
+            let bias_owned: Option<trtx::OwnedWeights> = match bias_id {
+                None => None,
                 Some(id) => {
                     if !graph.constant_operand_ids_to_handles.contains_key(&id) {
                         return Err(GraphError::ConversionFailed {
@@ -6792,56 +6795,28 @@ impl TrtxConverter {
                         .operand(id)
                         .map(|o| o.descriptor.data_type)
                         .unwrap_or(DataType::Float32);
-                    if dtype == DataType::Float16 {
-                        let f32_bias = Self::f16_bytes_to_f32_bytes(raw)?;
-                        temp_weights.push(f32_bias);
-                        (Some(temp_weights.len() - 1), None)
+                    let values = if dtype == DataType::Float16 {
+                        Self::f16_bytes_to_f32_bytes(raw)?
                     } else {
-                        (None, Some(raw))
-                    }
-                }
-                None => (None, None),
-            };
-            let filter_dtype = filter_operand.descriptor.data_type;
-            let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
-                (DataType::Float16, _) => {
-                    let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
-                    let oihw = if filter_layout == "oihw" {
-                        f32_bytes
-                    } else {
-                        Self::conv_filter_to_oihw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                        raw.to_vec()
                     };
-                    temp_weights.push(oihw);
-                    Some(temp_weights.len() - 1)
-                }
-                (DataType::Float32, "oihw") => None,
-                (DataType::Float32, _) => {
-                    let oihw =
-                        Self::conv_filter_to_oihw(filter_data, filter_layout, &filter_shape_u32)?;
-                    temp_weights.push(oihw);
-                    Some(temp_weights.len() - 1)
-                }
-                _ => {
-                    return Err(GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "Conv2d filter data type {:?} not supported (use float32 or float16)",
-                            filter_dtype
-                        ),
-                    });
+                    Some(trtx::OwnedWeights {
+                        shape: vec![o_ch as i64],
+                        data_type: TrtDataType::kFLOAT,
+                        values,
+                    })
                 }
             };
-            let bias_data: Option<&[u8]> = match bias_temp_index {
-                Some(idx) => Some(temp_weights[idx].as_slice()),
-                None => bias_raw,
-            };
-            let filter_data_to_use: &[u8] = match filter_temp_index {
-                Some(idx) => temp_weights[idx].as_slice(),
-                None => filter_data,
-            };
-            (Some(filter_data_to_use), bias_data)
+
+            Some(trtx::OwnedConvWeights {
+                kernel: trtx::OwnedWeights {
+                    shape: vec![o_ch as i64, i_ch as i64, kh as i64, kw as i64],
+                    data_type: TrtDataType::kFLOAT,
+                    values: kernel_values,
+                },
+                bias: bias_owned,
+            })
         } else {
-            // Non-constant filter: use tensor inputs (setInput(1)=kernel, setInput(2)=bias). TensorRT expects OIHW for kernel.
             if filter_layout != "oihw" {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
@@ -6849,15 +6824,15 @@ impl TrtxConverter {
                         .to_string(),
                 });
             }
-            if let Some(id) = bias_id {
-                if graph.constant_operand_ids_to_handles.contains_key(&id) {
-                    return Err(GraphError::ConversionFailed {
+            if let Some(id) = bias_id
+                && graph.constant_operand_ids_to_handles.contains_key(&id)
+            {
+                return Err(GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: "conv2d with non-constant filter requires bias to be a tensor input (constant bias not supported)".to_string(),
                     });
-                }
             }
-            (None, None)
+            None
         };
 
         // Input layout: nchw (default) or nhwc. TensorRT conv is NCHW; we use IShuffleLayer::setFirstTranspose for NHWC.
@@ -6886,7 +6861,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(network, &[0, 3, 1, 2]);
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .with_context("Failed to set shuffle for conv2d output");
             Some(
                 shuffle
                     .get_output(network, 0)
@@ -6957,7 +6934,7 @@ impl TrtxConverter {
         let conv_input =
             if pre_padding.iter().any(|&p| p != 0) || post_padding.iter().any(|&p| p != 0) {
                 let padding_layer = network
-                    .add_padding(&conv_input_source, &pre_padding, &post_padding)
+                    .add_padding(conv_input_source, &pre_padding, &post_padding)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add padding layer: {}", e),
@@ -6971,7 +6948,7 @@ impl TrtxConverter {
                     })?
             } else {
                 // No padding needed, use conv_input_source directly
-                let id_layer = network.add_identity(&conv_input_source).map_err(|e| {
+                let id_layer = network.add_identity(conv_input_source).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add identity layer: {}", e),
@@ -6986,23 +6963,15 @@ impl TrtxConverter {
             };
 
         // Add convolution layer with zero padding (padding already applied via padding layer)
-        // Constant path always passes f32 data (f16 filter/bias are converted above); dtype must match.
-        let mut layer = match (filter_data_to_use, bias_data) {
-            (Some(fd), b) => {
-                let conv_weights = trtx::ConvWeights {
-                    kernel_weights: fd,
-                    kernel_dtype: TrtDataType::kFLOAT,
-                    bias_weights: b,
-                    bias_dtype: b.map(|_| TrtDataType::kFLOAT),
-                };
-                network
-                    .add_convolution(&conv_input, num_output_maps, &kernel_size, &conv_weights)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add convolution: {}", e),
-                    })?
-            }
-            (None, _) => {
+        // Constant path: owned f32 kernel/bias (f16 converted above).
+        let mut layer = match constant_conv_weights {
+            Some(owned) => network
+                .add_convolution_owned_weights(&conv_input, num_output_maps, &kernel_size, owned)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add convolution: {}", e),
+                })?,
+            None => {
                 let filter_tensor =
                     tensor_map
                         .get(&filter_id)
@@ -7127,7 +7096,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(network, &[0, 2, 3, 1]);
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .with_context("Failed to set first transpose for convolution")?;
             shuffle
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -7150,7 +7121,6 @@ impl TrtxConverter {
         graph: &'network GraphInfo,
         network: &'_ mut trtx::NetworkDefinition<'network>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
-        temp_weights: &'network mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -7180,7 +7150,7 @@ impl TrtxConverter {
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("iohw");
-        let (_i, o, h, w): (u32, u32, u32, u32) = match filter_layout {
+        let (i_ch, o_pg, kh, kw): (u32, u32, u32, u32) = match filter_layout {
             "iohw" => (fs[0], fs[1], fs[2], fs[3]),
             "oihw" => (fs[1], fs[0], fs[2], fs[3]),
             "hwio" => (fs[2], fs[3], fs[0], fs[1]),
@@ -7196,17 +7166,44 @@ impl TrtxConverter {
         };
         let groups = deconv_opts.map(|o| o.groups).unwrap_or(1);
         // WebNN filter shape is [inputChannels, outputChannels/groups, H, W]; TensorRT expects total output maps.
-        let num_output_maps = o * groups;
-        let kernel_size: [i64; 2] = [h.into(), w.into()];
+        let num_output_maps = o_pg * groups;
+        let kernel_size: [i64; 2] = [kh.into(), kw.into()];
 
         let filter_constant = graph
             .constant_operand_ids_to_handles
             .contains_key(&filter_id);
 
-        let (filter_data_to_use, bias_data) = if filter_constant {
+        let constant_deconv_weights: Option<trtx::OwnedConvWeights> = if filter_constant {
             let filter_shape_u32 = filter_operand.descriptor.static_or_max_shape();
             let filter_data = Self::get_constant_data(graph, filter_id)?;
-            let (bias_temp_index, bias_raw): (Option<usize>, Option<&[u8]>) = match bias_id {
+            let filter_dtype = filter_operand.descriptor.data_type;
+
+            let kernel_values: Vec<u8> = match (filter_dtype, filter_layout) {
+                (DataType::Float16, _) => {
+                    let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
+                    if filter_layout == "iohw" {
+                        f32_bytes
+                    } else {
+                        Self::deconv_filter_to_iohw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                    }
+                }
+                (DataType::Float32, "iohw") => filter_data.to_vec(),
+                (DataType::Float32, _) => {
+                    Self::deconv_filter_to_iohw(filter_data, filter_layout, &filter_shape_u32)?
+                }
+                _ => {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "convTranspose2d filter data type {:?} not supported (use float32 or float16)",
+                            filter_dtype
+                        ),
+                    });
+                }
+            };
+
+            let bias_owned: Option<trtx::OwnedWeights> = match bias_id {
+                None => None,
                 Some(id) => {
                     if !graph.constant_operand_ids_to_handles.contains_key(&id) {
                         return Err(GraphError::ConversionFailed {
@@ -7219,54 +7216,27 @@ impl TrtxConverter {
                         .operand(id)
                         .map(|o| o.descriptor.data_type)
                         .unwrap_or(DataType::Float32);
-                    if dtype == DataType::Float16 {
-                        let f32_bias = Self::f16_bytes_to_f32_bytes(raw)?;
-                        temp_weights.push(f32_bias);
-                        (Some(temp_weights.len() - 1), None)
+                    let values = if dtype == DataType::Float16 {
+                        Self::f16_bytes_to_f32_bytes(raw)?
                     } else {
-                        (None, Some(raw))
-                    }
-                }
-                None => (None, None),
-            };
-            let filter_dtype = filter_operand.descriptor.data_type;
-            let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
-                (DataType::Float16, _) => {
-                    let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
-                    let iohw = if filter_layout == "iohw" {
-                        f32_bytes
-                    } else {
-                        Self::deconv_filter_to_iohw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                        raw.to_vec()
                     };
-                    temp_weights.push(iohw);
-                    Some(temp_weights.len() - 1)
-                }
-                (DataType::Float32, "iohw") => None,
-                (DataType::Float32, _) => {
-                    let iohw =
-                        Self::deconv_filter_to_iohw(filter_data, filter_layout, &filter_shape_u32)?;
-                    temp_weights.push(iohw);
-                    Some(temp_weights.len() - 1)
-                }
-                _ => {
-                    return Err(GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "convTranspose2d filter data type {:?} not supported (use float32 or float16)",
-                            filter_dtype
-                        ),
-                    });
+                    Some(trtx::OwnedWeights {
+                        shape: vec![num_output_maps as i64],
+                        data_type: TrtDataType::kFLOAT,
+                        values,
+                    })
                 }
             };
-            let bias_data: Option<&[u8]> = match bias_temp_index {
-                Some(idx) => Some(temp_weights[idx].as_slice()),
-                None => bias_raw,
-            };
-            let filter_data_to_use: &[u8] = match filter_temp_index {
-                Some(idx) => temp_weights[idx].as_slice(),
-                None => filter_data,
-            };
-            (Some(filter_data_to_use), bias_data)
+
+            Some(trtx::OwnedConvWeights {
+                kernel: trtx::OwnedWeights {
+                    shape: vec![i_ch as i64, o_pg as i64, kh as i64, kw as i64],
+                    data_type: TrtDataType::kFLOAT,
+                    values: kernel_values,
+                },
+                bias: bias_owned,
+            })
         } else {
             if filter_layout != "iohw" {
                 return Err(GraphError::ConversionFailed {
@@ -7276,15 +7246,15 @@ impl TrtxConverter {
                             .to_string(),
                 });
             }
-            if let Some(id) = bias_id {
-                if graph.constant_operand_ids_to_handles.contains_key(&id) {
-                    return Err(GraphError::ConversionFailed {
+            if let Some(id) = bias_id
+                && graph.constant_operand_ids_to_handles.contains_key(&id)
+            {
+                return Err(GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: "convTranspose2d with non-constant filter requires bias to be a tensor input (constant bias not supported)".to_string(),
                     });
-                }
             }
-            (None, None)
+            None
         };
 
         let input_layout = deconv_opts
@@ -7311,7 +7281,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(network, &[0, 3, 1, 2]);
+            shuffle.set_first_transpose(network, &[0, 3, 1, 2])?;
             Some(
                 shuffle
                     .get_output(network, 0)
@@ -7377,7 +7347,7 @@ impl TrtxConverter {
 
         // Map WebNN padding to TensorRT IDeconvolutionLayer pre/post (trim); do not pad the input.
         let deconv_input = {
-            let id_layer = network.add_identity(&deconv_input_source).map_err(|e| {
+            let id_layer = network.add_identity(deconv_input_source).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d identity: {}", e),
@@ -7391,27 +7361,19 @@ impl TrtxConverter {
                 })?
         };
 
-        let mut layer = match (filter_data_to_use, bias_data) {
-            (Some(fd), b) => {
-                let deconv_weights = trtx::ConvWeights {
-                    kernel_weights: fd,
-                    kernel_dtype: TrtDataType::kFLOAT,
-                    bias_weights: b,
-                    bias_dtype: b.map(|_| TrtDataType::kFLOAT),
-                };
-                network
-                    .add_deconvolution(
-                        &deconv_input,
-                        num_output_maps.into(),
-                        &kernel_size,
-                        &deconv_weights,
-                    )
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add deconvolution: {}", e),
-                    })?
-            }
-            (None, _) => {
+        let mut layer = match constant_deconv_weights {
+            Some(owned) => network
+                .add_deconvolution_owned_weights(
+                    &deconv_input,
+                    num_output_maps.into(),
+                    &kernel_size,
+                    owned,
+                )
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add deconvolution: {}", e),
+                })?,
+            None => {
                 let filter_tensor =
                     tensor_map
                         .get(&filter_id)
@@ -7469,35 +7431,28 @@ impl TrtxConverter {
                     None
                 };
 
-                let deconv_weights = trtx::ConvWeights {
-                    kernel_weights: &[],
-                    kernel_dtype: TrtDataType::kFLOAT,
-                    bias_weights: None,
-                    bias_dtype: None,
-                };
                 let mut layer = network
-                    .add_deconvolution(
+                    .add_deconvolution_deferred_weights(
                         &deconv_input,
                         num_output_maps as i64,
                         &kernel_size,
-                        &deconv_weights,
                     )
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add deconvolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(network, 1, filter_tensor_to_use);
+                layer.set_input(network, 1, filter_tensor_to_use)?;
                 if let Some(bt) = bias_tensor_for_conv.as_ref() {
-                    layer.set_input(network, 2, bt);
+                    layer.set_input(network, 2, bt)?;
                 } else if let Some(bt) = bias_tensor_raw.as_ref() {
-                    layer.set_input(network, 2, bt);
+                    layer.set_input(network, 2, bt)?;
                 }
                 layer
             }
         };
 
-        layer.set_stride(network, &strides);
-        layer.set_dilation(network, &dilations);
+        layer.set_stride(network, &strides)?;
+        layer.set_dilation(network, &dilations)?;
         // outputPadding extends output size. Absorb by reducing padding when possible; otherwise add
         // IPaddingLayer for remainder. WebNN: out = (in-1)*stride + kernel - pre - post + outputPadding.
         // TensorRT: out = (in-1)*stride + kernel - pre - post. Reduce pre+post by outputPadding.
@@ -7532,9 +7487,9 @@ impl TrtxConverter {
         // See https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-861/operators/docs/Deconvolution.html
         let pre: [i64; 2] = pre_effective;
         let post: [i64; 2] = post_effective;
-        layer.set_pre_padding(network, &pre);
-        layer.set_post_padding(network, &post);
-        layer.set_num_groups(network, groups as i64);
+        layer.set_pre_padding(network, &pre)?;
+        layer.set_post_padding(network, &post)?;
+        layer.set_num_groups(network, groups as i64)?;
 
         let deconv_output =
             layer
@@ -7641,11 +7596,12 @@ impl TrtxConverter {
                         if pad_h > 0 || pad_w > 0 {
                             let pre: Vec<i64> = vec![0, 0];
                             let post: Vec<i64> = vec![pad_h, pad_w];
-                            let pad_layer = network
-                                .add_padding(&mut current, &pre, &post)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("convTranspose2d outputSizes pad: {}", e),
+                            let pad_layer =
+                                network.add_padding(&current, &pre, &post).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("convTranspose2d outputSizes pad: {}", e),
+                                    }
                                 })?;
                             pad_layer.get_output(network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
@@ -7690,7 +7646,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(network, &[0, 2, 3, 1]);
+            shuffle.set_first_transpose(network, &[0, 2, 3, 1])?;
             shuffle
                 .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8739,9 +8695,7 @@ impl GraphConverter for TrtxConverter {
                 reason: format!("Failed to create TensorRT network: {}", e),
             })?;
 
-        // Build the network from WebNN graph and capture temporary weights
-        let mut temp_weights = Vec::new();
-        Self::build_network(graph_info, &mut network, &mut temp_weights)?;
+        Self::build_network(graph_info, &mut network)?;
 
         // Create builder config
         let mut config = builder

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -7892,12 +7892,6 @@ impl TrtxConverter {
                 });
             }
         };
-        if new_shape.is_empty() {
-            return Err(GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "reshape operation missing 'newShape'".to_string(),
-            });
-        }
 
         let dims: Vec<i64> = crate::operator_options::mldimensions_static_or_max(new_shape)
             .into_iter()

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -28,13 +28,15 @@ use half::f16;
 use super::{ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
+use crate::graph::{DataType, GraphInfo, OperandKind, Operation, get_static_or_max_size};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use trtx::network::Layer;
+use trtx::network::Layer;
 use trtx::{
-    ActivationType, DataType as TrtDataType, ElementWiseOperation, PoolingType, ReduceOperation,
-    ResizeMode, ScatterMode, UnaryOperation,
+    ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
+    PoolingType, ReduceOperation, ResizeMode, ScatterMode, TopKOperation, UnaryOperation,
 };
 
 /// TensorRT native converter
@@ -222,10 +224,10 @@ impl TrtxConverter {
     }
 
     /// Cast Float32 tensor to BOOL (0.0 → false, non-zero → true)
-    fn cast_to_bool(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_bool<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        input: &'_ trtx::Tensor<'network>,
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kBOOL).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -233,7 +235,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -241,10 +243,10 @@ impl TrtxConverter {
     }
 
     /// Cast BOOL tensor to Float32 (false → 0.0, true → 1.0)
-    fn cast_to_float32(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_float32<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        input: &'_ trtx::Tensor<'network>,
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kFLOAT).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -252,7 +254,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -260,10 +262,10 @@ impl TrtxConverter {
     }
 
     /// Cast tensor to Float16 (e.g. after float32 reduction to avoid float16 overflow).
-    fn cast_to_float16(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_float16<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        input: &'_ trtx::Tensor<'network>,
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kHALF).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -271,7 +273,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -279,10 +281,10 @@ impl TrtxConverter {
     }
 
     /// Cast INT32 tensor to Float32
-    fn cast_int32_to_float32(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_int32_to_float32<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        input: &'_ trtx::Tensor<'network>,
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kFLOAT).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -290,7 +292,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -299,11 +301,11 @@ impl TrtxConverter {
 
     /// Build TensorRT network from WebNN graph
     /// Returns temporary weight storage that must be kept alive until engine is serialized
-    fn build_network(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
+    fn build_network<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
     ) -> Result<Vec<Vec<u8>>, GraphError> {
-        let mut tensor_map: HashMap<u32, trtx::Tensor> = HashMap::new();
+        let mut tensor_map: HashMap<u32, trtx::Tensor<'network>> = HashMap::new();
         let mut temp_weights: Vec<Vec<u8>> = Vec::new(); // Storage for temporary constants
         let promoted_constants: HashSet<u32> = HashSet::new();
         let constants_stored_flat: HashSet<u32> = HashSet::new();
@@ -312,11 +314,11 @@ impl TrtxConverter {
         for (operand_id, operand) in graph.operands.iter().enumerate() {
             if operand.kind == OperandKind::Input {
                 let dtype = Self::webnn_to_trt_dtype(operand.descriptor.data_type)?;
-                let dims: Vec<i32> = operand
+                let dims: Vec<i64> = operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let name = operand.name.as_deref().unwrap_or("input");
 
@@ -328,7 +330,7 @@ impl TrtxConverter {
                 })?;
 
                 tensor
-                    .set_name(name)
+                    .set_name(network, name)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to set input name: {}", e),
@@ -341,11 +343,11 @@ impl TrtxConverter {
         // Step 2: Add constants
         for (operand_id, operand) in graph.operands.iter().enumerate() {
             if operand.kind == OperandKind::Constant {
-                let dims: Vec<i32> = operand
+                let dims: Vec<i64> = operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let data = Self::get_constant_data(graph, operand_id as u32)?;
 
@@ -420,12 +422,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add constant (operand {}): {}", operand_id, e),
                     })?;
 
-                let tensor = layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get constant layer output: {}", e),
-                    })?;
+                let tensor =
+                    layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get constant layer output: {}", e),
+                        })?;
 
                 tensor_map.insert(operand_id as u32, tensor);
             }
@@ -447,7 +450,7 @@ impl TrtxConverter {
         // Step 4: Mark outputs (only actual graph outputs, not intermediate tensors)
         for (operand_id, operand) in graph.operands.iter().enumerate() {
             if operand.kind == OperandKind::Output {
-                let tensor = tensor_map.get_mut(&(operand_id as u32)).ok_or_else(|| {
+                let tensor = tensor_map.get(&(operand_id as u32)).ok_or_else(|| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Output operand {} not found in tensor map", operand_id),
@@ -456,19 +459,10 @@ impl TrtxConverter {
 
                 // Set the output tensor name if available
                 if let Some(name) = &operand.name {
-                    let _ = tensor.set_name(name); // Ignore error if name setting fails
+                    let _ = tensor.set_name(network, name); // Ignore error if name setting fails
                 }
 
-                network
-                    .mark_output(tensor)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "Failed to mark output {}: {}",
-                            operand.name.as_deref().unwrap_or("unnamed"),
-                            e
-                        ),
-                    })?;
+                network.mark_output(tensor);
             }
         }
 
@@ -476,10 +470,10 @@ impl TrtxConverter {
     }
 
     /// Add a single operation to the network
-    fn add_operation(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_operation<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         temp_weights: &mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
@@ -559,9 +553,7 @@ impl TrtxConverter {
             "gelu" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kGELU_ERF)?
             }
-            "leakyRelu" => {
-                Self::add_leaky_relu_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "leakyRelu" => Self::add_leaky_relu_op(graph, network, tensor_map, operation)?,
             "prelu" => Self::add_prelu_op(network, tensor_map, operation)?,
             "hardSigmoid" => {
                 Self::add_hard_sigmoid_op(graph, network, tensor_map, operation, temp_weights)?
@@ -608,7 +600,7 @@ impl TrtxConverter {
 
             // Matrix operations
             "matmul" => Self::add_matmul_op(network, tensor_map, operation)?,
-            "gemm" => Self::add_gemm_op(graph, network, tensor_map, temp_weights, operation)?,
+            "gemm" => Self::add_gemm_op(graph, network, tensor_map, operation)?,
 
             // Convolution operations
             "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, temp_weights, operation)?,
@@ -632,13 +624,9 @@ impl TrtxConverter {
             "batchNormalization" => {
                 Self::add_batch_normalization_op(graph, network, tensor_map, operation)?
             }
-            "instanceNormalization" => Self::add_instance_normalization_op(
-                graph,
-                network,
-                tensor_map,
-                operation,
-                temp_weights,
-            )?,
+            "instanceNormalization" => {
+                Self::add_instance_normalization_op(graph, network, tensor_map, operation)?
+            }
             "layerNormalization" => Self::add_layer_normalization_op(
                 graph,
                 network,
@@ -738,9 +726,9 @@ impl TrtxConverter {
             "argMin" => Self::add_arg_min_op(network, tensor_map, operation)?,
 
             // Other operations
-            "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation, temp_weights)?,
+            "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation)?,
             "where" => Self::add_where_op(network, tensor_map, operation)?,
-            "linear" => Self::add_linear_op(graph, network, tensor_map, operation, temp_weights)?,
+            "linear" => Self::add_linear_op(graph, network, tensor_map, operation)?,
             "pad" => Self::add_pad_op(network, tensor_map, operation)?,
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
             "concat" => Self::add_concat_op(network, tensor_map, operation)?,
@@ -775,15 +763,15 @@ impl TrtxConverter {
 
     /// Helper to ensure two tensors have compatible shapes for elementwise operations
     /// Returns potentially reshaped tensors that are guaranteed to be broadcast-compatible
-    fn ensure_broadcast_compatible(
-        network: &mut trtx::NetworkDefinition,
-        tensor0: &trtx::Tensor,
-        tensor1: &trtx::Tensor,
-        op_name: &str,
-    ) -> Result<(trtx::Tensor, trtx::Tensor), GraphError> {
+    fn ensure_broadcast_compatible<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor0: &'_ trtx::Tensor<'network>,
+        tensor1: &'_ trtx::Tensor<'network>,
+        op_name: &'_ str,
+    ) -> Result<(trtx::Tensor<'network>, trtx::Tensor<'network>), GraphError> {
         // Get dimensions of both tensors
         let dims0 = tensor0
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!(
@@ -793,7 +781,7 @@ impl TrtxConverter {
             })?;
 
         let dims1 = tensor1
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!(
@@ -812,7 +800,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor0: {}", e),
                 })?;
             let t0 = id0
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -825,7 +813,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor1: {}", e),
                 })?;
             let t1 = id1
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -864,7 +852,7 @@ impl TrtxConverter {
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
                 let t0 = id0
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -878,7 +866,7 @@ impl TrtxConverter {
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
                 let t1 = id1
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -903,15 +891,10 @@ impl TrtxConverter {
                             reason: format!("Failed to add resize layer for tensor0: {}", e),
                         })?;
 
-                resize_layer.set_output_dimensions(&dims1).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to set output dimensions: {}", e),
-                    }
-                })?;
+                resize_layer.set_output_dimensions(network, &dims1);
 
                 resize_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -924,10 +907,11 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
-                id.get_output(0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get identity output: {}", e),
-                })?
+                id.get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?
             };
 
             let t1 = if dims1
@@ -944,15 +928,10 @@ impl TrtxConverter {
                             reason: format!("Failed to add resize layer for tensor1: {}", e),
                         })?;
 
-                resize_layer.set_output_dimensions(&dims0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to set output dimensions: {}", e),
-                    }
-                })?;
+                resize_layer.set_output_dimensions(network, &dims0);
 
                 resize_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -965,10 +944,11 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
-                id.get_output(0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get identity output: {}", e),
-                })?
+                id.get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?
             };
 
             return Ok((t0, t1));
@@ -982,22 +962,24 @@ impl TrtxConverter {
             (tensor1, tensor0, false)
         };
 
-        let reshape_dims = to_reshape
-            .dimensions()
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get reshape dims: {}", e),
-            })?;
-        let target_dims = to_keep
-            .dimensions()
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get target dims: {}", e),
-            })?;
+        let reshape_dims =
+            to_reshape
+                .dimensions(network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get reshape dims: {}", e),
+                })?;
+        let target_dims =
+            to_keep
+                .dimensions(network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get target dims: {}", e),
+                })?;
 
         // Pad smaller tensor with leading 1s
         let rank_diff = target_dims.len() - reshape_dims.len();
-        let mut new_shape: Vec<i32> = vec![1; rank_diff];
+        let mut new_shape: Vec<i64> = vec![1; rank_diff];
         new_shape.extend_from_slice(&reshape_dims);
 
         let mut shuffle_layer =
@@ -1009,18 +991,19 @@ impl TrtxConverter {
                 })?;
 
         shuffle_layer
-            .set_reshape_dimensions(&new_shape)
+            .set_reshape_dimensions(network, &new_shape)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape dimensions: {}", e),
             })?;
 
-        let reshaped = shuffle_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get reshape output: {}", e),
-            })?;
+        let reshaped =
+            shuffle_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get reshape output: {}", e),
+                })?;
 
         // Clone the other tensor with identity
         let id_keep = network
@@ -1030,7 +1013,7 @@ impl TrtxConverter {
                 reason: format!("Failed to clone kept tensor: {}", e),
             })?;
         let kept = id_keep
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -1045,10 +1028,10 @@ impl TrtxConverter {
     }
 
     /// Add elementwise operation
-    fn add_elementwise_op(
+    fn add_elementwise_op<'network>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1067,11 +1050,11 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility (this may reshape tensors if needed)
-        let (bc_input0, bc_input1) =
+        let (mut bc_input0, mut bc_input1) =
             Self::ensure_broadcast_compatible(network, input0, input1, operation.op_type())?;
 
         let layer = network
-            .add_elementwise(&bc_input0, &bc_input1, op_code)
+            .add_elementwise(&mut bc_input0, &mut bc_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elementwise operation: {}", e),
@@ -1079,7 +1062,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1092,10 +1075,10 @@ impl TrtxConverter {
     }
 
     /// Add comparison operation (outputs BOOL, cast to Float32)
-    fn add_comparison_op(
+    fn add_comparison_op<'network>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1114,26 +1097,27 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility
-        let (bc_input0, bc_input1) =
+        let (mut bc_input0, mut bc_input1) =
             Self::ensure_broadcast_compatible(network, input0, input1, operation.op_type())?;
 
         // Comparison operation returns BOOL
         let layer = network
-            .add_elementwise(&bc_input0, &bc_input1, op_code)
+            .add_elementwise(&mut bc_input0, &mut bc_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add comparison operation: {}", e),
             })?;
 
-        let bool_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let mut bool_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
-        let output = Self::cast_to_float32(network, &bool_output)?;
+        let output = Self::cast_to_float32(network, &mut bool_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1142,10 +1126,10 @@ impl TrtxConverter {
     }
 
     /// Add logical operation (cast Float32 to BOOL, perform operation, cast back to Float32)
-    fn add_logical_binary_op(
+    fn add_logical_binary_op<'network>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1172,22 +1156,25 @@ impl TrtxConverter {
         let bool_input1 = Self::cast_to_bool(network, &bc_input1)?;
 
         // Perform logical operation on BOOL
+        let mut bool_input0 = bool_input0;
+        let mut bool_input1 = bool_input1;
         let layer = network
-            .add_elementwise(&bool_input0, &bool_input1, op_code)
+            .add_elementwise(&mut bool_input0, &mut bool_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add logical operation: {}", e),
             })?;
 
-        let bool_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let mut bool_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         // Cast BOOL output back to Float32
-        let output = Self::cast_to_float32(network, &bool_output)?;
+        let output = Self::cast_to_float32(network, &mut bool_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1198,10 +1185,10 @@ impl TrtxConverter {
     /// Add logical NOT operation. TensorRT Unary(kNOT) requires Bool input.
     /// Quantized constants (kINT8) may only feed DQ/plugin; for UInt8/Int8 constant, add a kBOOL
     /// constant (0 -> false, non-zero -> true) and feed it directly to kNOT so no extra Cast is needed.
-    fn add_logical_not_op(
+    fn add_logical_not_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
@@ -1213,7 +1200,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let not_input = if graph
+        let mut not_input = if graph
             .constant_operand_ids_to_handles
             .contains_key(&input_id)
         {
@@ -1251,12 +1238,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: failed to add BOOL constant: {}", e),
                         })?;
-                    const_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
+                    const_layer.get_output(network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: BOOL constant output: {}", e),
-                        })?
+                        }
+                    })?
                 }
                 _ => Self::cast_to_bool(network, input)?,
             }
@@ -1265,20 +1252,21 @@ impl TrtxConverter {
         };
 
         let layer = network
-            .add_unary(&not_input, UnaryOperation::kNOT)
+            .add_unary(&mut not_input, UnaryOperation::kNOT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add logical NOT: {}", e),
             })?;
 
-        let not_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let mut not_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
-        let output = Self::cast_to_float32(network, &not_output)?;
+        let output = Self::cast_to_float32(network, &mut not_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1287,9 +1275,9 @@ impl TrtxConverter {
     }
 
     /// Add activation operation
-    fn add_activation_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_activation_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         activation_type: ActivationType,
     ) -> Result<(), GraphError> {
@@ -1309,7 +1297,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1324,10 +1312,10 @@ impl TrtxConverter {
     /// Add ELU activation: ELU(x) = x if x > 0, else alpha * (exp(x) - 1)
     /// TensorRT kELU uses alpha=1; for custom alpha we decompose as:
     /// relu(x) + alpha * min(0, exp(x) - 1)
-    fn add_elu_op(
+    fn add_elu_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
@@ -1383,25 +1371,27 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for elu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let mut relu_output =
+            relu_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         let exp_layer = network
-            .add_unary(input, UnaryOperation::kEXP)
+            .add_unary(input, UnaryOperation::kEXP.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add exp for elu: {}", e),
             })?;
-        let exp_output = exp_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get exp output: {}", e),
-            })?;
+        let mut exp_output =
+            exp_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get exp output: {}", e),
+                })?;
 
         temp_weights.push(one_bytes);
         let one_const = network
@@ -1414,25 +1404,30 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create one constant for elu: {}", e),
             })?;
-        let one_tensor = one_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get one constant output: {}", e),
-            })?;
+        let mut one_tensor =
+            one_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get one constant output: {}", e),
+                })?;
 
-        let (bc_exp, bc_one) =
-            Self::ensure_broadcast_compatible(network, &exp_output, &one_tensor, "elu_exp_sub")?;
+        let (mut bc_exp, mut bc_one) = Self::ensure_broadcast_compatible(
+            network,
+            &mut exp_output,
+            &mut one_tensor,
+            "elu_exp_sub",
+        )?;
 
         let exp_minus_1_layer = network
-            .add_elementwise(&bc_exp, &bc_one, ElementWiseOperation::kSUB)
+            .add_elementwise(&mut bc_exp, &mut bc_one, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract 1 for elu: {}", e),
             })?;
-        let exp_minus_1 =
+        let mut exp_minus_1 =
             exp_minus_1_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get exp-1 output: {}", e),
@@ -1449,28 +1444,34 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create zero constant for elu: {}", e),
             })?;
-        let zero_tensor = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get zero constant output: {}", e),
-            })?;
+        let mut zero_tensor =
+            zero_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get zero constant output: {}", e),
+                })?;
 
-        let (bc_em1, bc_zero) =
-            Self::ensure_broadcast_compatible(network, &exp_minus_1, &zero_tensor, "elu_min")?;
+        let (mut bc_em1, mut bc_zero) = Self::ensure_broadcast_compatible(
+            network,
+            &mut exp_minus_1,
+            &mut zero_tensor,
+            "elu_min",
+        )?;
 
         let neg_part_layer = network
-            .add_elementwise(&bc_em1, &bc_zero, ElementWiseOperation::kMIN)
+            .add_elementwise(&mut bc_em1, &mut bc_zero, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min for elu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get neg part output: {}", e),
-            })?;
+        let mut neg_part =
+            neg_part_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get neg part output: {}", e),
+                })?;
 
         temp_weights.push(alpha_bytes);
         let alpha_const = network
@@ -1483,45 +1484,55 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create alpha constant for elu: {}", e),
             })?;
-        let alpha_tensor = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get alpha constant output: {}", e),
-            })?;
+        let mut alpha_tensor =
+            alpha_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get alpha constant output: {}", e),
+                })?;
 
-        let (bc_neg, bc_alpha) =
-            Self::ensure_broadcast_compatible(network, &neg_part, &alpha_tensor, "elu_scale")?;
+        let (mut bc_neg, mut bc_alpha) = Self::ensure_broadcast_compatible(
+            network,
+            &mut neg_part,
+            &mut alpha_tensor,
+            "elu_scale",
+        )?;
 
         let scaled_neg_layer = network
-            .add_elementwise(&bc_neg, &bc_alpha, ElementWiseOperation::kPROD)
+            .add_elementwise(&mut bc_neg, &mut bc_alpha, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to multiply by alpha for elu: {}", e),
             })?;
-        let scaled_neg =
+        let mut scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled neg output: {}", e),
                 })?;
 
-        let (bc_relu, bc_scaled) =
-            Self::ensure_broadcast_compatible(network, &relu_output, &scaled_neg, "elu_add")?;
+        let (mut bc_relu, mut bc_scaled) = Self::ensure_broadcast_compatible(
+            network,
+            &mut relu_output,
+            &mut scaled_neg,
+            "elu_add",
+        )?;
 
         let final_layer = network
-            .add_elementwise(&bc_relu, &bc_scaled, ElementWiseOperation::kSUM)
+            .add_elementwise(&mut bc_relu, &mut bc_scaled, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elu parts: {}", e),
             })?;
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get elu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get elu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1530,9 +1541,9 @@ impl TrtxConverter {
     }
 
     /// Add unary operation (element-wise mathematical operations)
-    fn add_unary_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_unary_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         unary_op: UnaryOperation,
     ) -> Result<(), GraphError> {
@@ -1543,17 +1554,16 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let layer =
-            network
-                .add_unary(input, unary_op)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add unary operation: {}", e),
-                })?;
+        let layer = network.add_unary(input, unary_op.into()).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add unary operation: {}", e),
+            }
+        })?;
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1568,12 +1578,11 @@ impl TrtxConverter {
     /// Add leaky ReLU activation
     /// LeakyReLU(x) = max(alpha * x, x) = x if x >= 0, else alpha * x
     /// Implemented as: max(0, x) + alpha * min(0, x) so alpha is respected (including negative).
-    fn add_leaky_relu_op(
+    fn add_leaky_relu_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1607,21 +1616,20 @@ impl TrtxConverter {
             ),
             _ => (alpha.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
         };
-        temp_weights.push(alpha_bytes);
-        let alpha_ref = temp_weights.last().unwrap().as_slice();
 
         let alpha_const = network
-            .add_constant(&broadcast_shape, alpha_ref, alpha_dtype)
+            .add_constant(&broadcast_shape, &alpha_bytes, alpha_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LeakyReLU: failed to add alpha constant: {}", e),
             })?;
-        let alpha_tensor = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("LeakyReLU: alpha const output: {}", e),
-            })?;
+        let mut alpha_tensor =
+            alpha_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("LeakyReLU: alpha const output: {}", e),
+                })?;
 
         // max(0, x) = relu(x)
         let relu_layer = network
@@ -1630,37 +1638,43 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for leaky relu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let mut relu_output =
+            relu_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         // min(0, x) = x - relu(x)
         let neg_part_layer = network
-            .add_elementwise(input, &relu_output, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mut relu_output, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get min(0,x) for leaky relu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get neg part output: {}", e),
-            })?;
+        let mut neg_part =
+            neg_part_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get neg part output: {}", e),
+                })?;
 
         // alpha * min(0, x)
         let scaled_neg_layer = network
-            .add_elementwise(&neg_part, &alpha_tensor, ElementWiseOperation::kPROD)
+            .add_elementwise(
+                &mut neg_part,
+                &mut alpha_tensor,
+                ElementWiseOperation::kPROD,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale neg part for leaky relu: {}", e),
             })?;
-        let scaled_neg =
+        let mut scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled neg output: {}", e),
@@ -1668,18 +1682,23 @@ impl TrtxConverter {
 
         // relu(x) + alpha * min(0, x)
         let final_layer = network
-            .add_elementwise(&relu_output, &scaled_neg, ElementWiseOperation::kSUM)
+            .add_elementwise(
+                &mut relu_output,
+                &mut scaled_neg,
+                ElementWiseOperation::kSUM,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add leaky relu parts: {}", e),
             })?;
 
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get leaky relu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get leaky relu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1688,9 +1707,9 @@ impl TrtxConverter {
     }
 
     /// Add PReLU activation
-    fn add_prelu_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_prelu_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -1717,12 +1736,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for prelu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let mut relu_output =
+            relu_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         // Negative part: min(0, x)
         let zero_layer = network
@@ -1731,37 +1751,39 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add second relu: {}", e),
             })?;
-        let zero_output = zero_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get zero output: {}", e),
-            })?;
+        let mut zero_output =
+            zero_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get zero output: {}", e),
+                })?;
 
         // x - relu(x) = min(0, x)
         let neg_part_layer = network
-            .add_elementwise(input, &zero_output, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mut zero_output, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract for prelu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get negative part: {}", e),
-            })?;
+        let mut neg_part =
+            neg_part_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get negative part: {}", e),
+                })?;
 
         // slope * min(0, x)
         let scaled_neg_layer = network
-            .add_elementwise(&neg_part, slope, ElementWiseOperation::kPROD)
+            .add_elementwise(&mut neg_part, slope, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale negative part: {}", e),
             })?;
-        let scaled_neg =
+        let mut scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled negative: {}", e),
@@ -1769,18 +1791,23 @@ impl TrtxConverter {
 
         // Final: relu + slope * neg_part
         let final_layer = network
-            .add_elementwise(&relu_output, &scaled_neg, ElementWiseOperation::kSUM)
+            .add_elementwise(
+                &mut relu_output,
+                &mut scaled_neg,
+                ElementWiseOperation::kSUM,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add prelu parts: {}", e),
             })?;
 
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get prelu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get prelu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1791,12 +1818,12 @@ impl TrtxConverter {
     /// Add hard sigmoid activation
     /// HardSigmoid(x) = clamp(alpha * x + beta, 0, 1)
     /// Uses built-in kHARD_SIGMOID when alpha=0.2 and beta=0.5; otherwise decomposes with elementwise ops.
-    fn add_hard_sigmoid_op(
+    fn add_hard_sigmoid_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1817,12 +1844,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add hard sigmoid: {}", e),
                 })?;
-            let output = layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+            let output =
+                layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get layer output: {}", e),
+                    })?;
             let output_ids = operation.output_operands_slice();
             tensor_map.insert(output_ids[0], output);
             return Ok(());
@@ -1838,7 +1866,7 @@ impl TrtxConverter {
                 ),
             })?;
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to get input dimensions: {}", e),
@@ -1897,51 +1925,57 @@ impl TrtxConverter {
                 reason: format!("HardSigmoid: failed to add one constant: {}", e),
             })?;
 
-        let alpha_out = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: alpha const output: {}", e),
-            })?;
-        let beta_out = beta_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: beta const output: {}", e),
-            })?;
-        let zero_out = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: zero const output: {}", e),
-            })?;
-        let one_out = one_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: one const output: {}", e),
-            })?;
+        let mut alpha_out =
+            alpha_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: alpha const output: {}", e),
+                })?;
+        let mut beta_out =
+            beta_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: beta const output: {}", e),
+                })?;
+        let mut zero_out =
+            zero_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: zero const output: {}", e),
+                })?;
+        let mut one_out =
+            one_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: one const output: {}", e),
+                })?;
 
         // linear = alpha * x + beta
         let ax = network
-            .add_elementwise(input, &alpha_out, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &mut alpha_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: alpha*x: {}", e),
             })?;
-        let linear = ax.get_output(0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("HardSigmoid: linear get output: {}", e),
-        })?;
+        let mut linear = ax
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSigmoid: linear get output: {}", e),
+            })?;
         let linear_plus_beta = network
-            .add_elementwise(&linear, &beta_out, ElementWiseOperation::kSUM)
+            .add_elementwise(&mut linear, &mut beta_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear+beta: {}", e),
             })?;
-        let linear_out =
+        let mut linear_out =
             linear_plus_beta
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: linear_out: {}", e),
@@ -1949,29 +1983,30 @@ impl TrtxConverter {
 
         // clamp(linear, 0, 1) = max(0, min(1, linear))
         let min1 = network
-            .add_elementwise(&linear_out, &one_out, ElementWiseOperation::kMIN)
+            .add_elementwise(&mut linear_out, &mut one_out, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: min(1, linear): {}", e),
             })?;
-        let min1_out = min1
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: min1 output: {}", e),
-            })?;
+        let mut min1_out =
+            min1.get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: min1 output: {}", e),
+                })?;
         let output_layer = network
-            .add_elementwise(&zero_out, &min1_out, ElementWiseOperation::kMAX)
+            .add_elementwise(&mut zero_out, &mut min1_out, ElementWiseOperation::kMAX)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: max(0, ...): {}", e),
             })?;
-        let output = output_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: output: {}", e),
-            })?;
+        let output =
+            output_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         tensor_map.insert(output_ids[0], output);
@@ -1980,12 +2015,12 @@ impl TrtxConverter {
 
     /// Add hard swish activation
     /// WebNN: y = x * max(0, min(6, (x + 3))) / 6 (MobileNetV3). Follows spec decomposition.
-    fn add_hard_swish_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_hard_swish_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2004,7 +2039,7 @@ impl TrtxConverter {
                 ),
             })?;
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to get input dimensions: {}", e),
@@ -2056,87 +2091,97 @@ impl TrtxConverter {
                 reason: format!("HardSwish: failed to add zero constant: {}", e),
             })?;
 
-        let three_out = three_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: 3 const output: {}", e),
-            })?;
-        let six_out = six_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: 6 const output: {}", e),
-            })?;
-        let zero_out = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: zero const output: {}", e),
-            })?;
+        let mut three_out =
+            three_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: 3 const output: {}", e),
+                })?;
+        let mut six_out =
+            six_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: 6 const output: {}", e),
+                })?;
+        let mut zero_out =
+            zero_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: zero const output: {}", e),
+                })?;
 
         // Spec: div(mul(input, max(0, min(6, add(input, 3)))), 6)
         let x_plus_3 = network
-            .add_elementwise(input, &three_out, ElementWiseOperation::kSUM)
+            .add_elementwise(input, &mut three_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: add(input, 3): {}", e),
             })?;
-        let x_plus_3_out = x_plus_3
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: x+3 output: {}", e),
-            })?;
+        let mut x_plus_3_out =
+            x_plus_3
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: x+3 output: {}", e),
+                })?;
         let min6 = network
-            .add_elementwise(&six_out, &x_plus_3_out, ElementWiseOperation::kMIN)
+            .add_elementwise(&mut six_out, &mut x_plus_3_out, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: min(6, x+3): {}", e),
             })?;
-        let min6_out = min6
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: min6 output: {}", e),
-            })?;
+        let mut min6_out =
+            min6.get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: min6 output: {}", e),
+                })?;
         let inner = network
-            .add_elementwise(&zero_out, &min6_out, ElementWiseOperation::kMAX)
+            .add_elementwise(&mut zero_out, &mut min6_out, ElementWiseOperation::kMAX)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: max(0, ...): {}", e),
             })?;
-        let inner_out = inner
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: inner output: {}", e),
-            })?;
+        let mut inner_out =
+            inner
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: inner output: {}", e),
+                })?;
         let x_times_inner = network
-            .add_elementwise(input, &inner_out, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &mut inner_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: mul(input, inner): {}", e),
             })?;
-        let x_times_inner_out =
+        let mut x_times_inner_out =
             x_times_inner
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: x*inner output: {}", e),
                 })?;
         let output_layer = network
-            .add_elementwise(&x_times_inner_out, &six_out, ElementWiseOperation::kDIV)
+            .add_elementwise(
+                &mut x_times_inner_out,
+                &mut six_out,
+                ElementWiseOperation::kDIV,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: div(..., 6): {}", e),
             })?;
-        let output = output_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: output: {}", e),
-            })?;
+        let output =
+            output_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         tensor_map.insert(output_ids[0], output);
@@ -2145,9 +2190,9 @@ impl TrtxConverter {
 
     /// Add identity operation
     /// Identity just passes through the input unchanged using IIdentityLayer
-    fn add_identity_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_identity_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
@@ -2167,7 +2212,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -2179,15 +2224,38 @@ impl TrtxConverter {
         Ok(())
     }
 
+    /// Helper: DQ(scale=1) with per-tensor (0D) scale. TensorRT only allows scalar or per-channel scale.
+    fn add_dq_scale_constant_helper<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
+        err_prefix: &str,
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
+        let scale_one: Vec<u8> = 1.0f32.to_le_bytes().to_vec();
+        temp_weights.push(scale_one);
+        let scale_ref = temp_weights.last().unwrap();
+        let scale_constant = network
+            .add_constant(&[], scale_ref, TrtDataType::kFLOAT)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: {}", err_prefix, e),
+            })?;
+        scale_constant
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: get scale output: {}", err_prefix, e),
+            })
+    }
+
     /// Add cast operation: convert input to the output operand's data type.
     /// TensorRT does not allow INT8/UINT8 constants to feed a Cast (only DQ or plugin).
     /// Scalar int8/uint8 constants are promoted to int32 when added; Cast then becomes identity.
     /// For non-scalar int8/uint8 -> int32 we emulate via Dequantize(scale=1) -> Cast(INT32).
-    fn add_cast_op(
+    fn add_cast_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -2249,43 +2317,20 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add identity for promoted scalar cast: {}", e),
                     })?;
-            let output =
-                identity_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get identity output: {}", e),
-                    })?;
+            let output = identity_layer.get_output(network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get identity output: {}", e),
+                }
+            })?;
             tensor_map.insert(output_id, output);
             return Ok(());
         }
 
-        // Helper: DQ(scale=1) with per-tensor (0D) scale. TensorRT only allows scalar or per-channel scale; 4D scale causes "ScaleMode is illegal".
-        let add_dq_scale_constant = |network: &mut trtx::NetworkDefinition,
-                                     temp_weights: &mut Vec<Vec<u8>>,
-                                     err_prefix: &str|
-         -> Result<trtx::Tensor, GraphError> {
-            let scale_one: Vec<u8> = 1.0f32.to_le_bytes().to_vec();
-            temp_weights.push(scale_one);
-            let scale_ref = temp_weights.last().unwrap();
-            let scale_constant = network
-                .add_constant(&[], scale_ref, TrtDataType::kFLOAT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{}: {}", err_prefix, e),
-                })?;
-            scale_constant
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{}: get scale output: {}", err_prefix, e),
-                })
-        };
-
         // Constant stored flat: 1D int8. Try 1D -> Reshape(4D) -> DQ so DQ sees Shuffle output not Constant.
         let stored_flat = constants_stored_flat.contains(&input_id);
         let _input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Cast: failed to get input dimensions: {}", e),
@@ -2299,11 +2344,11 @@ impl TrtxConverter {
                 });
             }
             {
-                let original_shape: Vec<i32> = input_operand
+                let original_shape: Vec<i64> = input_operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let mut shuffle_to_4d =
                     network
@@ -2312,38 +2357,44 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Cast: failed to add reshape shuffle: {}", e),
                         })?;
-                let _ = shuffle_to_4d.set_layer_name("cast_flat_reshape_4d");
+                let _ = shuffle_to_4d.set_name(network, "cast_flat_reshape_4d");
                 shuffle_to_4d
-                    .set_reshape_dimensions(&original_shape)
+                    .set_reshape_dimensions(network, &original_shape)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d =
-                    shuffle_to_4d
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Cast: failed to get reshape output: {}", e),
-                        })?;
-                let _ = reshaped_4d.set_name("cast_flat_reshape_4d");
-                let scale_tensor =
-                    add_dq_scale_constant(network, temp_weights, "int8->float32 cast")?;
+                let mut reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Cast: failed to get reshape output: {}", e),
+                    }
+                })?;
+                let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
+                let mut scale_tensor = Self::add_dq_scale_constant_helper(
+                    network,
+                    temp_weights,
+                    "int8->float32 cast",
+                )?;
                 let mut dq_layer = network
-                    .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
+                    .add_dequantize(
+                        &mut reshaped_4d,
+                        &mut scale_tensor,
+                        TrtDataType::kFLOAT.into(),
+                    )
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
                     })?;
-                let _ = dq_layer.set_layer_name("cast_flat_dq_f32");
+                let _ = dq_layer.set_name(network, "cast_flat_dq_f32");
                 let mut output =
                     dq_layer
-                        .get_output(0)
+                        .get_output(network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to get dequantize output: {}", e),
                         })?;
-                let _ = output.set_name("cast_flat_dq_f32");
+                let _ = output.set_name(network, "cast_flat_dq_f32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
             }
@@ -2358,11 +2409,11 @@ impl TrtxConverter {
                 });
             }
             {
-                let original_shape: Vec<i32> = input_operand
+                let original_shape: Vec<i64> = input_operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let mut shuffle_to_4d =
                     network
@@ -2371,54 +2422,56 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Cast: failed to add reshape shuffle: {}", e),
                         })?;
-                let _ = shuffle_to_4d.set_layer_name("cast_flat_reshape_4d_int32");
+                let _ = shuffle_to_4d.set_name(network, "cast_flat_reshape_4d_int32");
                 shuffle_to_4d
-                    .set_reshape_dimensions(&original_shape)
+                    .set_reshape_dimensions(network, &original_shape)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d =
-                    shuffle_to_4d
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Cast: failed to get reshape output: {}", e),
-                        })?;
-                let _ = reshaped_4d.set_name("cast_flat_reshape_4d");
-                let scale_tensor =
-                    add_dq_scale_constant(network, temp_weights, "int8->int32 cast")?;
+                let mut reshaped_4d = shuffle_to_4d.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Cast: failed to get reshape output: {}", e),
+                    }
+                })?;
+                let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
+                let mut scale_tensor =
+                    Self::add_dq_scale_constant_helper(network, temp_weights, "int8->int32 cast")?;
                 let mut dq_layer = network
-                    .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
+                    .add_dequantize(
+                        &mut reshaped_4d,
+                        &mut scale_tensor,
+                        TrtDataType::kFLOAT.into(),
+                    )
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->int32 cast: {}", e),
                     })?;
-                let _ = dq_layer.set_layer_name("cast_flat_dq_int32");
+                let _ = dq_layer.set_name(network, "cast_flat_dq_int32");
                 let mut dq_out =
                     dq_layer
-                        .get_output(0)
+                        .get_output(network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to get dequantize output: {}", e),
                         })?;
-                let _ = dq_out.set_name("cast_flat_dq_int32");
+                let _ = dq_out.set_name(network, "cast_flat_dq_int32");
                 let mut cast_layer =
                     network
-                        .add_cast(&dq_out, TrtDataType::kINT32)
+                        .add_cast(&mut dq_out, TrtDataType::kINT32)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to add cast to INT32: {}", e),
                         })?;
-                let _ = cast_layer.set_layer_name("cast_flat_cast_int32");
-                let mut output =
-                    cast_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get cast output: {}", e),
-                        })?;
-                let _ = output.set_name("cast_flat_cast_int32");
+                let _ = cast_layer.set_name(network, "cast_flat_cast_int32");
+                let mut output = cast_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get cast output: {}", e),
+                    }
+                })?;
+                let _ = output.set_name(network, "cast_flat_cast_int32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
             }
@@ -2436,7 +2489,7 @@ impl TrtxConverter {
                 })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -2447,9 +2500,9 @@ impl TrtxConverter {
     }
 
     /// Add quantizeLinear operation (float to quantized integer)
-    fn add_quantize_linear_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_quantize_linear_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -2472,14 +2525,14 @@ impl TrtxConverter {
 
         // Create quantize layer - output type is INT8 for quantization
         let layer = network
-            .add_quantize(input, scale, TrtDataType::kINT8)
+            .add_quantize(input, scale, TrtDataType::kINT8.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add quantize layer: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get quantize output: {}", e),
@@ -2492,9 +2545,9 @@ impl TrtxConverter {
     }
 
     /// Add dequantizeLinear operation (quantized integer to float)
-    fn add_dequantize_linear_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_dequantize_linear_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -2517,14 +2570,14 @@ impl TrtxConverter {
 
         // Create dequantize layer - output type is FLOAT for dequantization
         let layer = network
-            .add_dequantize(input, scale, TrtDataType::kFLOAT)
+            .add_dequantize(input, scale, TrtDataType::kFLOAT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add dequantize layer: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get dequantize output: {}", e),
@@ -2537,9 +2590,9 @@ impl TrtxConverter {
     }
 
     /// Add global pooling operation
-    fn add_global_pooling_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_global_pooling_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
@@ -2552,7 +2605,7 @@ impl TrtxConverter {
 
         // Get input dimensions to determine window size
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dimensions: {}", e),
@@ -2570,7 +2623,10 @@ impl TrtxConverter {
             });
         }
 
-        let window: [i32; 2] = [input_dims[2], input_dims[3]];
+        let window: [i32; 2] = [
+            input_dims[2].try_into().unwrap(),
+            input_dims[3].try_into().unwrap(),
+        ];
 
         let layer = network
             .add_pooling(input, pool_type, &window)
@@ -2580,7 +2636,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -2595,9 +2651,9 @@ impl TrtxConverter {
     /// Add matrix multiply operation.
     /// TensorRT IMatrixMultiplyLayer requires both inputs to have the same number of dimensions;
     /// if ranks differ, unsqueeze the lower-rank input by prepending 1s.
-    fn add_matmul_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_matmul_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -2615,13 +2671,13 @@ impl TrtxConverter {
             })?;
 
         let dims0 = input0
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Matmul: input0 dimensions: {}", e),
             })?;
         let dims1 = input1
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Matmul: input1 dimensions: {}", e),
@@ -2631,11 +2687,16 @@ impl TrtxConverter {
         let rank1 = dims1.len();
 
         let layer = if rank0 == rank1 {
-            network.add_matrix_multiply(input0, 0, input1, 0)
+            network.add_matrix_multiply(
+                &input0,
+                MatrixOperation::kNONE,
+                input1,
+                MatrixOperation::kNONE,
+            )
         } else if rank0 < rank1 {
-            let reshape_dims: Vec<i32> = dims0.iter().map(|&d| d as i32).collect();
+            let reshape_dims: Vec<i64> = dims0.iter().copied().collect();
             let rank_diff = rank1 - rank0;
-            let mut new_shape: Vec<i32> = vec![1; rank_diff];
+            let mut new_shape: Vec<i64> = vec![1; rank_diff];
             new_shape.extend(reshape_dims);
             let mut shuffle =
                 network
@@ -2644,23 +2705,29 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Matmul: set reshape: {}", e),
-                }
-            })?;
-            let reshaped0 = shuffle
-                .get_output(0)
+            shuffle
+                .set_reshape_dimensions(network, &new_shape)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Matmul: shuffle output: {}", e),
+                    reason: format!("Matmul: set reshape: {}", e),
                 })?;
-            network.add_matrix_multiply(&reshaped0, 0, input1, 0)
+            let mut reshaped0 =
+                shuffle
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Matmul: shuffle output: {}", e),
+                    })?;
+            network.add_matrix_multiply(
+                &mut reshaped0,
+                MatrixOperation::kNONE,
+                input1,
+                MatrixOperation::kNONE,
+            )
         } else {
-            let reshape_dims: Vec<i32> = dims1.iter().map(|&d| d as i32).collect();
+            let reshape_dims: Vec<i64> = dims1.iter().copied().collect();
             let rank_diff = rank0 - rank1;
-            let mut new_shape: Vec<i32> = vec![1; rank_diff];
+            let mut new_shape: Vec<i64> = vec![1; rank_diff];
             new_shape.extend(reshape_dims);
             let mut shuffle =
                 network
@@ -2669,19 +2736,25 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Matmul: set reshape: {}", e),
-                }
-            })?;
-            let reshaped1 = shuffle
-                .get_output(0)
+            shuffle
+                .set_reshape_dimensions(network, &new_shape)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Matmul: shuffle output: {}", e),
+                    reason: format!("Matmul: set reshape: {}", e),
                 })?;
-            network.add_matrix_multiply(input0, 0, &reshaped1, 0)
+            let mut reshaped1 =
+                shuffle
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Matmul: shuffle output: {}", e),
+                    })?;
+            network.add_matrix_multiply(
+                input0.1,
+                MatrixOperation::kNONE,
+                &mut reshaped1,
+                MatrixOperation::kNONE,
+            )
         }
         .map_err(|e| GraphError::ConversionFailed {
             format: "trtx".to_string(),
@@ -2689,7 +2762,7 @@ impl TrtxConverter {
         })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -2707,21 +2780,21 @@ impl TrtxConverter {
 
     /// Reshape 1D batch-norm stats [C] to same rank as input with shape [1,...,1,C,1,...,1]
     /// so that the channel dimension aligns with the input's axis. TensorRT then broadcasts correctly.
-    fn reshape_batch_norm_stats_for_broadcast(
-        network: &mut trtx::NetworkDefinition,
-        stats: &trtx::Tensor,
-        input: &trtx::Tensor,
+    fn reshape_batch_norm_stats_for_broadcast<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        stats: &'_ trtx::Tensor<'network>,
+        input: &'_ trtx::Tensor<'_>,
         axis: i64,
         op_name: &str,
-    ) -> Result<trtx::Tensor, GraphError> {
+    ) -> Result<trtx::Tensor<'network>, GraphError> {
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dims for {}: {}", op_name, e),
             })?;
         let stats_dims = stats
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get stats dims for {}: {}", op_name, e),
@@ -2733,7 +2806,7 @@ impl TrtxConverter {
         }
         axis_idx = axis_idx.max(0).min((rank.saturating_sub(1)) as i64);
         // Channel count: stats may be 1D [C], 4D [C,1,1,1], or 4D [1,C,1,1]; use product so we get C in all cases.
-        let c: i32 = stats_dims.iter().product::<i32>().max(1);
+        let c: i64 = stats_dims.iter().product::<i64>().max(1);
         // When stats are 4D [C,1,1,1], use a transpose-only shuffle so TensorRT sees [1,C,1,1].
         // (Transpose+reshape in one shuffle can leave logical shape as [C,1,1,1].)
         let is_4d_channel_first = rank >= 2
@@ -2756,14 +2829,14 @@ impl TrtxConverter {
                             op_name, e
                         ),
                     })?;
-            shuffle
-                .set_first_transpose(&perm)
-                .map_err(|e| GraphError::ConversionFailed {
+            shuffle.set_first_transpose(network, &perm).map_err(|e| {
+                GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set transpose for {}: {}", op_name, e),
-                })?;
+                }
+            })?;
             return shuffle
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
@@ -2772,12 +2845,12 @@ impl TrtxConverter {
 
         // For 1D [C], reshape to [1,1,...,1,C] then transpose so C moves to axis_idx; avoids TensorRT giving [C,1,1,1].
         let (target_shape, need_second_transpose) = if stats_dims.len() == 1 {
-            let shape_last: Vec<i32> = (0..rank)
+            let shape_last: Vec<i64> = (0..rank)
                 .map(|i| if i == rank - 1 { c } else { 1 })
                 .collect();
             (shape_last, true)
         } else {
-            let shape_axis: Vec<i32> = (0..rank)
+            let shape_axis: Vec<i64> = (0..rank)
                 .map(|i| if i as i64 == axis_idx { c } else { 1 })
                 .collect();
             (shape_axis, false)
@@ -2788,18 +2861,19 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add shuffle for {}: {}", op_name, e),
             })?;
-        shuffle.set_reshape_dimensions(&target_shape).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set reshape for {}: {}", op_name, e),
-            }
-        })?;
-        let mut result = shuffle
-            .get_output(0)
+        shuffle
+            .set_reshape_dimensions(network, &target_shape)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
+                reason: format!("Failed to set reshape for {}: {}", op_name, e),
             })?;
+        let mut result =
+            shuffle
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
+                })?;
         if need_second_transpose {
             // Move dimension (rank-1) to axis_idx: perm[axis_idx] = rank-1, perm[rank-1] = axis_idx.
             let mut perm: Vec<i32> = (0..rank as i32).collect();
@@ -2807,19 +2881,19 @@ impl TrtxConverter {
             perm[rank - 1] = axis_idx as i32;
             let mut shuffle2 =
                 network
-                    .add_shuffle(&result)
+                    .add_shuffle(&mut result)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add second shuffle for {}: {}", op_name, e),
                     })?;
-            shuffle2
-                .set_first_transpose(&perm)
-                .map_err(|e| GraphError::ConversionFailed {
+            shuffle2.set_first_transpose(network, &perm).map_err(|e| {
+                GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set second transpose for {}: {}", op_name, e),
-                })?;
+                }
+            })?;
             result = shuffle2
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get second shuffle output for {}: {}", op_name, e),
@@ -2830,10 +2904,10 @@ impl TrtxConverter {
 
     /// Add batch normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias
-    fn add_batch_normalization_op(
+    fn add_batch_normalization_op<'network>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         // Input operands: input, mean, variance, scale (optional), bias (optional)
@@ -2879,19 +2953,20 @@ impl TrtxConverter {
 
         // Step 1: x - mean
         let mut sub_layer = network
-            .add_elementwise(input, &mean_bc, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mut mean_bc, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for batch norm: {}", e),
             })?;
-        let _ = sub_layer.set_layer_name("batch_norm_sub");
+        let _ = sub_layer.set_name(network, "batch_norm_sub");
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let x_minus_mean =
+            sub_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // Step 2: variance + epsilon (using constant)
         // Need to create a constant tensor with epsilon value
@@ -2907,21 +2982,21 @@ impl TrtxConverter {
         )?;
 
         // Step 3: sqrt(variance + epsilon)
-        let mut sqrt_var_layer =
-            network
-                .add_unary(&var_bc, UnaryOperation::kSQRT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add sqrt for batch norm: {}", e),
-                })?;
-        let _ = sqrt_var_layer.set_layer_name("batch_norm_sqrt_var");
-
-        let sqrt_var = sqrt_var_layer
-            .get_output(0)
+        let mut sqrt_var_layer = network
+            .add_unary(&var_bc, UnaryOperation::kSQRT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
+                reason: format!("Failed to add sqrt for batch norm: {}", e),
             })?;
+        let _ = sqrt_var_layer.set_name(network, "batch_norm_sqrt_var");
+
+        let mut sqrt_var =
+            sqrt_var_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // Step 4: (x - mean) / sqrt(variance + epsilon)
         let mut div_layer = network
@@ -2930,14 +3005,15 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for batch norm: {}", e),
             })?;
-        let _ = div_layer.set_layer_name("batch_norm_div");
+        let _ = div_layer.set_name(network, "batch_norm_div");
 
-        let normalized = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let normalized =
+            div_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Step 5: Apply scale if present (WebNN: scale is in MLBatchNormalizationOptions, not a positional input)
         let scale_id = operation
@@ -2967,14 +3043,15 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add mul for scale: {}", e),
                 })?;
-            let _ = mul_layer.set_layer_name("batch_norm_scale_mul");
+            let _ = mul_layer.set_name(network, "batch_norm_scale_mul");
 
-            result = mul_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mul output: {}", e),
-                })?;
+            result =
+                mul_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get mul output: {}", e),
+                    })?;
         }
 
         // Step 6: Apply bias if present (WebNN: bias is in MLBatchNormalizationOptions, not a positional input)
@@ -2990,7 +3067,7 @@ impl TrtxConverter {
                     reason: format!("Bias operand {} not found", bias_id),
                 })?;
 
-            let bias_bc = Self::reshape_batch_norm_stats_for_broadcast(
+            let mut bias_bc = Self::reshape_batch_norm_stats_for_broadcast(
                 network,
                 bias,
                 &result,
@@ -3004,14 +3081,15 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
                 })?;
-            let _ = add_layer.set_layer_name("batch_norm_bias_add");
+            let _ = add_layer.set_name(network, "batch_norm_bias_add");
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3023,12 +3101,11 @@ impl TrtxConverter {
     /// Add instance normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias (WebNN spec)
     /// Computed per-instance over spatial dimensions
-    fn add_instance_normalization_op(
+    fn add_instance_normalization_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Instance normalization computes statistics per-instance (N, C) over spatial dims
         // Input operands: input, scale (optional), bias (optional)
@@ -3040,7 +3117,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to get input dimensions: {}", e),
@@ -3064,20 +3141,15 @@ impl TrtxConverter {
         };
 
         // Compute mean: E[x]
-        let mut axes_mask: u32 = 0;
-        for &axis in &axes {
-            axes_mask |= 1 << axis;
-        }
-
         let mean_layer = network
-            .add_reduce(input, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(input, ReduceOperation::kAVG.into(), Axes::new(axes), true)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add mean reduce for instance norm: {}", e),
             })?;
 
         let mean = mean_layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get mean output: {}", e),
@@ -3085,18 +3157,19 @@ impl TrtxConverter {
 
         // x - mean
         let sub_layer = network
-            .add_elementwise(input, &mean, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mut mean, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for instance norm: {}", e),
             })?;
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let x_minus_mean =
+            sub_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // (x - mean)^2
         let square_layer = network
@@ -3106,31 +3179,38 @@ impl TrtxConverter {
                 reason: format!("Failed to add square for instance norm: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get square output: {}", e),
-            })?;
+        let squared =
+            square_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get square output: {}", e),
+                })?;
 
         // variance = mean((x - mean)^2)
         let var_layer = network
-            .add_reduce(&squared, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                &squared,
+                ReduceOperation::kAVG.into(),
+                Axes::new(axes),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add variance reduce for instance norm: {}", e),
             })?;
 
-        let variance = var_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get variance output: {}", e),
-            })?;
+        let variance =
+            var_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get variance output: {}", e),
+                })?;
 
         // variance + epsilon per WebNN spec (epsilon cast to input's dataType)
         let var_dims = variance
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to get variance dimensions: {}", e),
@@ -3161,18 +3241,16 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        temp_weights.push(epsilon_bytes);
-        let epsilon_ref = temp_weights.last().unwrap().as_slice();
         let var_shape: Vec<i32> = var_dims.iter().map(|&d| d as i32).collect();
         let epsilon_const = network
-            .add_constant(&var_shape, epsilon_ref, trt_dtype)
+            .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to add epsilon constant: {}", e),
             })?;
         let epsilon_out =
             epsilon_const
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: epsilon const output: {}", e),
@@ -3183,9 +3261,9 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: variance + epsilon: {}", e),
             })?;
-        let var_plus_eps_out =
+        let mut var_plus_eps_out =
             var_plus_eps
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: var_plus_eps output: {}", e),
@@ -3193,41 +3271,43 @@ impl TrtxConverter {
 
         // sqrt(variance + epsilon)
         let sqrt_layer = network
-            .add_unary(&var_plus_eps_out, UnaryOperation::kSQRT)
+            .add_unary(&var_plus_eps_out, UnaryOperation::kSQRT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for instance norm: {}", e),
             })?;
 
-        let std_dev = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
-            })?;
+        let mut std_dev =
+            sqrt_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
-            .add_elementwise(&x_minus_mean, &std_dev, ElementWiseOperation::kDIV)
+            .add_elementwise(&mut x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for instance norm: {}", e),
             })?;
 
-        let mut result = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let result =
+            div_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Build broadcast shape for scale/bias [C] to match input (TensorRT elementwise needs same rank).
-        let scale_broadcast_shape: Vec<i32> = if layout == "nchw" && !input_dims.is_empty() {
-            let mut s = vec![1i32; input_dims.len()];
+        let scale_broadcast_shape: Vec<i64> = if layout == "nchw" && !input_dims.is_empty() {
+            let mut s = vec![1i64; input_dims.len()];
             s[1] = input_dims[1];
             s
         } else if !input_dims.is_empty() {
-            let mut s = vec![1i32; input_dims.len()];
+            let mut s = vec![1i64; input_dims.len()];
             let last = input_dims.len() - 1;
             s[last] = input_dims[last];
             s
@@ -3270,33 +3350,29 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for scale: {}", e),
                     })?;
-            scale_shuffle
-                .set_reshape_dimensions(&scale_broadcast_shape)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to set scale reshape: {}", e),
-                })?;
-            let scale_bc =
+            scale_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape);
+            let mut scale_bc =
                 scale_shuffle
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
                     })?;
 
             let mul_layer = network
-                .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
+                .add_elementwise(&mut result, &mut scale_bc, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add mul for scale: {}", e),
                 })?;
 
-            result = mul_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mul output: {}", e),
-                })?;
+            result =
+                mul_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get mul output: {}", e),
+                    })?;
         }
 
         // Apply bias if present (add)
@@ -3315,32 +3391,29 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for bias: {}", e),
                     })?;
-            bias_shuffle
-                .set_reshape_dimensions(&scale_broadcast_shape)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to set bias reshape: {}", e),
-                })?;
-            let bias_bc = bias_shuffle
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
-                })?;
+            bias_shuffle.set_reshape_dimensions(network, &scale_broadcast_shape);
+            let mut bias_bc =
+                bias_shuffle
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
+                    })?;
 
             let add_layer = network
-                .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
+                .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3352,12 +3425,12 @@ impl TrtxConverter {
     /// Add layer normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias
     /// Computed over specified axes (typically last dimensions)
-    fn add_layer_normalization_op(
+    fn add_layer_normalization_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Layer normalization computes statistics over specified axes
         // Input operands: input, scale (optional), bias (optional)
@@ -3369,7 +3442,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input shape: {}", e),
@@ -3403,7 +3476,7 @@ impl TrtxConverter {
                 })?;
             let mut result =
                 zero_const
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: zero const output: {}", e),
@@ -3426,31 +3499,31 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm 0D: failed to add bias shuffle: {}", e),
                         })?;
-                bias_shuffle.set_reshape_dimensions(&[1]).map_err(|e| {
-                    GraphError::ConversionFailed {
+                bias_shuffle
+                    .set_reshape_dimensions(network, &[1])
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),
+                    })?;
+                let mut bias_bc = bias_shuffle.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
                     }
                 })?;
-                let bias_bc =
-                    bias_shuffle
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
-                        })?;
                 let add_layer = network
-                    .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm 0D: bias add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm 0D: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -3508,7 +3581,7 @@ impl TrtxConverter {
                 })?;
             let mut result =
                 zero_const
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: zero const output: {}", e),
@@ -3523,7 +3596,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Bias operand {} not found", bias_id),
                         })?;
-                let bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bias_id) {
+                let mut bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bias_id) {
                     // Shuffle cannot change volume. Broadcast by creating a constant filled with the bias value.
                     let bias_data = Self::get_constant_data(graph, bias_id)?;
                     let bias_broadcast_bytes: Vec<u8> = match input_operand.descriptor.data_type {
@@ -3567,7 +3640,7 @@ impl TrtxConverter {
                             ),
                         })?;
                     bias_const
-                        .get_output(0)
+                        .get_output(network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: bias const output: {}", e),
@@ -3591,74 +3664,75 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    let ones_tensor =
-                        ones_const
-                            .get_output(0)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("LayerNorm axes=[]: ones const output: {}", e),
-                            })?;
+                    let mut ones_tensor = ones_const.get_output(network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: ones const output: {}", e),
+                        }
+                    })?;
                     let (bias_bc, _) = Self::ensure_broadcast_compatible(
                         network,
                         bias,
-                        &ones_tensor,
+                        &mut ones_tensor,
                         "layer_norm_axes_empty_bias",
                     )?;
                     bias_bc
                 };
                 let add_layer = network
-                    .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm axes=[]: bias add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
             return Ok(());
         }
 
-        // Convert axes to bitmask
-        let mut axes_mask: u32 = 0;
-        for &axis in &axes {
-            axes_mask |= 1 << axis;
-        }
-
         // Compute mean: E[x]
         let mean_layer = network
-            .add_reduce(input, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                input,
+                ReduceOperation::kAVG.into(),
+                Axes::from_slice(&axes),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add mean reduce for layer norm: {}", e),
             })?;
 
-        let mean = mean_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get mean output: {}", e),
-            })?;
+        let mut mean =
+            mean_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mean output: {}", e),
+                })?;
 
         // x - mean
         let sub_layer = network
-            .add_elementwise(input, &mean, ElementWiseOperation::kSUB)
+            .add_elementwise(input, &mut mean, ElementWiseOperation::kSUB)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for layer norm: {}", e),
             })?;
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let mut x_minus_mean =
+            sub_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // (x - mean)^2
         let square_layer = network
@@ -3668,36 +3742,43 @@ impl TrtxConverter {
                 reason: format!("Failed to add square for layer norm: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get square output: {}", e),
-            })?;
+        let mut squared =
+            square_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get square output: {}", e),
+                })?;
 
         // variance = mean((x - mean)^2)
         let var_layer = network
-            .add_reduce(&squared, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                &mut squared,
+                ReduceOperation::kAVG.into(),
+                Axes::from_slice(&axes),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add variance reduce for layer norm: {}", e),
             })?;
 
-        let variance = var_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get variance output: {}", e),
-            })?;
+        let mut variance =
+            var_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get variance output: {}", e),
+                })?;
 
         // variance + epsilon per WebNN spec (then sqrt)
         let var_dims = variance
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
             })?;
-        let var_shape: Vec<i32> = var_dims.iter().map(|&d| d as i32).collect();
+        let var_shape: Vec<i64> = var_dims.iter().map(|&d| d as i64).collect();
         let num_var_el: usize = var_dims.iter().map(|&d| d as usize).product();
         let input_operand = graph
             .operand(operation.input_operands()[0])
@@ -3730,22 +3811,22 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to add epsilon constant: {}", e),
             })?;
-        let epsilon_out =
+        let mut epsilon_out =
             epsilon_const
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: epsilon const output: {}", e),
                 })?;
         let var_plus_eps = network
-            .add_elementwise(&variance, &epsilon_out, ElementWiseOperation::kSUM)
+            .add_elementwise(&mut variance, &mut epsilon_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: variance + epsilon: {}", e),
             })?;
-        let variance_eps =
+        let mut variance_eps =
             var_plus_eps
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: variance+eps output: {}", e),
@@ -3753,55 +3834,58 @@ impl TrtxConverter {
 
         // sqrt(variance + epsilon)
         let sqrt_layer = network
-            .add_unary(&variance_eps, UnaryOperation::kSQRT)
+            .add_unary(&mut variance_eps, UnaryOperation::kSQRT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for layer norm: {}", e),
             })?;
 
-        let std_dev = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
-            })?;
+        let mut std_dev =
+            sqrt_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
-            .add_elementwise(&x_minus_mean, &std_dev, ElementWiseOperation::kDIV)
+            .add_elementwise(&mut x_minus_mean, &mut std_dev, ElementWiseOperation::kDIV)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for layer norm: {}", e),
             })?;
 
-        let mut result = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let mut result =
+            div_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Reshape scale/bias so they broadcast to result. Scale/bias have shape [d_axes[0], d_axes[1], ...]
         // in axis order; result has input shape. Broadcast shape: for each result dim i, use
         // scale_bias dim at that axis position if i is in axes, else 1.
-        let reshape_scale_bias_to_result_rank = |network: &mut trtx::NetworkDefinition,
-                                                 tensor: &trtx::Tensor,
+        let reshape_scale_bias_to_result_rank = |tensor: &trtx::Tensor,
                                                  result: &trtx::Tensor,
                                                  op_name: &str,
                                                  axes: &[u32]|
          -> Result<trtx::Tensor, GraphError> {
-            let result_dims = result
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: result dims: {}", op_name, e),
-                })?;
-            let tensor_dims = tensor
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
-                })?;
+            let result_dims =
+                result
+                    .dimensions(network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm {}: result dims: {}", op_name, e),
+                    })?;
+            let tensor_dims =
+                tensor
+                    .dimensions(network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
+                    })?;
             if tensor_dims.len() >= result_dims.len() {
                 let id_layer =
                     network
@@ -3811,20 +3895,20 @@ impl TrtxConverter {
                             reason: format!("LayerNorm {}: identity: {}", op_name, e),
                         })?;
                 return id_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm {}: identity output: {}", op_name, e),
                     });
             }
-            let (new_shape, transpose_perm): (Vec<i32>, Option<Vec<i32>>) =
+            let (new_shape, transpose_perm): (Vec<i64>, Option<Vec<i32>>) =
                 if tensor_dims.len() == axes.len() {
-                    let new_shape: Vec<i32> = (0..result_dims.len())
+                    let new_shape: Vec<i64> = (0..result_dims.len())
                         .map(|i| {
                             let axis = i as u32;
                             axes.iter()
                                 .position(|&a| a == axis)
-                                .map(|j| tensor_dims[j] as i32)
+                                .map(|j| tensor_dims[j])
                                 .unwrap_or(1)
                         })
                         .collect();
@@ -3849,8 +3933,8 @@ impl TrtxConverter {
                     (new_shape, transpose_perm)
                 } else {
                     let pad = result_dims.len() - tensor_dims.len();
-                    let mut shape: Vec<i32> = vec![1; pad];
-                    shape.extend(tensor_dims.iter().map(|&d| d as i32));
+                    let mut shape: Vec<i64> = vec![1; pad];
+                    shape.extend(tensor_dims.iter().copied());
                     (shape, None)
                 };
             let mut shuffle =
@@ -3861,22 +3945,12 @@ impl TrtxConverter {
                         reason: format!("LayerNorm {}: shuffle: {}", op_name, e),
                     })?;
             if let Some(ref perm) = transpose_perm {
-                shuffle
-                    .set_first_transpose(perm)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm {}: set transpose: {}", op_name, e),
-                    })?;
+                shuffle.set_first_transpose(network, perm);
             }
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: set reshape: {}", op_name, e),
-                }
-            })?;
+            shuffle.set_reshape_dimensions(network, &new_shape);
             shuffle
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
+                .get_output(network, 0)
+                .map_err(move |e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm {}: shuffle output: {}", op_name, e),
                 })
@@ -3897,7 +3971,6 @@ impl TrtxConverter {
                 .unwrap_or("");
             let is_bias_1 = name_1.to_lowercase().contains("bias");
             let opt_1_bc = reshape_scale_bias_to_result_rank(
-                network,
                 opt_1,
                 &result,
                 if is_bias_1 { "bias" } else { "scale" },
@@ -3905,30 +3978,32 @@ impl TrtxConverter {
             )?;
             if is_bias_1 {
                 let add_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kSUM)
+                    .add_elementwise(&mut result, &opt_1_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get add output: {}", e),
+                        })?;
             } else {
                 let mul_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kPROD)
+                    .add_elementwise(&mut result, &opt_1_bc, ElementWiseOperation::kPROD)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add scale: {}", e),
                     })?;
-                result = mul_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get mul output: {}", e),
-                    })?;
+                result =
+                    mul_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get mul output: {}", e),
+                        })?;
             }
         }
 
@@ -3940,21 +4015,22 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Bias operand {} not found", operation.input_operands()[2]),
                 })?;
-            let bias_bc = reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
+            let mut bias_bc = reshape_scale_bias_to_result_rank(bias, &result, "bias", &axes)?;
 
             let add_layer = network
-                .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
+                .add_elementwise(&mut result, &mut bias_bc, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3969,9 +4045,9 @@ impl TrtxConverter {
 
     /// Add reduction operation (sum, mean, max, min, product).
     /// Axes optional: when missing, default to all axes (0..rank). Empty axes -> identity.
-    fn add_reduce_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         reduce_op: ReduceOperation,
     ) -> Result<(), GraphError> {
@@ -3983,7 +4059,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Reduce: input dimensions: {}", e),
@@ -4004,12 +4080,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Reduce axes=[] identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Reduce axes=[] output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Reduce axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4023,14 +4100,14 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(input, reduce_op, axes_mask, keep_dims)
+            .add_reduce(input, reduce_op.into(), Axes(axes_mask), keep_dims)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce operation: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4043,9 +4120,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceL1 operation: sum(abs(x)). Axes optional; empty axes -> output = abs(input).
-    fn add_reduce_l1_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_l1_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4056,21 +4133,22 @@ impl TrtxConverter {
             })?;
 
         let abs_layer = network
-            .add_unary(input, UnaryOperation::kABS)
+            .add_unary(input, UnaryOperation::kABS.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add abs for L1: {}", e),
             })?;
 
-        let abs_output = abs_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get abs output: {}", e),
-            })?;
+        let abs_output =
+            abs_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get abs output: {}", e),
+                })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceL1: input dimensions: {}", e),
@@ -4089,22 +4167,22 @@ impl TrtxConverter {
             return Ok(());
         }
 
-        let mut axes_mask: u32 = 0;
-        for &axis in &axes {
-            axes_mask |= 1 << axis;
-        }
-
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(&abs_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &abs_output,
+                ReduceOperation::kSUM.into(),
+                Axes::from_slice(&axes),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for L1: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4118,10 +4196,10 @@ impl TrtxConverter {
 
     /// Add reduceL2 operation: sqrt(sum(x^2)). Axes optional; empty axes -> output = sqrt(x^2) = |x|.
     /// For float16 input, sum of squares can overflow; do reduce in float32 then cast back.
-    fn add_reduce_l2_op(
+    fn add_reduce_l2_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4136,23 +4214,34 @@ impl TrtxConverter {
             .map(|o| o.descriptor.data_type)
             .unwrap_or(DataType::Float32);
 
+        let mut input_copy = network
+            .add_identity(input)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add identity for L2 square: {}", e),
+            })?
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get identity output for L2: {}", e),
+            })?;
         let square_layer = network
-            .add_elementwise(input, input, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &mut input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add square for L2: {}", e),
             })?;
 
-        let square_output =
+        let mut square_output =
             square_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
                 })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceL2: input dimensions: {}", e),
@@ -4167,17 +4256,18 @@ impl TrtxConverter {
 
         if axes.is_empty() {
             let sqrt_layer = network
-                .add_unary(&square_output, UnaryOperation::kSQRT)
+                .add_unary(&mut square_output, UnaryOperation::kSQRT.into())
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ReduceL2 axes=[] sqrt: {}", e),
                 })?;
-            let output = sqrt_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceL2 axes=[] output: {}", e),
-                })?;
+            let output =
+                sqrt_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceL2 axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4191,34 +4281,41 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         // Always reduce in float32 to avoid overflow (sum of squares can exceed float16 range).
-        let to_reduce = Self::cast_to_float32(network, &square_output)?;
+        let mut to_reduce = Self::cast_to_float32(network, &square_output)?;
         let sum_layer = network
-            .add_reduce(&to_reduce, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &mut to_reduce,
+                ReduceOperation::kSUM.into(),
+                Axes(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for L2: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let sum_output =
+            sum_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         let sqrt_layer = network
-            .add_unary(&sum_output, UnaryOperation::kSQRT)
+            .add_unary(&sum_output, UnaryOperation::kSQRT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sqrt for L2: {}", e),
             })?;
 
-        let sqrt_output = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let sqrt_output =
+            sqrt_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output = if input_dtype == DataType::Float16 {
             Self::cast_to_float16(network, &sqrt_output)?
@@ -4232,9 +4329,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceLogSum operation: log(sum(x)). Axes optional; empty axes -> output = log(x).
-    fn add_reduce_log_sum_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_log_sum_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4245,7 +4342,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceLogSum: input dimensions: {}", e),
@@ -4260,17 +4357,18 @@ impl TrtxConverter {
 
         if axes.is_empty() {
             let log_layer = network
-                .add_unary(input, UnaryOperation::kLOG)
+                .add_unary(input, UnaryOperation::kLOG.into())
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ReduceLogSum axes=[] log: {}", e),
                 })?;
-            let output = log_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceLogSum axes=[] output: {}", e),
-                })?;
+            let output =
+                log_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceLogSum axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4284,33 +4382,40 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let sum_layer = network
-            .add_reduce(input, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                input,
+                ReduceOperation::kSUM.into(),
+                Axes(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for LogSum: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let mut sum_output =
+            sum_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         // Then log
         let log_layer = network
-            .add_unary(&sum_output, UnaryOperation::kLOG)
+            .add_unary(&mut sum_output, UnaryOperation::kLOG.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add log for LogSum: {}", e),
             })?;
 
-        let output = log_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let output =
+            log_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4319,9 +4424,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceLogSumExp operation: log(sum(exp(x))). Axes optional; empty axes -> output = x.
-    fn add_reduce_log_sum_exp_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_log_sum_exp_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4332,21 +4437,22 @@ impl TrtxConverter {
             })?;
 
         let exp_layer = network
-            .add_unary(input, UnaryOperation::kEXP)
+            .add_unary(input, UnaryOperation::kEXP.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add exp for LogSumExp: {}", e),
             })?;
 
-        let exp_output = exp_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get exp output: {}", e),
-            })?;
+        let mut exp_output =
+            exp_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get exp output: {}", e),
+                })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceLogSumExp: input dimensions: {}", e),
@@ -4367,12 +4473,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("ReduceLogSumExp axes=[] identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceLogSumExp axes=[] output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceLogSumExp axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4386,33 +4493,40 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let sum_layer = network
-            .add_reduce(&exp_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &mut exp_output,
+                ReduceOperation::kSUM.into(),
+                Axes(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for LogSumExp: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let mut sum_output =
+            sum_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         // Finally log
         let log_layer = network
-            .add_unary(&sum_output, UnaryOperation::kLOG)
+            .add_unary(&mut sum_output, UnaryOperation::kLOG.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add log for LogSumExp: {}", e),
             })?;
 
-        let output = log_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let output =
+            log_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4421,9 +4535,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceSumSquare operation: sum(x^2). Axes optional; empty axes -> output = x^2.
-    fn add_reduce_sum_square_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_sum_square_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4433,23 +4547,34 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
+        let mut input_copy = network
+            .add_identity(input)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add identity for SumSquare: {}", e),
+            })?
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get identity output for SumSquare: {}", e),
+            })?;
         let square_layer = network
-            .add_elementwise(input, input, ElementWiseOperation::kPROD)
+            .add_elementwise(input, &mut input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add square for SumSquare: {}", e),
             })?;
 
-        let square_output =
+        let mut square_output =
             square_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
                 })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceSumSquare: input dimensions: {}", e),
@@ -4468,22 +4593,22 @@ impl TrtxConverter {
             return Ok(());
         }
 
-        let mut axes_mask: u32 = 0;
-        for &axis in &axes {
-            axes_mask |= 1 << axis;
-        }
-
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(&square_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &mut square_output,
+                ReduceOperation::kSUM.into(),
+                Axes::from_slice(&axes),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for SumSquare: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4500,9 +4625,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add slice operation
-    fn add_slice_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_slice_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4544,34 +4669,35 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Slice no-op identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Slice no-op output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice no-op output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
         }
-        let starts: Vec<i32> = starts_u32.iter().map(|&u| u as i32).collect();
-        let sizes: Vec<i32> = sizes_ml.iter().map(|d| d.static_or_max() as i32).collect();
-        let strides: Vec<i32> = if opts.strides.is_empty() {
+        let starts: Vec<i64> = starts_u32.iter().map(|&u| u as i64).collect();
+        let sizes: Vec<i64> = sizes_ml.iter().map(|d| d.static_or_max() as i64).collect();
+        let strides: Vec<i64> = if opts.strides.is_empty() {
             vec![1; starts.len()]
         } else {
-            opts.strides.iter().map(|&u| u as i32).collect()
+            opts.strides.iter().map(|&u| u as i64).collect()
         };
 
         // TensorRT Slice expects "size" = output dimensions. WebNN "sizes" are extents (range
         // lengths); with stride != 1 the output length per axis is ceil(extent/stride).
-        let trt_sizes: Vec<i32> = sizes
+        let trt_sizes: Vec<i64> = sizes
             .iter()
             .zip(strides.iter())
-            .map(|(sz, st): (&i32, &i32)| {
-                if *st == 0 {
-                    0_i32 // avoid div-by-zero; validator should reject elsewhere
-                } else if *st == 1 {
-                    *sz
+            .map(|(&sz, &st)| {
+                if st == 0 {
+                    0_i64 // avoid div-by-zero; validator should reject elsewhere
+                } else if st == 1 {
+                    sz
                 } else {
                     // ceil(extent / stride) in integers
                     (*sz + st.abs() - 1) / st.abs()
@@ -4587,7 +4713,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4600,9 +4726,9 @@ impl TrtxConverter {
     }
 
     /// Add split operation
-    fn add_split_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_split_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
@@ -4612,7 +4738,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Input operand {} not found", input_id),
             })?
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input shape: {}", e),
@@ -4671,13 +4797,14 @@ impl TrtxConverter {
             });
         }
 
-        let mut offset = 0i32;
+        let mut offset = 0i64;
         for (k, &size_k) in splits.iter().enumerate() {
-            let mut starts = vec![0i32; ndim];
+            let size_k = size_k as i64;
+            let mut starts = vec![0i64; ndim];
             starts[axis as usize] = offset;
             let mut sizes = input_dims.clone();
             sizes[axis as usize] = size_k;
-            let strides = vec![1i32; ndim];
+            let strides = vec![1i64; ndim];
 
             let output = {
                 let input =
@@ -4694,7 +4821,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add slice layer for split {}: {}", k, e),
                     })?;
                 layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get layer output for split {}: {}", k, e),
@@ -4709,9 +4836,9 @@ impl TrtxConverter {
     }
 
     /// Add squeeze operation (remove dimensions of size 1)
-    fn add_squeeze_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_squeeze_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4739,7 +4866,7 @@ impl TrtxConverter {
         // For now, this creates the layer structure correctly
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4752,9 +4879,9 @@ impl TrtxConverter {
     }
 
     /// Add unsqueeze operation (add dimensions of size 1)
-    fn add_unsqueeze_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_unsqueeze_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4798,7 +4925,7 @@ impl TrtxConverter {
         // with the expanded shape (inserting 1s at specified axes)
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4812,12 +4939,12 @@ impl TrtxConverter {
 
     /// Add expand operation (broadcast to new shape)
     /// Implemented as input * ones(new_shape) so elementwise broadcast produces the expanded tensor.
-    fn add_expand_op(
+    fn add_expand_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -4838,6 +4965,10 @@ impl TrtxConverter {
                 });
             }
         };
+        let new_shape: Vec<i64> = new_shape
+            .iter()
+            .map(|d| MLDimension::static_or_max(d) as i64)
+            .collect();
 
         if new_shape.is_empty() {
             return Err(GraphError::ConversionFailed {
@@ -4848,7 +4979,7 @@ impl TrtxConverter {
 
         let num_elements: usize = new_shape
             .iter()
-            .map(|d: &i32| (*d).max(0) as usize)
+            .map(|d: &i64| (*d).max(0) as usize)
             .product::<usize>()
             .max(1);
 
@@ -4884,12 +5015,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ones constant for expand: {}", e),
             })?;
-        let ones_tensor = ones_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get ones constant output: {}", e),
-            })?;
+        let ones_tensor =
+            ones_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get ones constant output: {}", e),
+                })?;
 
         let (bc_input, bc_ones) =
             Self::ensure_broadcast_compatible(network, input, &ones_tensor, "expand")?;
@@ -4900,12 +5032,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add multiply for expand: {}", e),
             })?;
-        let output = mul_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get expand output: {}", e),
-            })?;
+        let output =
+            mul_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get expand output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4914,9 +5047,9 @@ impl TrtxConverter {
     }
 
     /// Add tile operation (repeat tensor along axes)
-    fn add_tile_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_tile_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let repetitions = match operation {
@@ -4956,7 +5089,8 @@ impl TrtxConverter {
                     })?;
 
             // Create a vector of references to the same tensor, repeated 'reps' times
-            let tensors_to_concat: Vec<&trtx::Tensor> = (0..reps).map(|_| current_tensor).collect();
+            let t: &trtx::Tensor<'network> = &*current_tensor;
+            let tensors_to_concat: Vec<&trtx::Tensor<'network>> = (0..reps).map(|_| t).collect();
 
             // Concatenate along this axis
             let mut concat_layer = network.add_concatenation(&tensors_to_concat).map_err(|e| {
@@ -4967,17 +5101,12 @@ impl TrtxConverter {
             })?;
 
             // Set the concatenation axis
-            concat_layer
-                .set_axis(axis as i32)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to set concatenation axis {}: {}", axis, e),
-                })?;
+            concat_layer.set_axis(network, axis as i32);
 
             // Get the output tensor
             let output_tensor =
                 concat_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!(
@@ -5009,13 +5138,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add identity layer: {}", e),
                     }
                 })?;
-                let output_tensor =
-                    identity_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get identity output: {}", e),
-                        })?;
+                let output_tensor = identity_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    }
+                })?;
                 tensor_map.insert(output_id, output_tensor);
             }
         }
@@ -5028,9 +5156,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add greaterOrEqual operation (greater(x, y) OR equal(x, y))
-    fn add_greater_or_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_greater_or_equal_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5060,7 +5188,7 @@ impl TrtxConverter {
 
         let greater_output =
             greater_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get greater output: {}", e),
@@ -5073,12 +5201,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let or_layer = network
             .add_elementwise(&greater_output, &equal_output, ElementWiseOperation::kOR)
@@ -5087,12 +5216,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add OR layer: {}", e),
             })?;
 
-        let bool_output = or_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get OR output: {}", e),
-            })?;
+        let bool_output =
+            or_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get OR output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5104,9 +5234,9 @@ impl TrtxConverter {
     }
 
     /// Add lesserOrEqual operation (lesser(x, y) OR equal(x, y))
-    fn add_lesser_or_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_lesser_or_equal_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5136,7 +5266,7 @@ impl TrtxConverter {
 
         let lesser_output =
             lesser_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get lesser output: {}", e),
@@ -5149,12 +5279,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let or_layer = network
             .add_elementwise(&lesser_output, &equal_output, ElementWiseOperation::kOR)
@@ -5163,12 +5294,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add OR layer: {}", e),
             })?;
 
-        let bool_output = or_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get OR output: {}", e),
-            })?;
+        let bool_output =
+            or_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get OR output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5180,9 +5312,9 @@ impl TrtxConverter {
     }
 
     /// Add notEqual operation (NOT equal(x, y))
-    fn add_not_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_not_equal_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5210,26 +5342,28 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let not_layer = network
-            .add_unary(&equal_output, UnaryOperation::kNOT)
+            .add_unary(&equal_output, UnaryOperation::kNOT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add NOT layer: {}", e),
             })?;
 
-        let bool_output = not_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get NOT output: {}", e),
-            })?;
+        let bool_output =
+            not_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get NOT output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5246,12 +5380,11 @@ impl TrtxConverter {
 
     /// Add gather operation (gather elements along an axis using indices).
     /// Clamps indices to [-dim_size, dim_size - 1] to match WebNN/Chromium behavior and avoid TensorRT out-of-bounds.
-    fn add_gather_op(
+    fn add_gather_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -5297,7 +5430,7 @@ impl TrtxConverter {
                 ),
             });
         }
-        let dim_size = get_static_or_max_size(&data_operand.descriptor.shape[axis_usize]) as i32;
+        let dim_size = get_static_or_max_size(&data_operand.descriptor.shape[axis_usize]) as i64;
 
         let indices_operand = graph
             .operand(operation.input_operands()[1])
@@ -5308,11 +5441,11 @@ impl TrtxConverter {
                     operation.input_operands()[1]
                 ),
             })?;
-        let indices_shape: Vec<i32> = indices_operand
+        let indices_shape: Vec<i64> = indices_operand
             .descriptor
             .shape
             .iter()
-            .map(|d| get_static_or_max_size(d) as i32)
+            .map(|d| get_static_or_max_size(d) as i64)
             .collect();
 
         // Clamp indices to [-dim_size, dim_size - 1] (WebNN/conformance behavior).
@@ -5331,37 +5464,34 @@ impl TrtxConverter {
         let max_data: Vec<u8> = (0..num_elements)
             .flat_map(|_| clamp_max_val.to_le_bytes())
             .collect();
-        temp_weights.push(min_data);
-        temp_weights.push(max_data);
-        let idx = temp_weights.len();
-        let min_ref = temp_weights[idx - 2].as_slice();
-        let max_ref = temp_weights[idx - 1].as_slice();
 
         let min_const = network
-            .add_constant(&indices_shape, min_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&indices_shape, &min_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp min constant: {}", e),
             })?;
         let max_const = network
-            .add_constant(&indices_shape, max_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&indices_shape, &max_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp max constant: {}", e),
             })?;
 
-        let min_const_out = min_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get clamp min output: {}", e),
-            })?;
-        let max_const_out = max_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get clamp max output: {}", e),
-            })?;
+        let min_const_out =
+            min_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get clamp min output: {}", e),
+                })?;
+        let max_const_out =
+            max_const
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get clamp max output: {}", e),
+                })?;
 
         let clamped_upper = network
             .add_elementwise(indices, &max_const_out, ElementWiseOperation::kMIN)
@@ -5371,7 +5501,7 @@ impl TrtxConverter {
             })?;
         let clamped_upper_out =
             clamped_upper
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get gather clamp upper output: {}", e),
@@ -5387,12 +5517,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather indices clamp (max): {}", e),
             })?;
-        let clamped_indices = clamped
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get gather clamped indices output: {}", e),
-            })?;
+        let clamped_indices =
+            clamped
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get gather clamped indices output: {}", e),
+                })?;
 
         let layer = network
             .add_gather(input, &clamped_indices, axis)
@@ -5402,7 +5533,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gather output: {}", e),
@@ -5415,9 +5546,9 @@ impl TrtxConverter {
     }
 
     /// Add gatherND operation (N-dimensional gather)
-    fn add_gather_nd_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_gather_nd_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -5440,22 +5571,17 @@ impl TrtxConverter {
         // Create gather layer with axis 0 (required by addGather API)
         let mut layer =
             network
-                .add_gather(input, indices, 0)
+                .add_gather(&input, &indices, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add gatherND layer: {}", e),
                 })?;
 
         // Set gather mode to kND for N-dimensional gather
-        layer
-            .set_gather_mode(trtx::GatherMode::kND)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set gather mode to kND: {}", e),
-            })?;
+        layer.set_gather_mode(network, trtx::GatherMode::kND);
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherND output: {}", e),
@@ -5468,9 +5594,9 @@ impl TrtxConverter {
     }
 
     /// Add scatterElements operation (element-wise scatter)
-    fn add_scatter_elements_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_scatter_elements_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let data = tensor_map
@@ -5516,15 +5642,10 @@ impl TrtxConverter {
             })?;
 
         // Set axis for element-wise scatter
-        layer
-            .set_axis(axis)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set scatter axis: {}", e),
-            })?;
+        layer.set_axis(network, axis);
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterElements output: {}", e),
@@ -5537,9 +5658,9 @@ impl TrtxConverter {
     }
 
     /// Add scatterND operation (N-dimensional scatter)
-    fn add_scatter_nd_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_scatter_nd_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let data = tensor_map
@@ -5578,7 +5699,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterND output: {}", e),
@@ -5591,9 +5712,9 @@ impl TrtxConverter {
     }
 
     /// Add argMax operation (find indices of maximum values)
-    fn add_arg_max_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_arg_max_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -5616,9 +5737,8 @@ impl TrtxConverter {
             }
         };
 
-        // TopK operation: 0=kMAX, 1=kMIN
         let layer = network
-            .add_topk(input, 0, 1, 1u32 << axis) // operation=kMAX, k=1, axes as bitmask
+            .add_topk(input, TopKOperation::kMAX, 1, Axes::new([axis]))
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add topK layer: {}", e),
@@ -5626,12 +5746,13 @@ impl TrtxConverter {
 
         // TopK returns two outputs: values and indices
         // We want indices (output 1)
-        let indices_output = layer
-            .get_output(1)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get topK indices output: {}", e),
-            })?;
+        let indices_output =
+            layer
+                .get_output(network, 1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get topK indices output: {}", e),
+                })?;
 
         let squeezed_output = if !keep_dims {
             // Squeeze the k dimension (which is 1)
@@ -5644,7 +5765,7 @@ impl TrtxConverter {
                     })?;
 
             squeeze_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get squeeze output: {}", e),
@@ -5663,9 +5784,9 @@ impl TrtxConverter {
     }
 
     /// Add argMin operation (find indices of minimum values)
-    fn add_arg_min_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_arg_min_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -5690,7 +5811,8 @@ impl TrtxConverter {
 
         // TopK operation: 0=kMAX, 1=kMIN
         let layer = network
-            .add_topk(input, 1, 1, 1u32 << axis) // operation=kMIN, k=1, axes as bitmask
+            .add_topk(input, TopKOperation::kMIN, 1, Axes::new([axis])) // operation=kMIN, k=1, axes as
+            // bitmask
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add topK layer: {}", e),
@@ -5698,12 +5820,13 @@ impl TrtxConverter {
 
         // TopK returns two outputs: values and indices
         // We want indices (output 1)
-        let indices_output = layer
-            .get_output(1)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get topK indices output: {}", e),
-            })?;
+        let indices_output =
+            layer
+                .get_output(network, 1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get topK indices output: {}", e),
+                })?;
 
         let squeezed_output = if !keep_dims {
             // Squeeze the k dimension (which is 1)
@@ -5716,7 +5839,7 @@ impl TrtxConverter {
                     })?;
 
             squeeze_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get squeeze output: {}", e),
@@ -5739,12 +5862,12 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add clamp operation (clip values to range [min, max])
-    fn add_clamp_op(
+    fn add_clamp_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -5766,7 +5889,7 @@ impl TrtxConverter {
         let num_dims = input_operand.descriptor.shape.len();
         let input_dtype = input_operand.descriptor.data_type;
         // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1; num_dims];
 
         // Get min and max values from attributes (handle "Infinity"/"-Infinity"/"NaN" strings from WPT).
         let parse_clamp_bound_f32 = |v: &serde_json::Value| -> Option<f32> {
@@ -5897,10 +6020,8 @@ impl TrtxConverter {
 
         // Implement clamp as: max(min_value, min(input, max_value))
         // First: min(input, max_value)
-        temp_weights.push(max_bytes);
-        let max_const_data = temp_weights.last().unwrap();
         let max_const = network
-            .add_constant(&broadcast_shape, max_const_data, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &max_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add max constant: {}", e),
@@ -5908,7 +6029,7 @@ impl TrtxConverter {
 
         let max_const_output =
             max_const
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get max constant output: {}", e),
@@ -5923,17 +6044,15 @@ impl TrtxConverter {
 
         let clamped_upper_output =
             clamped_upper
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get upper clamp output: {}", e),
                 })?;
 
         // Second: max(min_value, clamped_upper)
-        temp_weights.push(min_bytes);
-        let min_const_data = temp_weights.last().unwrap();
         let min_const = network
-            .add_constant(&broadcast_shape, min_const_data, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &min_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min constant: {}", e),
@@ -5941,7 +6060,7 @@ impl TrtxConverter {
 
         let min_const_output =
             min_const
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get min constant output: {}", e),
@@ -5959,7 +6078,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get clamp output: {}", e),
@@ -5972,9 +6091,9 @@ impl TrtxConverter {
     }
 
     /// Add where operation (select elements based on condition)
-    fn add_where_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_where_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let condition = tensor_map
@@ -6018,7 +6137,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get select output: {}", e),
@@ -6031,12 +6150,11 @@ impl TrtxConverter {
     }
 
     /// Add linear operation (alpha * x + beta)
-    fn add_linear_op(
+    fn add_linear_op<'network>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -6057,7 +6175,7 @@ impl TrtxConverter {
             })?;
         let num_dims = input_operand.descriptor.shape.len();
         // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1; num_dims];
 
         let attrs = operation.attributes();
         let linear_opts = attrs.as_linear();
@@ -6068,7 +6186,7 @@ impl TrtxConverter {
         // Note: All scalar constants must use shape [1,1,...,1] matching input dims for TensorRT broadcasting
 
         // Step 1: If alpha != 1.0, multiply x by alpha
-        let after_multiply = if (alpha - 1.0).abs() > f32::EPSILON {
+        let mut after_multiply = if (alpha - 1.0).abs() > f32::EPSILON {
             // Create alpha constant with type matching input (Half vs Float) for TensorRT elementwise
             let (alpha_bytes, alpha_dtype) = match input_operand.descriptor.data_type {
                 DataType::Float16 => (
@@ -6077,34 +6195,31 @@ impl TrtxConverter {
                 ),
                 _ => (alpha.to_le_bytes().to_vec(), trtx::DataType::kFLOAT),
             };
-            temp_weights.push(alpha_bytes);
-            let alpha_bytes_ref = temp_weights.last().unwrap();
 
             let alpha_constant = network
-                .add_constant(&broadcast_shape, alpha_bytes_ref, alpha_dtype)
+                .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let alpha_tensor =
-                alpha_constant
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get alpha constant output: {}", e),
-                    })?;
+            let mut alpha_tensor = alpha_constant.get_output(network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get alpha constant output: {}", e),
+                }
+            })?;
 
             // Multiply: alpha * x
             let mul_layer = network
-                .add_elementwise(input, &alpha_tensor, ElementWiseOperation::kPROD)
+                .add_elementwise(input, &mut alpha_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to multiply by alpha: {}", e),
                 })?;
 
             mul_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get multiply output: {}", e),
@@ -6119,7 +6234,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add identity layer: {}", e),
                     })?;
             identity_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -6136,19 +6251,17 @@ impl TrtxConverter {
                 ),
                 _ => (beta.to_le_bytes().to_vec(), trtx::DataType::kFLOAT),
             };
-            temp_weights.push(beta_bytes);
-            let beta_bytes_ref = temp_weights.last().unwrap();
 
             let beta_constant = network
-                .add_constant(&broadcast_shape, beta_bytes_ref, beta_dtype)
+                .add_small_constant_copied(&broadcast_shape, &beta_bytes, beta_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create beta constant: {}", e),
                 })?;
 
-            let beta_tensor =
+            let mut beta_tensor =
                 beta_constant
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get beta constant output: {}", e),
@@ -6156,14 +6269,18 @@ impl TrtxConverter {
 
             // Add: (alpha * x) + beta
             let add_layer = network
-                .add_elementwise(&after_multiply, &beta_tensor, ElementWiseOperation::kSUM)
+                .add_elementwise(
+                    &mut after_multiply,
+                    &mut beta_tensor,
+                    ElementWiseOperation::kSUM,
+                )
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add beta: {}", e),
                 })?;
 
             add_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get add output: {}", e),
@@ -6179,9 +6296,9 @@ impl TrtxConverter {
     }
 
     /// Add pad operation (pad tensor with constant/edge/reflection values)
-    fn add_pad_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_pad_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -6214,8 +6331,8 @@ impl TrtxConverter {
                 });
             }
         };
-        let pre_padding: Vec<i32> = beginning_padding.iter().map(|&u| u as i32).collect();
-        let post_padding: Vec<i32> = ending_padding.iter().map(|&u| u as i32).collect();
+        let pre_padding: Vec<i64> = opts.beginning_padding.iter().map(|&u| u as i64).collect();
+        let post_padding: Vec<i64> = opts.ending_padding.iter().map(|&u| u as i64).collect();
         if pre_padding.is_empty() || post_padding.is_empty() {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -6225,7 +6342,7 @@ impl TrtxConverter {
 
         // Get input dimensions
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dimensions: {}", e),
@@ -6263,14 +6380,14 @@ impl TrtxConverter {
                     })?;
 
             reshape_layer
-                .set_reshape_dimensions(&shape_4d)
+                .set_reshape_dimensions(network, &shape_4d)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set reshape dimensions: {}", e),
                 })?;
 
             reshape_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape output: {}", e),
@@ -6286,7 +6403,7 @@ impl TrtxConverter {
                         reason: format!("Failed to create identity layer: {}", e),
                     })?;
             identity
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -6300,8 +6417,8 @@ impl TrtxConverter {
         let spatial_dims = 2; // H, W dimensions in NCHW
 
         // Right-align: If we have fewer than 2 padding values, pad LEFT with zeros
-        let mut pre_padding_spatial = vec![0; spatial_dims];
-        let mut post_padding_spatial = vec![0; spatial_dims];
+        let mut pre_padding_spatial = vec![0i64; spatial_dims];
+        let mut post_padding_spatial = vec![0i64; spatial_dims];
 
         let len = pre_padding.len().min(spatial_dims);
         let pad_offset = spatial_dims.saturating_sub(pre_padding.len());
@@ -6313,7 +6430,7 @@ impl TrtxConverter {
         // Check actual dimensions of input_to_pad
         let input_to_pad_dims =
             input_to_pad
-                .dimensions()
+                .dimensions(network)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get input_to_pad dimensions: {}", e),
@@ -6346,7 +6463,7 @@ impl TrtxConverter {
 
         let padded_output =
             padding_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get padding output: {}", e),
@@ -6358,7 +6475,7 @@ impl TrtxConverter {
             let mut output_shape = input_dims.clone();
             for (i, (&pre, &post)) in pre_padding.iter().zip(post_padding.iter()).enumerate() {
                 if i < output_shape.len() {
-                    output_shape[i] += pre + post;
+                    output_shape[i] += (pre as i64) + (post as i64);
                 }
             }
 
@@ -6371,14 +6488,14 @@ impl TrtxConverter {
                     })?;
 
             reshape_back
-                .set_reshape_dimensions(&output_shape)
+                .set_reshape_dimensions(network, &output_shape)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set reshape-back dimensions: {}", e),
                 })?;
 
             reshape_back
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape-back output: {}", e),
@@ -6395,11 +6512,10 @@ impl TrtxConverter {
 
     /// Add GEMM (General Matrix Multiply) operation
     /// Computes: C = alpha * A * B + beta * C
-    fn add_gemm_op(
-        _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+    fn add_gemm_op<'network>(
+        _graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_a = tensor_map
@@ -6425,13 +6541,13 @@ impl TrtxConverter {
 
         // Get actual dimensions for validation
         let _dims_a = input_a
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input A dimensions: {}", e),
             })?;
         let _dims_b = input_b
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input B dimensions: {}", e),
@@ -6472,19 +6588,19 @@ impl TrtxConverter {
             (
                 input_a,
                 input_b,
-                MatrixOperation::kNONE as i32,
-                MatrixOperation::kTRANSPOSE as i32,
+                MatrixOperation::kNONE,
+                MatrixOperation::kTRANSPOSE,
             )
         } else {
             let a_op = if a_transpose {
-                MatrixOperation::kTRANSPOSE as i32
+                MatrixOperation::kTRANSPOSE
             } else {
-                MatrixOperation::kNONE as i32
+                MatrixOperation::kNONE
             };
             let b_op = if b_transpose {
-                MatrixOperation::kTRANSPOSE as i32
+                MatrixOperation::kTRANSPOSE
             } else {
-                MatrixOperation::kNONE as i32
+                MatrixOperation::kNONE
             };
             (input_a, input_b, a_op, b_op)
         };
@@ -6497,42 +6613,40 @@ impl TrtxConverter {
                 reason: format!("Failed to add GEMM matrix multiply: {}", e),
             })?;
 
-        let mut result = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get GEMM layer output: {}", e),
-            })?;
+        let mut result =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get GEMM layer output: {}", e),
+                })?;
 
         // If alpha != 1.0, scale the result
         if (alpha - 1.0).abs() > 1e-6 {
             // Get result dimensions to create a constant with matching shape
-            let result_dims = result
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get result dimensions: {}", e),
-                })?;
+            let result_dims =
+                result
+                    .dimensions(network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get result dimensions: {}", e),
+                    })?;
 
             // Create constant filled with alpha value matching result shape
             let num_elements: usize = result_dims.iter().map(|&d| d as usize).product();
             let alpha_data: Vec<f32> = vec![alpha; num_elements];
             let alpha_bytes: Vec<u8> = alpha_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-            // Store weights to keep them alive until engine serialization
-            temp_weights.push(alpha_bytes);
-            let alpha_bytes_ref = temp_weights.last().unwrap().as_slice();
-
             let alpha_layer = network
-                .add_constant(&result_dims, alpha_bytes_ref, TrtDataType::kFLOAT)
+                .add_small_constant_copied(&result_dims, &alpha_bytes, TrtDataType::kFLOAT)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let alpha_tensor =
+            let mut alpha_tensor =
                 alpha_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get alpha tensor: {}", e),
@@ -6540,18 +6654,19 @@ impl TrtxConverter {
 
             // Multiply result by alpha
             let scale_layer = network
-                .add_elementwise(&result, &alpha_tensor, ElementWiseOperation::kPROD)
+                .add_elementwise(&mut result, &mut alpha_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to scale by alpha: {}", e),
                 })?;
 
-            result = scale_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get scaled output: {}", e),
-                })?;
+            result =
+                scale_layer
+                    .get_output(network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get scaled output: {}", e),
+                    })?;
         }
 
         // If there's a C input and beta != 0, add it
@@ -6566,36 +6681,32 @@ impl TrtxConverter {
             // Scale C by beta if needed, then add to result
             if (beta - 1.0).abs() > 1e-6 {
                 // Get C dimensions to create a constant with matching shape
-                let c_dims = input_c
-                    .dimensions()
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get C dimensions: {}", e),
-                    })?;
+                let c_dims =
+                    input_c
+                        .dimensions(network)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get C dimensions: {}", e),
+                        })?;
 
                 // Create constant filled with beta value matching C shape
                 let num_elements: usize = c_dims.iter().map(|&d| d as usize).product();
                 let beta_data: Vec<f32> = vec![beta; num_elements];
                 let beta_bytes: Vec<u8> = beta_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-                // Store weights to keep them alive until engine serialization
-                temp_weights.push(beta_bytes);
-                let beta_bytes_ref = temp_weights.last().unwrap().as_slice();
-
                 let beta_layer = network
-                    .add_constant(&c_dims, beta_bytes_ref, TrtDataType::kFLOAT)
+                    .add_small_constant_copied(&c_dims, &beta_bytes, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to create beta constant: {}", e),
                     })?;
 
-                let beta_tensor =
-                    beta_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get beta tensor: {}", e),
-                        })?;
+                let mut beta_tensor = beta_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get beta tensor: {}", e),
+                    }
+                })?;
 
                 // Multiply C by beta
                 let scale_c_layer = network
@@ -6605,13 +6716,12 @@ impl TrtxConverter {
                         reason: format!("Failed to scale C by beta: {}", e),
                     })?;
 
-                let scaled_c =
-                    scale_c_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get scaled C: {}", e),
-                        })?;
+                let scaled_c = scale_c_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get scaled C: {}", e),
+                    }
+                })?;
 
                 // Add result + beta*C
                 let add_layer = network
@@ -6621,27 +6731,29 @@ impl TrtxConverter {
                         reason: format!("Failed to add scaled C to result: {}", e),
                     })?;
 
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             } else {
                 // beta == 1.0: add C directly
                 let add_layer = network
-                    .add_elementwise(&result, input_c, ElementWiseOperation::kSUM)
+                    .add_elementwise(&mut result, input_c, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add C to result: {}", e),
                     })?;
 
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             }
         }
 
@@ -6652,11 +6764,11 @@ impl TrtxConverter {
     }
 
     /// Add 2D convolution operation
-    fn add_conv2d_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+    fn add_conv2d_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &'network mut HashMap<u32, trtx::Tensor<'network>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -6816,15 +6928,10 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 3, 1, 2]).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
-                }
-            })?;
+            shuffle.set_first_transpose(network, &[0, 3, 1, 2]);
             Some(
                 shuffle
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC shuffle output: {}", e),
@@ -6836,52 +6943,51 @@ impl TrtxConverter {
         let pre_conv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
         // TensorRT conv kernel is always Float; cast Half input to Float so types match.
-        let half_cast_output: Option<trtx::Tensor> = if input_dtype == DataType::Float16 {
-            let cast_layer = network
-                .add_cast(pre_conv_input, TrtDataType::kFLOAT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Conv2d Half->Float cast: {}", e),
-                })?;
-            Some(
-                cast_layer
-                    .get_output(0)
+        let half_cast_output: Option<trtx::Tensor> =
+            if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pre_conv_input, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("Conv2d Half->Float cast: {}", e),
+                    })?;
+                Some(cast_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("Conv2d cast output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let conv_input_source = half_cast_output.as_ref().unwrap_or(pre_conv_input);
 
         // Stride, padding, dilation, groups from typed options
-        let strides: [i32; 2] = conv_opts
+        let strides: [i64; 2] = conv_opts
             .and_then(|o| {
                 if o.strides.len() >= 2 {
-                    Some([o.strides[0] as i32, o.strides[1] as i32])
+                    Some([o.strides[0] as i64, o.strides[1] as i64])
                 } else {
                     None
                 }
             })
             .unwrap_or([1, 1]);
-        let dilations: [i32; 2] = conv_opts
+        let dilations: [i64; 2] = conv_opts
             .and_then(|o| {
                 if o.dilations.len() >= 2 {
-                    Some([o.dilations[0] as i32, o.dilations[1] as i32])
+                    Some([o.dilations[0] as i64, o.dilations[1] as i64])
                 } else {
                     None
                 }
             })
             .unwrap_or([1, 1]);
-        let groups = conv_opts.map(|o| o.groups as i32).unwrap_or(1);
+        let groups = conv_opts.map(|o| o.groups as i64).unwrap_or(1);
         let (pre_padding, post_padding) = conv_opts
             .map(|o| {
                 if o.padding.len() >= 4 {
                     (
-                        vec![o.padding[0] as i32, o.padding[1] as i32],
-                        vec![o.padding[2] as i32, o.padding[3] as i32],
+                        vec![o.padding[0] as i64, o.padding[1] as i64],
+                        vec![o.padding[2] as i64, o.padding[3] as i64],
                     )
                 } else {
                     (vec![0, 0], vec![0, 0])
@@ -6900,7 +7006,7 @@ impl TrtxConverter {
                     })?;
 
                 padding_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get padding layer output: {}", e),
@@ -6914,7 +7020,7 @@ impl TrtxConverter {
                     }
                 })?;
                 id_layer
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -6957,7 +7063,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter cast output: {}", e),
@@ -6983,7 +7089,7 @@ impl TrtxConverter {
                                         reason: format!("Conv2d bias Half->Float cast: {}", e),
                                     }
                                 })?;
-                            Some(cast_layer.get_output(0).map_err(|e| {
+                            Some(cast_layer.get_output(network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!("Conv2d bias cast output: {}", e),
@@ -7009,61 +7115,32 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add convolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(1, filter_tensor_to_use).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Conv2d set_input(1) filter: {}", e),
-                    }
-                })?;
+                layer.set_input(network, 1, filter_tensor_to_use);
                 if let Some(bt) = bias_tensor_to_use {
-                    layer
-                        .set_input(2, bt)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Conv2d set_input(2) bias: {}", e),
-                        })?;
+                    layer.set_input(network, 2, bt);
                 }
                 layer
             }
         };
 
         // Set layer properties (matches C++ API pattern: call setters after creation)
-        layer
-            .set_stride(&strides)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set stride: {}", e),
-            })?;
+        layer.set_stride(network, &strides);
 
         // No need to set padding on convolution layer - already handled by explicit padding layer
-        layer
-            .set_padding(&[0, 0])
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set padding: {}", e),
-            })?;
+        layer.set_padding(network, &[0, 0]);
 
-        layer
-            .set_dilation(&dilations)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set dilation: {}", e),
-            })?;
+        layer.set_dilation(network, &dilations);
 
-        layer
-            .set_num_groups(groups)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set groups: {}", e),
-            })?;
+        layer.set_num_groups(network, groups);
 
         // Extract output tensor from layer (NCHW, Float)
-        let conv_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get convolution output: {}", e),
-            })?;
+        let conv_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get convolution output: {}", e),
+                })?;
 
         // If input was Half, cast conv output back to Half to match graph output type.
         let conv_output = if input_dtype == DataType::Float16 {
@@ -7074,7 +7151,7 @@ impl TrtxConverter {
                     reason: format!("Conv2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d cast output: {}", e),
@@ -7092,14 +7169,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 2, 3, 1]).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Conv2d set_first_transpose NCHW->NHWC: {}", e),
-                }
-            })?;
+            shuffle.set_first_transpose(network, &[0, 2, 3, 1]);
             shuffle
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d NHWC output shuffle: {}", e),
@@ -7116,11 +7188,11 @@ impl TrtxConverter {
 
     /// Add convTranspose2d operation (deconvolution/transposed convolution).
     /// Mirrors add_conv2d_op: supports constant or non-constant filter/bias via setInput(1)/setInput(2).
-    fn add_conv_transpose2d_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+    fn add_conv_transpose2d_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -7164,10 +7236,10 @@ impl TrtxConverter {
                 });
             }
         };
-        let groups = deconv_opts.map(|o| o.groups as i32).unwrap_or(1);
+        let groups = deconv_opts.map(|o| o.groups).unwrap_or(1);
         // WebNN filter shape is [inputChannels, outputChannels/groups, H, W]; TensorRT expects total output maps.
-        let num_output_maps = (o as i32) * groups;
-        let kernel_size: [i32; 2] = [h as i32, w as i32];
+        let num_output_maps = o * groups;
+        let kernel_size: [i64; 2] = [h.into(), w.into()];
 
         let filter_constant = graph
             .constant_operand_ids_to_handles
@@ -7281,15 +7353,10 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 3, 1, 2]).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
-                }
-            })?;
+            shuffle.set_first_transpose(network, &[0, 3, 1, 2]);
             Some(
                 shuffle
-                    .get_output(0)
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC shuffle output: {}", e),
@@ -7300,39 +7367,38 @@ impl TrtxConverter {
         };
         let pre_deconv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
-        let half_cast_output: Option<trtx::Tensor> = if input_dtype == DataType::Float16 {
-            let cast_layer = network
-                .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("convTranspose2d Half->Float cast: {}", e),
-                })?;
-            Some(
-                cast_layer
-                    .get_output(0)
+        let half_cast_output: Option<trtx::Tensor> =
+            if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("convTranspose2d Half->Float cast: {}", e),
+                    })?;
+                Some(cast_layer.get_output(network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("convTranspose2d cast output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let deconv_input_source = half_cast_output.as_ref().unwrap_or(pre_deconv_input);
 
-        let strides: [i32; 2] = deconv_opts
+        let strides: [i64; 2] = deconv_opts
             .and_then(|o| {
                 if o.strides.len() >= 2 {
-                    Some([o.strides[0] as i32, o.strides[1] as i32])
+                    Some([o.strides[0] as i64, o.strides[1] as i64])
                 } else {
                     None
                 }
             })
             .unwrap_or([1, 1]);
-        let dilations: [i32; 2] = deconv_opts
+        let dilations: [i64; 2] = deconv_opts
             .and_then(|o| {
                 if o.dilations.len() >= 2 {
-                    Some([o.dilations[0] as i32, o.dilations[1] as i32])
+                    Some([o.dilations[0] as i64, o.dilations[1] as i64])
                 } else {
                     None
                 }
@@ -7342,8 +7408,8 @@ impl TrtxConverter {
             .map(|o| {
                 if o.padding.len() >= 4 {
                     (
-                        vec![o.padding[0] as i32, o.padding[2] as i32],
-                        vec![o.padding[1] as i32, o.padding[3] as i32],
+                        vec![o.padding[0] as i64, o.padding[2] as i64],
+                        vec![o.padding[1] as i64, o.padding[3] as i64],
                     )
                 } else {
                     (vec![0, 0], vec![0, 0])
@@ -7360,7 +7426,7 @@ impl TrtxConverter {
                 }
             })?;
             id_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d identity output: {}", e),
@@ -7378,7 +7444,7 @@ impl TrtxConverter {
                 network
                     .add_deconvolution(
                         &deconv_input,
-                        num_output_maps,
+                        num_output_maps.into(),
                         &kernel_size,
                         &deconv_weights,
                     )
@@ -7405,7 +7471,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter cast output: {}", e),
@@ -7432,7 +7498,7 @@ impl TrtxConverter {
                                     reason: format!("convTranspose2d bias Half->Float cast: {}", e),
                                 }
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d bias cast output: {}", e),
@@ -7444,7 +7510,6 @@ impl TrtxConverter {
                 } else {
                     None
                 };
-                let bias_tensor_to_use = bias_tensor_for_conv.as_ref().or(bias_tensor_raw);
 
                 let deconv_weights = trtx::ConvWeights {
                     kernel_weights: &[],
@@ -7455,7 +7520,7 @@ impl TrtxConverter {
                 let mut layer = network
                     .add_deconvolution(
                         &deconv_input,
-                        num_output_maps,
+                        num_output_maps as i64,
                         &kernel_size,
                         &deconv_weights,
                     )
@@ -7463,57 +7528,39 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add deconvolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(1, filter_tensor_to_use).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("convTranspose2d set_input(1) filter: {}", e),
-                    }
-                })?;
-                if let Some(bt) = bias_tensor_to_use {
-                    layer
-                        .set_input(2, bt)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("convTranspose2d set_input(2) bias: {}", e),
-                        })?;
+                layer.set_input(network, 1, filter_tensor_to_use);
+                if let Some(bt) = bias_tensor_for_conv.as_ref() {
+                    layer.set_input(network, 2, bt);
+                } else if let Some(bt) = bias_tensor_raw.as_ref() {
+                    layer.set_input(network, 2, bt);
                 }
                 layer
             }
         };
 
-        layer
-            .set_stride(&strides)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("convTranspose2d set_stride: {}", e),
-            })?;
-        layer
-            .set_dilation(&dilations)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("convTranspose2d set_dilation: {}", e),
-            })?;
+        layer.set_stride(network, &strides);
+        layer.set_dilation(network, &dilations);
         // outputPadding extends output size. Absorb by reducing padding when possible; otherwise add
         // IPaddingLayer for remainder. WebNN: out = (in-1)*stride + kernel - pre - post + outputPadding.
         // TensorRT: out = (in-1)*stride + kernel - pre - post. Reduce pre+post by outputPadding.
-        let output_padding: [i32; 2] = deconv_opts
+        let output_padding: [i64; 2] = deconv_opts
             .and_then(|o| {
                 if o.output_padding.len() >= 2 {
-                    Some([o.output_padding[0] as i32, o.output_padding[1] as i32])
+                    Some([o.output_padding[0] as i64, o.output_padding[1] as i64])
                 } else {
                     None
                 }
             })
             .unwrap_or([0, 0]);
-        let post_effective: [i32; 2] = [
+        let post_effective: [i64; 2] = [
             (post_padding[0] - output_padding[0]).max(0),
             (post_padding[1] - output_padding[1]).max(0),
         ];
-        let pre_effective: [i32; 2] = [
+        let pre_effective: [i64; 2] = [
             (pre_padding[0] - (output_padding[0] - post_padding[0]).max(0)).max(0),
             (pre_padding[1] - (output_padding[1] - post_padding[1]).max(0)).max(0),
         ];
-        let padding_remainder: [i32; 2] = [
+        let padding_remainder: [i64; 2] = [
             (output_padding[0]
                 - (post_padding[0] - post_effective[0])
                 - (pre_padding[0] - pre_effective[0]))
@@ -7525,39 +7572,24 @@ impl TrtxConverter {
         ];
         // TensorRT Deconvolution: pre/post padding trim the output. DimsHW order is (height, width).
         // See https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-861/operators/docs/Deconvolution.html
-        let pre: [i32; 2] = pre_effective;
-        let post: [i32; 2] = post_effective;
-        layer
-            .set_pre_padding(&pre)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("convTranspose2d set_pre_padding: {}", e),
-            })?;
-        layer
-            .set_post_padding(&post)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("convTranspose2d set_post_padding: {}", e),
-            })?;
+        let pre: [i64; 2] = pre_effective;
+        let post: [i64; 2] = post_effective;
+        layer.set_pre_padding(network, &pre);
+        layer.set_post_padding(network, &post);
+        layer.set_num_groups(network, groups as i64);
 
-        layer
-            .set_num_groups(groups)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("convTranspose2d set_num_groups: {}", e),
-            })?;
-
-        let deconv_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get deconvolution output: {}", e),
-            })?;
+        let deconv_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get deconvolution output: {}", e),
+                })?;
 
         // When padding could not fully absorb outputPadding, add IPaddingLayer for remainder.
         let deconv_output = if padding_remainder[0] != 0 || padding_remainder[1] != 0 {
-            let pre_pad: Vec<i32> = vec![0, 0];
-            let post_pad: Vec<i32> = vec![padding_remainder[0], padding_remainder[1]];
+            let pre_pad: Vec<i64> = vec![0, 0];
+            let post_pad: Vec<i64> = vec![padding_remainder[0], padding_remainder[1]];
             let pad_layer = network
                 .add_padding(&deconv_output, &pre_pad, &post_pad)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -7565,7 +7597,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d outputPadding remainder: {}", e),
                 })?;
             pad_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d outputPadding remainder output: {}", e),
@@ -7584,31 +7616,31 @@ impl TrtxConverter {
                 if in_shape.len() != 4 || out_shape.len() != 4 {
                     deconv_output
                 } else {
-                    let (input_h, input_w): (i32, i32) = if input_layout == "nhwc" {
+                    let (input_h, input_w): (i64, i64) = if input_layout == "nhwc" {
                         (
-                            get_static_or_max_size(&in_shape[1]) as i32,
-                            get_static_or_max_size(&in_shape[2]) as i32,
+                            get_static_or_max_size(&in_shape[1]) as i64,
+                            get_static_or_max_size(&in_shape[2]) as i64,
                         )
                     } else {
                         (
-                            get_static_or_max_size(&in_shape[2]) as i32,
-                            get_static_or_max_size(&in_shape[3]) as i32,
+                            get_static_or_max_size(&in_shape[2]) as i64,
+                            get_static_or_max_size(&in_shape[3]) as i64,
                         )
                     };
-                    let (target_h, target_w, out_c): (i32, i32, i32) = if input_layout == "nhwc" {
+                    let (target_h, target_w, out_c): (i64, i64, i64) = if input_layout == "nhwc" {
                         (
-                            get_static_or_max_size(&out_shape[1]) as i32,
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
+                            get_static_or_max_size(&out_shape[1]) as i64,
+                            get_static_or_max_size(&out_shape[2]) as i64,
+                            get_static_or_max_size(&out_shape[3]) as i64,
                         )
                     } else {
                         (
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
-                            get_static_or_max_size(&out_shape[1]) as i32,
+                            get_static_or_max_size(&out_shape[2]) as i64,
+                            get_static_or_max_size(&out_shape[3]) as i64,
+                            get_static_or_max_size(&out_shape[1]) as i64,
                         )
                     };
-                    let out_batch = get_static_or_max_size(&in_shape[0]) as i32;
+                    let out_batch = get_static_or_max_size(&in_shape[0]) as i64;
                     if target_h <= 0 || target_w <= 0 {
                         deconv_output
                     } else {
@@ -7627,16 +7659,16 @@ impl TrtxConverter {
                         let slice_w = current_w.min(target_w);
                         let mut current = deconv_output;
                         if slice_h < current_h || slice_w < current_w {
-                            let start: Vec<i32> = vec![0, 0, 0, 0];
-                            let size: Vec<i32> = vec![out_batch, out_c, slice_h, slice_w];
-                            let stride: Vec<i32> = vec![1, 1, 1, 1];
+                            let start: Vec<i64> = vec![0, 0, 0, 0];
+                            let size: Vec<i64> = vec![out_batch, out_c, slice_h, slice_w];
+                            let stride: Vec<i64> = vec![1, 1, 1, 1];
                             let slice_layer = network
                                 .add_slice(&current, &start, &size, &stride)
                                 .map_err(|e| GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d outputSizes slice: {}", e),
                             })?;
-                            current = slice_layer.get_output(0).map_err(|e| {
+                            current = slice_layer.get_output(network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!(
@@ -7649,24 +7681,23 @@ impl TrtxConverter {
                         let pad_h = target_h - slice_h;
                         let pad_w = target_w - slice_w;
                         if pad_h > 0 || pad_w > 0 {
-                            let pre: Vec<i32> = vec![0, 0];
-                            let post: Vec<i32> = vec![pad_h, pad_w];
-                            let pad_layer =
-                                network.add_padding(&current, &pre, &post).map_err(|e| {
-                                    GraphError::ConversionFailed {
-                                        format: "trtx".to_string(),
-                                        reason: format!("convTranspose2d outputSizes pad: {}", e),
-                                    }
-                                })?;
-                            pad_layer
-                                .get_output(0)
+                            let pre: Vec<i64> = vec![0, 0];
+                            let post: Vec<i64> = vec![pad_h, pad_w];
+                            let pad_layer = network
+                                .add_padding(&mut current, &pre, &post)
                                 .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("convTranspose2d outputSizes pad: {}", e),
+                                })?;
+                            pad_layer.get_output(network, 0).map_err(|e| {
+                                GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!(
                                         "convTranspose2d outputSizes pad output: {}",
                                         e
                                     ),
-                                })?
+                                }
+                            })?
                         } else {
                             current
                         }
@@ -7684,7 +7715,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d cast output: {}", e),
@@ -7701,14 +7732,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 2, 3, 1]).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("convTranspose2d set_first_transpose NCHW->NHWC: {}", e),
-                }
-            })?;
+            shuffle.set_first_transpose(network, &[0, 2, 3, 1]);
             shuffle
-                .get_output(0)
+                .get_output(network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d NHWC output shuffle: {}", e),
@@ -7724,9 +7750,9 @@ impl TrtxConverter {
     }
 
     /// Add pooling operation
-    fn add_pooling_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_pooling_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
@@ -7753,9 +7779,9 @@ impl TrtxConverter {
                 reason: "Missing windowDimensions attribute".to_string(),
             })?;
 
-        let window: [i32; 2] = [
-            window_size.get(0).copied().unwrap_or(2) as i32,
-            window_size.get(1).copied().unwrap_or(2) as i32,
+        let window: [i64; 2] = [
+            window_size.get(0).copied().unwrap_or(2) as i64,
+            window_size.get(1).copied().unwrap_or(2) as i64,
         ];
 
         let layer = network
@@ -7767,7 +7793,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7780,9 +7806,9 @@ impl TrtxConverter {
     }
 
     /// Add softmax operation
-    fn add_softmax_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_softmax_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -7802,14 +7828,8 @@ impl TrtxConverter {
                 });
             }
         };
-
-        // TensorRT uses a bitmask where bit N represents axis N
-
-        // Create bitmask for the axis
-        let axes = 1u32 << positive_axis;
-
         let layer = network
-            .add_softmax(input, axes)
+            .add_softmax(input, Axes::new([positive_axis]))
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add softmax: {}", e),
@@ -7817,7 +7837,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7830,9 +7850,9 @@ impl TrtxConverter {
     }
 
     /// Add concatenation operation
-    fn add_concat_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_concat_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let inputs: Vec<&trtx::Tensor> = operation
@@ -7866,7 +7886,7 @@ impl TrtxConverter {
                 .unwrap_or(0),
         };
         let ndim = inputs[0]
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Concat: failed to get input dimensions: {}", e),
@@ -7877,16 +7897,11 @@ impl TrtxConverter {
             axis_i32 += ndim;
         }
         axis_i32 = axis_i32.max(0).min(ndim.saturating_sub(1));
-        layer
-            .set_axis(axis_i32)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set concat axis {}: {}", axis_i32, e),
-            })?;
+        layer.set_axis(network, axis_i32);
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7904,10 +7919,10 @@ impl TrtxConverter {
     }
 
     /// Add transpose operation using shuffle layer
-    fn add_transpose_op(
-        _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_transpose_op<'network>(
+        _graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -7918,7 +7933,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Transpose: failed to get input dimensions: {}", e),
@@ -7952,14 +7967,14 @@ impl TrtxConverter {
             })?;
 
         layer
-            .set_first_transpose(&perm)
+            .set_first_transpose(network, &perm)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set transpose permutation: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7972,10 +7987,10 @@ impl TrtxConverter {
     }
 
     /// Add reshape operation using shuffle layer
-    fn add_reshape_op(
-        _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reshape_op<'network>(
+        _graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -8001,9 +8016,9 @@ impl TrtxConverter {
             });
         }
 
-        let dims: Vec<i32> = crate::operator_options::mldimensions_static_or_max(new_shape)
+        let dims: Vec<i64> = crate::operator_options::mldimensions_static_or_max(new_shape)
             .into_iter()
-            .map(|u| u as i32)
+            .map(|u| u as i64)
             .collect();
 
         // Use shuffle layer for reshape
@@ -8016,7 +8031,7 @@ impl TrtxConverter {
 
         // Set the reshape dimensions
         layer
-            .set_reshape_dimensions(&dims)
+            .set_reshape_dimensions(network, &dims)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape dimensions: {}", e),
@@ -8024,7 +8039,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -8037,9 +8052,9 @@ impl TrtxConverter {
     }
 
     /// Add resample2d operation (resize/interpolate 2D tensor)
-    fn add_resample2d_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_resample2d_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -8069,11 +8084,7 @@ impl TrtxConverter {
             .attributes()
             .get("sizes")
             .and_then(|v| v.as_array().cloned())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_i64().map(|i| i as i32))
-                    .collect::<Vec<i32>>()
-            })
+            .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect::<Vec<i64>>())
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: "Missing sizes attribute for resample2d".to_string(),
@@ -8104,23 +8115,13 @@ impl TrtxConverter {
         let output_dims = vec![1, 1, sizes[0], sizes[1]]; // Placeholder: [N=1, C=1, H, W]
 
         // Set output dimensions
-        layer
-            .set_output_dimensions(&output_dims)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set resize output dimensions: {}", e),
-            })?;
+        layer.set_output_dimensions(network, &output_dims);
 
         // Set resize mode (uses ResizeMode typedef for InterpolationMode)
-        layer
-            .set_resize_mode(resize_mode)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set resize mode: {}", e),
-            })?;
+        layer.set_resize_mode(network, resize_mode);
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get resize output: {}", e),
@@ -8137,9 +8138,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add isNaN operation (check if value is NaN using x != x)
-    fn add_is_nan_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_is_nan_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8151,34 +8152,47 @@ impl TrtxConverter {
 
         // NaN is the only value where x != x is true
         // Use elementwise EQUAL operation with itself, then negate
+        let mut input_copy = network
+            .add_identity(input_tensor)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add identity for isNaN: {}", e),
+            })?
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get identity output for isNaN: {}", e),
+            })?;
         let layer = network
-            .add_elementwise(input_tensor, input_tensor, ElementWiseOperation::kEQUAL)
+            .add_elementwise(input_tensor, &mut input_copy, ElementWiseOperation::kEQUAL)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create EQUAL layer for isNaN: {}", e),
             })?;
 
-        let equal_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get EQUAL output: {}", e),
-            })?;
+        let mut equal_output =
+            layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get EQUAL output: {}", e),
+                })?;
 
         // Negate the result (isNaN = NOT(x == x))
         let not_layer = network
-            .add_unary(&equal_output, UnaryOperation::kNOT)
+            .add_unary(&mut equal_output, UnaryOperation::kNOT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create NOT layer for isNaN: {}", e),
             })?;
 
-        let bool_output = not_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get isNaN output: {}", e),
-            })?;
+        let bool_output =
+            not_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get isNaN output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -8190,11 +8204,10 @@ impl TrtxConverter {
     }
 
     /// Add isInfinite operation (check if value is infinite)
-    fn add_is_infinite_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_is_infinite_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8206,35 +8219,34 @@ impl TrtxConverter {
         // Check if abs(x) == infinity
         // First compute abs(x)
         let abs_layer = network
-            .add_unary(input_tensor, UnaryOperation::kABS)
+            .add_unary(input_tensor, UnaryOperation::kABS.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ABS layer for isInfinite: {}", e),
             })?;
 
-        let abs_output = abs_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get ABS output: {}", e),
-            })?;
+        let abs_output =
+            abs_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get ABS output: {}", e),
+                })?;
 
-        // Create constant for infinity
-        temp_weights.push(f32::INFINITY.to_le_bytes().to_vec());
-        let inf_data = temp_weights.last().unwrap();
         let inf_constant = network
-            .add_constant(&[1], inf_data, TrtDataType::kFLOAT)
+            .add_small_constant_copied(&[1], &f32::INFINITY.to_le_bytes(), TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create infinity constant: {}", e),
             })?;
 
-        let inf_tensor = inf_constant
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get infinity tensor: {}", e),
-            })?;
+        let inf_tensor =
+            inf_constant
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get infinity tensor: {}", e),
+                })?;
 
         // Compare abs(x) == infinity
         let equal_layer = network
@@ -8244,12 +8256,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create EQUAL layer for isInfinite: {}", e),
             })?;
 
-        let bool_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get isInfinite output: {}", e),
-            })?;
+        let bool_output =
+            equal_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get isInfinite output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -8261,9 +8274,9 @@ impl TrtxConverter {
     }
 
     /// Add roundEven operation (round to nearest even integer, banker's rounding)
-    fn add_round_even_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_round_even_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8275,14 +8288,14 @@ impl TrtxConverter {
 
         // TensorRT's kROUND already uses round-to-nearest-even (banker's rounding) by default
         let layer = network
-            .add_unary(input_tensor, UnaryOperation::kROUND)
+            .add_unary(input_tensor, UnaryOperation::kROUND.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ROUND layer: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get roundEven output: {}", e),
@@ -8295,27 +8308,28 @@ impl TrtxConverter {
     }
 
     /// Add gatherElements operation (gather using index tensor along axis)
-    fn add_gather_elements_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_gather_elements_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let data_tensor = tensor_map
-            .get(&operation.input_operands()[0])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Data operand {} not found", operation.input_operands()[0]),
-            })?;
+        let data_id = operation.input_operands()[0];
+        let indices_id = operation.input_operands()[1];
+        let mut data_tensor =
+            tensor_map
+                .remove(&data_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Data operand {} not found", data_id),
+                })?;
 
-        let indices_tensor = tensor_map
-            .get(&operation.input_operands()[1])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!(
-                    "Indices operand {} not found",
-                    operation.input_operands()[1]
-                ),
-            })?;
+        let mut indices_tensor =
+            tensor_map
+                .remove(&indices_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Indices operand {} not found", indices_id),
+                })?;
 
         // Get axis parameter (default to 0)
         let axis = operation
@@ -8326,22 +8340,17 @@ impl TrtxConverter {
 
         // Create gather layer with ELEMENT mode
         let mut layer = network
-            .add_gather(data_tensor, indices_tensor, axis)
+            .add_gather(&mut data_tensor, &mut indices_tensor, axis)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create gather layer: {}", e),
             })?;
 
         // Set gather mode to ELEMENT
-        layer
-            .set_gather_mode(trtx::GatherMode::kELEMENT)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set gather mode: {}", e),
-            })?;
+        layer.set_gather_mode(network, trtx::GatherMode::kELEMENT);
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherElements output: {}", e),
@@ -8354,9 +8363,9 @@ impl TrtxConverter {
     }
 
     /// Add l2Pool2d operation (L2 pooling: square → avgPool → sqrt)
-    fn add_l2_pool2d_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_l2_pool2d_op<'network>(
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8367,19 +8376,31 @@ impl TrtxConverter {
             })?;
 
         // Step 1: Square the input (x^2)
+        let mut input_copy = network
+            .add_identity(input_tensor)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add identity for l2Pool2d square: {}", e),
+            })?
+            .get_output(network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get identity output for l2Pool2d: {}", e),
+            })?;
         let square_layer = network
-            .add_elementwise(input_tensor, input_tensor, ElementWiseOperation::kPROD)
+            .add_elementwise(input_tensor, &mut input_copy, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create square layer for l2Pool2d: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get squared output: {}", e),
-            })?;
+        let mut squared =
+            square_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get squared output: {}", e),
+                })?;
 
         // Step 2: Apply average pooling (use same parameters as maxPool2d/averagePool2d)
         let window_size = operation
@@ -8391,39 +8412,41 @@ impl TrtxConverter {
                 reason: "Missing windowDimensions for l2Pool2d".to_string(),
             })?;
 
-        let window: [i32; 2] = [
-            window_size[0].as_i64().unwrap_or(1) as i32,
-            window_size[1].as_i64().unwrap_or(1) as i32,
+        let window: [i64; 2] = [
+            window_size[0].as_i64().unwrap_or(1),
+            window_size[1].as_i64().unwrap_or(1),
         ];
 
         let pool_layer = network
-            .add_pooling(&squared, PoolingType::kAVERAGE, &window)
+            .add_pooling(&mut squared, PoolingType::kAVERAGE, &window)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
             })?;
 
-        let pooled = pool_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get pooled output: {}", e),
-            })?;
+        let mut pooled =
+            pool_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get pooled output: {}", e),
+                })?;
 
         // Step 3: Take square root
         let sqrt_layer = network
-            .add_unary(&pooled, UnaryOperation::kSQRT)
+            .add_unary(&mut pooled, UnaryOperation::kSQRT.into())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create sqrt layer for l2Pool2d: {}", e),
             })?;
 
-        let output = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get l2Pool2d output: {}", e),
-            })?;
+        let output =
+            sqrt_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get l2Pool2d output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -8433,10 +8456,10 @@ impl TrtxConverter {
 
     /// Add reverse operation (reverse elements along axes) - PLACEHOLDER
     /// Add reverse operation (reverse elements along axes using negative stride slicing)
-    fn add_reverse_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reverse_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &'_ mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8469,12 +8492,12 @@ impl TrtxConverter {
         //   size = n (number of elements)
         //   stride = -1
         //   end_idx should be = (n-1) + (n-1)*(-1) = (n-1) - (n-1) = 0 ✓
-        let mut starts: Vec<i32> = vec![0; rank];
-        let sizes: Vec<i32> = shape
+        let mut starts: Vec<i64> = vec![0; rank];
+        let sizes: Vec<i64> = shape
             .iter()
-            .map(|s| get_static_or_max_size(s) as i32)
+            .map(|s| get_static_or_max_size(s) as i64)
             .collect();
-        let mut strides: Vec<i32> = vec![1; rank];
+        let mut strides: Vec<i64> = vec![1; rank];
 
         for &axis in &axes_to_reverse {
             if axis >= rank {
@@ -8490,7 +8513,7 @@ impl TrtxConverter {
             // TensorRT will compute: indices = start + i*stride for i in 0..size
             // So: indices = (size-1) + i*(-1) = (size-1) - i
             // For i=0: size-1, i=1: size-2, ..., i=size-1: 0 ✓
-            starts[axis] = (get_static_or_max_size(&shape[axis]) - 1) as i32;
+            starts[axis] = (get_static_or_max_size(&shape[axis]) - 1) as i64;
             strides[axis] = -1;
         }
 
@@ -8502,7 +8525,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get reverse output: {}", e),
@@ -8518,12 +8541,11 @@ impl TrtxConverter {
     /// Add cumulativeSum operation using explicit slice-and-add decomposition
     ///
     /// Uses TensorRT's native ICumulativeLayer for efficient implementation.
-    fn add_cumulative_sum_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_cumulative_sum_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8552,25 +8574,20 @@ impl TrtxConverter {
             });
         }
 
-        // Create axis constant with proper lifetime management
-        // Store bytes in temp_weights to keep them alive until engine is built
         let axis_value = axis as i32;
-        let axis_bytes: Vec<u8> = axis_value.to_le_bytes().to_vec();
-        temp_weights.push(axis_bytes);
-        let axis_bytes_ref = temp_weights.last().unwrap();
 
         // Create axis constant tensor (true 0D scalar with shape [])
         // TensorRT requires axisDims.nbDims == 0 for cumulative operations
         let axis_constant = network
-            .add_constant(&[], axis_bytes_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&[], &axis_value.to_le_bytes(), trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create axis constant: {}", e),
             })?;
 
-        let axis_tensor =
+        let mut axis_tensor =
             axis_constant
-                .get_output(0)
+                .get_output(&network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get axis constant output: {}", e),
@@ -8580,7 +8597,7 @@ impl TrtxConverter {
         let layer = network
             .add_cumulative_with_axis_tensor(
                 input_tensor,
-                &axis_tensor,
+                &mut axis_tensor,
                 trtx::CumulativeOperation::kSUM,
                 exclusive,
                 reverse,
@@ -8591,7 +8608,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cumulative sum output: {}", e),
@@ -8605,12 +8622,12 @@ impl TrtxConverter {
 
     /// Add triangular operation (extract triangular part of matrix) - PLACEHOLDER
     /// Add triangular operation (extract upper/lower triangular part with masking)
-    fn add_triangular_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_triangular_op<'network>(
+        graph: &'network GraphInfo,
+        network: &'_ mut trtx::NetworkDefinition<'network>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        temp_weights: &'network mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8676,9 +8693,9 @@ impl TrtxConverter {
         let mask_bytes_ref = temp_weights.last().unwrap();
 
         // Create constant layer with the mask
-        let dims: Vec<i32> = shape
+        let dims: Vec<i64> = shape
             .iter()
-            .map(|s| get_static_or_max_size(s) as i32)
+            .map(|s| get_static_or_max_size(s) as i64)
             .collect();
         let mask_layer = network
             .add_constant(&dims, mask_bytes_ref, trtx::DataType::kFLOAT)
@@ -8687,27 +8704,29 @@ impl TrtxConverter {
                 reason: format!("Failed to add constant mask for triangular: {}", e),
             })?;
 
-        let mask_tensor = mask_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get mask tensor: {}", e),
-            })?;
+        let mut mask_tensor =
+            mask_layer
+                .get_output(network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mask tensor: {}", e),
+                })?;
 
         // Multiply input by mask (elementwise)
         let multiply_layer = network
-            .add_elementwise(input_tensor, &mask_tensor, ElementWiseOperation::kPROD)
+            .add_elementwise(input_tensor, &mut mask_tensor, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elementwise multiply for triangular: {}", e),
             })?;
 
-        let output = multiply_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get triangular output: {}", e),
-            })?;
+        let output =
+            multiply_layer
+                .get_output(&network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get triangular output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -8753,10 +8772,11 @@ impl GraphConverter for TrtxConverter {
             reason: format!("Failed to create TensorRT logger: {}", e),
         })?;
 
-        let builder = trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Failed to create TensorRT builder: {}", e),
-        })?;
+        let mut builder =
+            trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to create TensorRT builder: {}", e),
+            })?;
 
         let mut network = builder
             .create_network(trtx::builder::network_flags::EXPLICIT_BATCH)
@@ -8778,12 +8798,7 @@ impl GraphConverter for TrtxConverter {
             })?;
 
         // Set workspace size (1 GB)
-        config
-            .set_memory_pool_limit(trtx::builder::MemoryPoolType::Workspace, 1 << 30)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set workspace size: {}", e),
-            })?;
+        config.set_memory_pool_limit(trtx::builder::MemoryPoolType::kWORKSPACE, 1 << 30);
 
         // Build and serialize the engine
         let engine_data = builder
@@ -8796,7 +8811,7 @@ impl GraphConverter for TrtxConverter {
         Ok(ConvertedGraph {
             format: "trtx",
             content_type: "application/x-tensorrt-engine",
-            data: engine_data,
+            data: engine_data.to_vec(),
             weights_data: None,
         })
     }

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -3355,6 +3355,12 @@ impl TrtxConverter {
                 reason: format!("Failed to get input shape: {}", e),
             })?;
 
+        // Scale and bias are in MLLayerNormalizationOptions, not in input_operands() (legacy list is [input] only).
+        let attrs = operation.attributes();
+        let opts_ln = attrs.as_layer_normalization();
+        let scale_id = opts_ln.and_then(|o| o.scale);
+        let bias_id = opts_ln.and_then(|o| o.bias);
+
         // TensorRT Reduce requires at least 1 dimension. For 0D scalar: mean=x, variance=0, output = 0*scale + bias = bias or 0.
         if input_dims.is_empty() {
             let input_operand = graph
@@ -3386,15 +3392,38 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: zero const output: {}", e),
                     })?;
-            // Optional operands are [scale?, bias?]; bias is last when present. So len>=2 => add last (bias when only bias, or bias when scale+bias).
-            if operation.input_operands().len() >= 2 {
-                let bias_id = operation.input_operands()[operation.input_operands().len() - 1];
+            if let Some(sid) = scale_id {
+                let scale = tensor_map.get(&sid).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("LayerNorm 0D: scale operand {} not found", sid),
+                })?;
+                let (lhs, rhs) = Self::ensure_broadcast_compatible(
+                    network,
+                    &result,
+                    scale,
+                    "layer_norm_0d_scale",
+                )?;
+                let mul_layer = network
+                    .add_elementwise(&lhs, &rhs, ElementWiseOperation::kPROD)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm 0D: failed to multiply by scale: {}", e),
+                    })?;
+                result =
+                    mul_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm 0D: scale mul output: {}", e),
+                        })?;
+            }
+            if let Some(bid) = bias_id {
                 let bias =
                     tensor_map
-                        .get(&bias_id)
+                        .get(&bid)
                         .ok_or_else(|| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
-                            reason: format!("Bias operand {} not found", bias_id),
+                            reason: format!("LayerNorm 0D: bias operand {} not found", bid),
                         })?;
                 // Bias may be scalar; broadcast to result shape [1] so ElementWise accepts same dims.
                 let mut bias_shuffle =
@@ -3437,10 +3466,8 @@ impl TrtxConverter {
 
         // Get epsilon and axes from typed options. Spec: when axes not present, axes = [1..rank) if rank > 1 else [].
         // Option<axes>: None = key omitted => default; Some(v) = use v (Some([]) = explicit no reduction).
-        let attrs = operation.attributes();
-        let opts = attrs.as_layer_normalization();
-        let _epsilon = opts.map(|o| o.epsilon as f32).unwrap_or(1e-5);
-        let axes: Vec<u32> = opts.and_then(|o| o.axes.clone()).unwrap_or_else(|| {
+        let _epsilon = opts_ln.map(|o| o.epsilon as f32).unwrap_or(1e-5);
+        let axes: Vec<u32> = opts_ln.and_then(|o| o.axes.clone()).unwrap_or_else(|| {
             if input_dims.len() > 1 {
                 (1..input_dims.len()).map(|i| i as u32).collect()
             } else {
@@ -3488,19 +3515,42 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: zero const output: {}", e),
                     })?;
-            // Optional operands are [scale?, bias?]; bias is last when present.
-            if operation.input_operands().len() >= 2 {
-                let bias_id = operation.input_operands()[operation.input_operands().len() - 1];
+            if let Some(sid) = scale_id {
+                let scale = tensor_map.get(&sid).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("LayerNorm axes=[]: scale operand {} not found", sid),
+                })?;
+                let (lhs, rhs) = Self::ensure_broadcast_compatible(
+                    network,
+                    &result,
+                    scale,
+                    "layer_norm_axes_empty_scale",
+                )?;
+                let mul_layer = network
+                    .add_elementwise(&lhs, &rhs, ElementWiseOperation::kPROD)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm axes=[]: failed to multiply by scale: {}", e),
+                    })?;
+                result =
+                    mul_layer
+                        .get_output(network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: scale mul output: {}", e),
+                        })?;
+            }
+            if let Some(bid) = bias_id {
                 let bias =
                     tensor_map
-                        .get(&bias_id)
+                        .get(&bid)
                         .ok_or_else(|| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
-                            reason: format!("Bias operand {} not found", bias_id),
+                            reason: format!("LayerNorm axes=[]: bias operand {} not found", bid),
                         })?;
-                let bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bias_id) {
+                let bias_bc = if graph.constant_operand_ids_to_handles.contains_key(&bid) {
                     // Shuffle cannot change volume. Broadcast by creating a constant filled with the bias value.
-                    let bias_data = Self::get_constant_data(graph, bias_id)?;
+                    let bias_data = Self::get_constant_data(graph, bid)?;
                     let bias_broadcast_bytes: Vec<u8> = match input_operand.descriptor.data_type {
                         DataType::Float16 => {
                             let bits =
@@ -3853,75 +3903,39 @@ impl TrtxConverter {
                     })
             };
 
-        // Optional operands are [scale?, bias?] in that order. When len() == 2, the single optional may be scale or bias; use name to distinguish.
-        if operation.input_operands().len() > 1 {
-            let opt_id_1 = operation.input_operands()[1];
-            let opt_1 = tensor_map
-                .get(&opt_id_1)
-                .ok_or_else(|| GraphError::ConversionFailed {
+        // Scale and bias operand IDs come from options (see top of this function).
+        if let Some(sid) = scale_id {
+            let scale = tensor_map.get(&sid).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("LayerNorm: scale operand {} not found", sid),
+            })?;
+            let scale_bc = reshape_scale_bias_to_result_rank(network, scale, &result, "scale", &axes)?;
+            let mul_layer = network
+                .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("LayerNorm optional operand {} not found", opt_id_1),
+                    reason: format!("Failed to add scale: {}", e),
                 })?;
-            let name_1 = graph
-                .operand(opt_id_1)
-                .and_then(|o| o.name.as_deref())
-                .unwrap_or("");
-            let is_bias_1 = name_1.to_lowercase().contains("bias");
-            let opt_1_bc = reshape_scale_bias_to_result_rank(
-                network,
-                opt_1,
-                &result,
-                if is_bias_1 { "bias" } else { "scale" },
-                &axes,
-            )?;
-            if is_bias_1 {
-                let add_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kSUM)
+            result =
+                mul_layer
+                    .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Failed to add bias: {}", e),
+                        reason: format!("Failed to get mul output: {}", e),
                     })?;
-                result =
-                    add_layer
-                        .get_output(network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get add output: {}", e),
-                        })?;
-            } else {
-                let mul_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kPROD)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add scale: {}", e),
-                    })?;
-                result =
-                    mul_layer
-                        .get_output(network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get mul output: {}", e),
-                        })?;
-            }
         }
-
-        // Second optional (when len() == 3) is always bias
-        if operation.input_operands().len() > 2 {
-            let bias = tensor_map
-                .get(&operation.input_operands()[2])
-                .ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Bias operand {} not found", operation.input_operands()[2]),
-                })?;
+        if let Some(bid) = bias_id {
+            let bias = tensor_map.get(&bid).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("LayerNorm: bias operand {} not found", bid),
+            })?;
             let bias_bc = reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
-
             let add_layer = network
                 .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
                 })?;
-
             result =
                 add_layer
                     .get_output(network, 0)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -5369,7 +5369,7 @@ impl TrtxConverter {
                 ),
             });
         }
-        let dim_size = get_static_or_max_size(&data_operand.descriptor.shape[axis_usize]) as i64;
+        let dim_size = get_static_or_max_size(&data_operand.descriptor.shape[axis_usize]) as i32;
 
         let indices_operand = graph
             .operand(operation.input_operands()[1])
@@ -6150,7 +6150,7 @@ impl TrtxConverter {
 
             // Multiply: alpha * x
             let mul_layer = network
-                .add_elementwise(input, alpha_tensor, ElementWiseOperation::kPROD)
+                .add_elementwise(input, &alpha_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to multiply by alpha: {}", e),
@@ -6579,7 +6579,7 @@ impl TrtxConverter {
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let mut alpha_tensor =
+            let alpha_tensor =
                 alpha_layer
                     .get_output(network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -6863,7 +6863,7 @@ impl TrtxConverter {
                     })?;
             shuffle
                 .set_first_transpose(network, &[0, 3, 1, 2])
-                .with_context("Failed to set shuffle for conv2d output");
+                .with_context("Failed to set shuffle for conv2d output")?;
             Some(
                 shuffle
                     .get_output(network, 0)
@@ -7042,9 +7042,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add convolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(network, 1, filter_tensor_to_use);
+                layer
+                    .set_input(network, 1, filter_tensor_to_use)
+                    .with_context("while setting kernel for conv2d")?;
                 if let Some(bt) = bias_tensor_to_use {
-                    layer.set_input(network, 2, bt);
+                    layer
+                        .set_input(network, 2, bt)
+                        .with_context("while setting bias for conv2d")?;
                 }
                 layer
             }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -212,10 +212,10 @@ fn execute_trtx_engine(
 ) -> Result<Vec<TrtxOutputWithData>, trtx::Error> {
     // Create logger and runtime
     let logger = create_trtx_logger().map_err(|e| trtx::Error::Runtime(e.to_string()))?;
-    let runtime = trtx::Runtime::new(&logger)?;
+    let mut runtime = trtx::Runtime::new(&logger)?;
 
     // Deserialize engine
-    let engine = runtime.deserialize_cuda_engine(engine_bytes)?;
+    let mut engine = runtime.deserialize_cuda_engine(engine_bytes)?;
     let mut context = engine.create_execution_context()?;
 
     // Get tensor information

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -130,11 +130,10 @@ impl OperationExtras {
             }
             "expand" => {
                 let _ = obj.remove("axes");
-                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape"))
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
                         out.expand_new_shape = parsed;
                     }
-                }
             }
             "cumulativeSum" => {
                 out.axis = remove_u32(obj, "axis");
@@ -180,11 +179,10 @@ impl OperationExtras {
             }
             "slice" => {
                 out.starts = remove_u32_vec(obj, "starts");
-                if let Some(s) = obj.remove("sizes") {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                if let Some(s) = obj.remove("sizes")
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
                         out.sizes = parsed;
                     }
-                }
             }
             "split" => {
                 if let Some(sv) = obj.remove("splits") {
@@ -205,11 +203,10 @@ impl OperationExtras {
                 out.repetitions = remove_u32_vec(obj, "repetitions");
             }
             "reshape" => {
-                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape"))
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
                         out.reshape_new_shape = parsed;
                     }
-                }
             }
             _ => {}
         }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1291,11 +1291,10 @@ impl Operation {
             Operation::ArgMin { axis, .. } | Operation::ArgMax { axis, .. } => {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
-            Operation::Cast { to, .. } => {
-                if !to.is_empty() {
+            Operation::Cast { to, .. }
+                if !to.is_empty() => {
                     obj.insert("to".to_string(), serde_json::Value::String(to.clone()));
                 }
-            }
             Operation::CumulativeSum { axis, .. } => {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
@@ -1303,11 +1302,10 @@ impl Operation {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
             Operation::Expand { new_shape, .. } => {
-                if !new_shape.is_empty() {
-                    if let Ok(v) = serde_json::to_value(new_shape) {
+                if !new_shape.is_empty()
+                    && let Ok(v) = serde_json::to_value(new_shape) {
                         obj.insert("newShape".to_string(), v);
                     }
-                }
             }
             Operation::Gather {
                 batch_dimensions, ..
@@ -1360,17 +1358,15 @@ impl Operation {
                     obj.insert("splits".to_string(), serde_json::json!(splits));
                 }
             }
-            Operation::Tile { repetitions, .. } => {
-                if !repetitions.is_empty() {
+            Operation::Tile { repetitions, .. }
+                if !repetitions.is_empty() => {
                     obj.insert("repetitions".to_string(), serde_json::json!(repetitions));
                 }
-            }
             Operation::Reshape { new_shape, .. } => {
-                if !new_shape.is_empty() {
-                    if let Ok(val) = serde_json::to_value(new_shape) {
+                if !new_shape.is_empty()
+                    && let Ok(val) = serde_json::to_value(new_shape) {
                         obj.insert("newShape".to_string(), val);
                     }
-                }
             }
             _ => {}
         }

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -775,9 +775,10 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     if let Some(input_shape) = input_shapes.first() {
                         match &op {
                             Operation::Slice { starts, sizes, .. } => {
-                                if starts.is_empty() || sizes.is_empty() {
-                                    None
-                                } else if starts.len() != sizes.len() {
+                                if starts.is_empty()
+                                    || sizes.is_empty()
+                                    || starts.len() != sizes.len()
+                                {
                                     None
                                 } else {
                                     let mut output = input_shape.clone();
@@ -797,13 +798,9 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                 }
 
                 // Shape
-                "shape" => {
-                    if let Some(input_shape) = input_shapes.first() {
-                        Some(vec![Dimension::Static(input_shape.len() as u32)])
-                    } else {
-                        None
-                    }
-                }
+                "shape" => input_shapes
+                    .first()
+                    .map(|input_shape| vec![Dimension::Static(input_shape.len() as u32)]),
 
                 // Constant: shape from operator options
                 "constant" => match &op {

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -1585,11 +1585,12 @@ mod tests {
         // HardSwish: x * hardSigmoid(x)
         let graph = create_unary_graph("hardSwish", vec![4], DataType::Float32);
         let input = vec![-3.0, 0.0, 1.0, 3.0];
+        //x * max(0, min(6, (x + 3))) / 6
         // -3: -3 * 0 = 0
         //  0:  0 * 0.5 = 0
-        //  1:  1 * 0.7 = 0.7
+        //  1:  1 * (1+3) / 6 = 4/6 = 2/3
         //  3:  3 * 1.0 = 3.0
-        let expected = vec![0.0, 0.0, 0.7, 3.0];
+        let expected = vec![0.0, 0.0, 2.0 / 3.0, 3.0];
 
         let output = execute_graph(&graph, &input).expect("Execution failed");
         verify_output(&output, &expected, 1e-3); // Slightly higher tolerance for composite op

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -11,6 +11,7 @@ mod tests {
     use rustnn::converters::{GraphConverter, TrtxConverter};
     use rustnn::graph::{
         ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
+        get_static_or_max_size, to_dimension_vector,
     };
     use rustnn::operator_options::MLConv2dOptions;
     use rustnn::operators::Operation;
@@ -57,7 +58,7 @@ mod tests {
     fn create_unary_graph(op_type: &str, input_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -101,13 +102,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -144,7 +145,7 @@ mod tests {
     fn create_binary_graph(op_type: &str, input_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -196,8 +197,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -215,7 +216,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers
@@ -280,8 +281,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -298,7 +299,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers
@@ -353,8 +354,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -385,7 +386,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers for all inputs
@@ -836,13 +837,13 @@ mod tests {
     fn create_matmul_graph(a_shape: Vec<u32>, b_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let a_desc = OperandDescriptor {
             data_type,
-            shape: a_shape.clone(),
+            shape: to_dimension_vector(&a_shape),
             pending_permutation: Vec::new(),
         };
 
         let b_desc = OperandDescriptor {
             data_type,
-            shape: b_shape.clone(),
+            shape: to_dimension_vector(&b_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -855,7 +856,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -905,8 +906,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -927,7 +928,7 @@ mod tests {
             let a_shape = &graph.operands[0].descriptor.shape;
             let b_shape = &graph.operands[1].descriptor.shape;
             if a_shape.len() == 2 && b_shape.len() == 2 {
-                (a_shape[0] * b_shape[1]) as usize * std::mem::size_of::<f32>()
+                (get_static_or_max_size(&a_shape[0]) * get_static_or_max_size(&b_shape[1])) as usize * std::mem::size_of::<f32>()
             } else {
                 input_a_size // Fallback
             }
@@ -1048,19 +1049,19 @@ mod tests {
     ) -> GraphInfo {
         let a_desc = OperandDescriptor {
             data_type,
-            shape: a_shape.clone(),
+            shape: to_dimension_vector(&a_shape),
             pending_permutation: Vec::new(),
         };
 
         let b_desc = OperandDescriptor {
             data_type,
-            shape: b_shape.clone(),
+            shape: to_dimension_vector(&b_shape),
             pending_permutation: Vec::new(),
         };
 
         let c_desc = OperandDescriptor {
             data_type,
-            shape: c_shape.clone(),
+            shape: to_dimension_vector(&c_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1124,8 +1125,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -1299,13 +1300,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let filter_desc = OperandDescriptor {
             data_type,
-            shape: filter_shape.clone(),
+            shape: to_dimension_vector(&filter_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1317,7 +1318,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1351,7 +1352,7 @@ mod tests {
         if let Some(bias) = bias_data {
             let bias_desc = OperandDescriptor {
                 data_type,
-                shape: vec![filter_shape[0]], // bias shape = [out_channels]
+                shape: to_dimension_vector(&[filter_shape[0]]), // bias shape = [out_channels]
                 pending_permutation: Vec::new(),
             };
 
@@ -1500,13 +1501,13 @@ mod tests {
         // Create graph with slope constant
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![4],
+            shape: to_dimension_vector(&[4]),
             pending_permutation: Vec::new(),
         };
 
         let slope_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1],
+            shape: to_dimension_vector(&[1]),
             pending_permutation: Vec::new(),
         };
 
@@ -1628,13 +1629,13 @@ mod tests {
 
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Output: [1, 2, 1, 1]
+            shape: to_dimension_vector(&[1, 2, 1, 1]),
             pending_permutation: Vec::new(),
         };
 
@@ -1683,13 +1684,13 @@ mod tests {
 
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Output: [1, 2, 1, 1]
+            shape: to_dimension_vector(&[1, 2, 1, 1]),
             pending_permutation: Vec::new(),
         };
 
@@ -1745,13 +1746,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2066,19 +2067,19 @@ mod tests {
         // So we use [1, 2, 1, 1] instead of [2]
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 2],
+            shape: to_dimension_vector(&[1, 2, 1, 2]),
             pending_permutation: Vec::new(),
         };
 
         let stats_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Reshaped for broadcasting
+            shape: to_dimension_vector(&[1, 2, 1, 1]),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 2],
+            shape: to_dimension_vector(&[1, 2, 1, 2]),
             pending_permutation: Vec::new(),
         };
 
@@ -2145,13 +2146,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2230,13 +2231,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2310,13 +2311,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2431,13 +2432,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2492,13 +2493,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2560,13 +2561,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2638,13 +2639,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2848,19 +2849,19 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let indices_desc = OperandDescriptor {
             data_type: DataType::Int32,
-            shape: indices_shape,
+            shape: to_dimension_vector(&indices_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2930,13 +2931,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Int32,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -3038,7 +3039,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![8],
+                        shape: to_dimension_vector(&[8]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3047,7 +3048,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![8],
+                        shape: to_dimension_vector(&[8]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3095,7 +3096,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3104,7 +3105,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3146,7 +3147,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("condition".to_string()),
@@ -3155,7 +3156,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("true_value".to_string()),
@@ -3164,7 +3165,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("false_value".to_string()),
@@ -3173,7 +3174,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3221,7 +3222,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3230,7 +3231,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3276,7 +3277,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3285,7 +3286,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3329,7 +3330,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3338,7 +3339,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3379,7 +3380,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3388,7 +3389,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3435,7 +3436,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3444,7 +3445,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3496,7 +3497,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3505,7 +3506,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![7],
+                        shape: to_dimension_vector(&[7]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3547,7 +3548,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3556,7 +3557,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3565,7 +3566,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3620,7 +3621,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3629,7 +3630,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 4, 4],
+                        shape: to_dimension_vector(&[1, 1, 4, 4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3722,7 +3723,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3731,7 +3732,7 @@ mod tests {
                     kind: OperandKind::Constant,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("kernel".to_string()),
@@ -3740,7 +3741,7 @@ mod tests {
                     kind: OperandKind::Constant,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("bias".to_string()),
@@ -3749,7 +3750,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 3, 3],
+                        shape: to_dimension_vector(&[1, 1, 3, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3802,7 +3803,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3811,7 +3812,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3820,7 +3821,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("updates".to_string()),
@@ -3829,7 +3830,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3875,7 +3876,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3884,7 +3885,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3893,7 +3894,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("updates".to_string()),
@@ -3902,7 +3903,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3965,7 +3966,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3974,7 +3975,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("quant_scale".to_string()),
@@ -3983,7 +3984,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int8,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("quantized".to_string()),
@@ -3992,7 +3993,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("dequant_scale".to_string()),
@@ -4001,7 +4002,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("dequantized".to_string()),
@@ -4010,7 +4011,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("add_constant".to_string()),
@@ -4019,7 +4020,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4064,7 +4065,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4073,7 +4074,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4113,7 +4114,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4122,7 +4123,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4161,7 +4162,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4170,7 +4171,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4217,7 +4218,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -4226,7 +4227,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -4235,7 +4236,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4280,7 +4281,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4289,7 +4290,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 1, 1],
+                        shape: to_dimension_vector(&[1, 1, 1, 1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4331,7 +4332,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4340,7 +4341,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4383,7 +4384,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4392,7 +4393,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4433,7 +4434,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4442,7 +4443,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4490,7 +4491,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4499,7 +4500,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![6],
+                        shape: to_dimension_vector(&[6]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4539,13 +4540,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let filter_desc = OperandDescriptor {
             data_type,
-            shape: filter_shape.clone(),
+            shape: to_dimension_vector(&filter_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -4569,7 +4570,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -4603,7 +4604,7 @@ mod tests {
         if let Some(bias) = bias_data {
             let bias_desc = OperandDescriptor {
                 data_type,
-                shape: vec![filter_shape[0]], // bias shape = [out_channels]
+                shape: to_dimension_vector(&[filter_shape[0]]), // bias shape = [out_channels]
                 pending_permutation: Vec::new(),
             };
 
@@ -4857,7 +4858,7 @@ mod tests {
         // Operand layout: [0]=input, [1]=filter, [2]=output (no bias)
         assert_eq!(
             graph_same.operands[2].descriptor.shape,
-            vec![1, 1, 218, 218]
+            to_dimension_vector(&[1, 1, 218, 218])
         );
 
         // Branch 2: Valid padding shrinks by 2 per dimension
@@ -4875,7 +4876,7 @@ mod tests {
         // Operand layout: [0]=input, [1]=filter, [2]=output (no bias)
         assert_eq!(
             graph_valid.operands[2].descriptor.shape,
-            vec![1, 1, 216, 216]
+            to_dimension_vector(&[1, 1, 216, 216])
         );
 
         // This test documents the root cause of MobileNetV2 dimension mismatch:


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

   Test API changes in https://github.com/rustnn/trtx-rs/pull/28 . Main changes are
   - i64 for most API where TRT uses i64 (shapes, indices, padding)
   - Strong enum types where before i32 was used (e.g. `TopKOperation`)
   - lifetimes!
   - layer need to be mutable if mutable methods like `set_name` are used
   - most layer and tensor methods require a `&network`, `&mut network` parameter

## Validation

- [x] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

