### PR TITLE
OperatorOptions spec cleanup

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -28,6 +28,7 @@
 use crate::converters::operand_name;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension as GraphDimension, GraphInfo};
+use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use crate::protos::coreml::mil_spec::{
     Argument, Block, Dimension, Function, NamedValueType, Operation as MilOperation, Program,
@@ -1049,10 +1050,7 @@ impl CoremlMlProgramConverter {
                 Self::create_int_array_argument(split_sizes),
             );
         }
-        inputs.insert(
-            "axis".to_string(),
-            Self::create_int_argument(axis as i32),
-        );
+        inputs.insert("axis".to_string(), Self::create_int_argument(axis as i32));
 
         Ok(Self::create_mil_operation("split", inputs, outputs))
     }
@@ -1905,7 +1903,7 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::Concat { options, .. } => {
+            Operation::Concat { axis, .. } => {
                 // concat: values (variadic list of tensors), axis
                 // CoreML expects a single 'values' parameter containing a tuple of all inputs
                 if !input_names.is_empty() {
@@ -1915,9 +1913,7 @@ impl CoremlMlProgramConverter {
                     );
                 }
 
-                if let Some(opts) = options {
-                    inputs.insert("axis".to_string(), Self::create_immediate_int(opts.axis));
-                }
+                inputs.insert("axis".to_string(), Self::create_immediate_int(*axis));
                 inputs.insert("interleave".to_string(), Self::create_immediate_bool(false));
             }
 
@@ -1948,16 +1944,17 @@ impl CoremlMlProgramConverter {
                 let _ = options;
             }
 
-            Operation::Expand { options, .. } => {
+            Operation::Expand { new_shape, .. } => {
                 // CoreML tile operation requires input rank to match reps length
                 // If reshape was added before this operation, use reshaped input name
                 //  Otherwise use original input
 
-                if let Some(new_shape_u32) = options
-                    .as_ref()
-                    .map(|o| o.new_shape_static_or_max())
-                    .filter(|s| !s.is_empty())
-                {
+                if let Some(new_shape_u32) = (!new_shape.is_empty()).then(|| {
+                    new_shape
+                        .iter()
+                        .map(MLDimension::static_or_max)
+                        .collect::<Vec<u32>>()
+                }) {
                     // Get input operand shape
                     if !op.input_operands().is_empty()
                         && let Some(input_operand) = _graph.operand(op.input_operands()[0])
@@ -2049,9 +2046,7 @@ impl CoremlMlProgramConverter {
             }
 
             Operation::Split {
-                splits,
-                options,
-                ..
+                splits, options, ..
             } => {
                 // split: x, num_splits or split_sizes, axis
                 if !input_names.is_empty() {
@@ -2251,10 +2246,7 @@ impl CoremlMlProgramConverter {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                inputs.insert(
-                    "axis".to_string(),
-                    Self::create_int_argument(*axis as i32),
-                );
+                inputs.insert("axis".to_string(), Self::create_int_argument(*axis as i32));
                 if let Some(opts) = options {
                     inputs.insert(
                         "exclusive".to_string(),
@@ -2956,19 +2948,23 @@ impl super::GraphConverter for CoremlMlProgramConverter {
 
             // Special handling for expand operation (may need reshape first)
             if let Operation::Expand {
-                options: Some(opts),
+                new_shape: expand_shape,
                 ..
             } = &op
                 && !op.input_operands().is_empty()
+                && !expand_shape.is_empty()
                 && let Some(input_operand) = graph_info.operand(op.input_operands()[0])
             {
-                let new_shape = opts.new_shape_static_or_max();
+                let new_shape_u32: Vec<u32> = expand_shape
+                    .iter()
+                    .map(MLDimension::static_or_max)
+                    .collect();
                 let input_shape = input_operand.descriptor.static_or_max_shape();
                 let input_rank = input_shape.len();
-                let output_rank = new_shape.len();
+                let output_rank = new_shape_u32.len();
 
                 #[allow(clippy::collapsible_if)]
-                if !new_shape.is_empty() && input_rank < output_rank {
+                if input_rank < output_rank {
                     let mut reshaped_dims = vec![1u32; output_rank];
                     for i in 0..input_rank {
                         reshaped_dims[output_rank - i - 1] = input_shape[input_rank - i - 1];

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1489,14 +1489,14 @@ impl CoremlMlProgramConverter {
             }
 
             // Reshape: x, shape
-            Operation::Reshape { options, .. } => {
+            Operation::Reshape { new_shape, .. } => {
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                // Add shape parameter from operator options (required by CoreML)
-                if let Some(opts) = options {
-                    let shape_values = opts.new_shape_static_or_max();
+                if !new_shape.is_empty() {
+                    let shape_values =
+                        crate::operator_options::mldimensions_static_or_max(new_shape);
                     inputs.insert(
                         "shape".to_string(),
                         Self::create_immediate_int_array(&shape_values),

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -2224,18 +2224,16 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::Tile { options, .. } => {
+            Operation::Tile { repetitions, .. } => {
                 // tile: x, reps
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                if let Some(opts) = options
-                    && !opts.repetitions.is_empty()
-                {
+                if !repetitions.is_empty() {
                     inputs.insert(
                         "reps".to_string(),
-                        Self::create_immediate_int_array(&opts.repetitions),
+                        Self::create_immediate_int_array(repetitions),
                     );
                 }
             }

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1002,7 +1002,13 @@ impl CoremlMlProgramConverter {
         graph: &GraphInfo,
         op: &Operation,
     ) -> Result<MilOperation, GraphError> {
-        let Operation::Split { input, options, .. } = &op else {
+        let Operation::Split {
+            input,
+            splits,
+            options,
+            ..
+        } = &op
+        else {
             return Err(GraphError::ConversionFailed {
                 format: "CoreML MLProgram".to_string(),
                 reason: "expected Split operator".to_string(),
@@ -1029,26 +1035,24 @@ impl CoremlMlProgramConverter {
         // Add main input (x)
         inputs.insert("x".to_string(), Self::create_name_argument(input_name));
 
-        // Add num_splits or split_sizes from typed options
-        if let Some(opts) = options {
-            if opts.splits.is_empty() {
-                // Equal splits - use num_splits (from output count)
-                inputs.insert(
-                    "num_splits".to_string(),
-                    Self::create_int_argument(op.output_operands().len() as i32),
-                );
-            } else {
-                let split_sizes: Vec<i32> = opts.splits.iter().map(|&u| u as i32).collect();
-                inputs.insert(
-                    "split_sizes".to_string(),
-                    Self::create_int_array_argument(split_sizes),
-                );
-            }
+        // num_splits or split_sizes from operation; axis from MLSplitOptions.
+        let axis = options.as_ref().map(|o| o.axis).unwrap_or(0);
+        if splits.is_empty() {
             inputs.insert(
-                "axis".to_string(),
-                Self::create_int_argument(opts.axis as i32),
+                "num_splits".to_string(),
+                Self::create_int_argument(op.output_operands().len() as i32),
+            );
+        } else {
+            let split_sizes: Vec<i32> = splits.iter().map(|&u| u as i32).collect();
+            inputs.insert(
+                "split_sizes".to_string(),
+                Self::create_int_array_argument(split_sizes),
             );
         }
+        inputs.insert(
+            "axis".to_string(),
+            Self::create_int_argument(axis as i32),
+        );
 
         Ok(Self::create_mil_operation("split", inputs, outputs))
     }
@@ -1288,18 +1292,11 @@ impl CoremlMlProgramConverter {
             }
 
             // Softmax operation (axis is required by WebNN spec)
-            Operation::Softmax { options, .. } => {
+            Operation::Softmax { axis, .. } => {
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
-                let axis = options
-                    .as_ref()
-                    .ok_or_else(|| GraphError::ConversionFailed {
-                        format: "coreml_mlprogram".to_string(),
-                        reason: "softmax operation must have options with axis".to_string(),
-                    })?
-                    .axis;
-                inputs.insert("axis".to_string(), Self::create_immediate_int(axis));
+                inputs.insert("axis".to_string(), Self::create_immediate_int(*axis));
             }
 
             // Neg operation: implemented as mul by -1, requires x and y parameters
@@ -1924,27 +1921,31 @@ impl CoremlMlProgramConverter {
                 inputs.insert("interleave".to_string(), Self::create_immediate_bool(false));
             }
 
-            Operation::Slice { options, .. } => {
+            Operation::Slice {
+                starts,
+                sizes,
+                options,
+                ..
+            } => {
                 // slice_by_size: x, begin, size
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                if let Some(opts) = options {
-                    if !opts.starts.is_empty() {
-                        inputs.insert(
-                            "begin".to_string(),
-                            Self::create_immediate_int_array(&opts.starts),
-                        );
-                    }
-                    if !opts.sizes.is_empty() {
-                        let sizes_u32 = opts.sizes_static_or_max();
-                        inputs.insert(
-                            "size".to_string(),
-                            Self::create_immediate_int_array(&sizes_u32),
-                        );
-                    }
+                if !starts.is_empty() {
+                    inputs.insert(
+                        "begin".to_string(),
+                        Self::create_immediate_int_array(starts),
+                    );
                 }
+                if !sizes.is_empty() {
+                    let sizes_u32: Vec<u32> = sizes.iter().map(|d| d.static_or_max()).collect();
+                    inputs.insert(
+                        "size".to_string(),
+                        Self::create_immediate_int_array(&sizes_u32),
+                    );
+                }
+                let _ = options;
             }
 
             Operation::Expand { options, .. } => {
@@ -2047,13 +2048,17 @@ impl CoremlMlProgramConverter {
                 );
             }
 
-            Operation::Split { options, .. } => {
+            Operation::Split {
+                splits,
+                options,
+                ..
+            } => {
                 // split: x, num_splits or split_sizes, axis
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
                 if let Some(opts) = options {
-                    if opts.splits.is_empty() {
+                    if splits.is_empty() {
                         inputs.insert(
                             "num_splits".to_string(),
                             Self::create_immediate_int(op.output_operands().len() as u32),
@@ -2061,7 +2066,7 @@ impl CoremlMlProgramConverter {
                     } else {
                         inputs.insert(
                             "split_sizes".to_string(),
-                            Self::create_immediate_int_array(&opts.splits),
+                            Self::create_immediate_int_array(splits),
                         );
                     }
                     inputs.insert("axis".to_string(), Self::create_immediate_int(opts.axis));
@@ -2077,17 +2082,21 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::Pad { options, .. } => {
+            Operation::Pad {
+                beginning_padding,
+                ending_padding,
+                options,
+                ..
+            } => {
                 // pad: x, pad, mode, constant_val
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
                 if let Some(opts) = options {
                     // CoreML expects pad as [begin_0, end_0, begin_1, end_1, ...]
-                    let pad: Vec<u32> = opts
-                        .beginning_padding
+                    let pad: Vec<u32> = beginning_padding
                         .iter()
-                        .zip(opts.ending_padding.iter())
+                        .zip(ending_padding.iter())
                         .flat_map(|(a, b)| [*a, *b])
                         .collect();
                     if !pad.is_empty() {
@@ -2144,14 +2153,14 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::ArgMax { options, .. } | Operation::ArgMin { options, .. } => {
+            Operation::ArgMax { axis, options, .. } | Operation::ArgMin { axis, options, .. } => {
                 // reduce_argmax/reduce_argmin: x, axis, keep_dims
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
+                inputs.insert("axis".to_string(), Self::create_immediate_int(*axis));
                 if let Some(opts) = options {
-                    inputs.insert("axis".to_string(), Self::create_immediate_int(opts.axis));
                     inputs.insert(
                         "keep_dims".to_string(),
                         Self::create_immediate_bool(opts.keep_dimensions),
@@ -2160,17 +2169,15 @@ impl CoremlMlProgramConverter {
                 // Note: outputDataType is handled by the output tensor's data type
             }
 
-            Operation::Cast { options, .. } => {
+            Operation::Cast { to, .. } => {
                 // cast: x, dtype
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
                 // Add dtype parameter (required)
-                if let Some(opts) = options
-                    && !opts.to.is_empty()
-                {
-                    let to_type = &opts.to;
+                if !to.is_empty() {
+                    let to_type = to;
                     let dtype_string = match to_type.as_str() {
                         "float32" => "fp32",
                         "float16" => "fp16",
@@ -2238,17 +2245,17 @@ impl CoremlMlProgramConverter {
                 }
             }
 
-            Operation::CumulativeSum { options, .. } => {
+            Operation::CumulativeSum { axis, options, .. } => {
                 // cumsum: x, axis, exclusive, reverse
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
+                inputs.insert(
+                    "axis".to_string(),
+                    Self::create_int_argument(*axis as i32),
+                );
                 if let Some(opts) = options {
-                    inputs.insert(
-                        "axis".to_string(),
-                        Self::create_int_argument(opts.axis as i32),
-                    );
                     inputs.insert(
                         "exclusive".to_string(),
                         Self::create_immediate_bool(opts.exclusive),
@@ -3649,7 +3656,7 @@ mod tests {
     #[cfg(feature = "dynamic-inputs")]
     use crate::graph::DynamicDimension;
     use crate::graph::{ConstantData, GraphInfo, Operand, OperandDescriptor, OperandKind};
-    use crate::operator_options::OperatorOptions;
+    use crate::operator_options::{OperationExtras, OperatorOptions};
     use crate::operators::Operation;
 
     /// Build an `Operation` from WebNN-style `op` name, operand indices, and parsed options (tests).
@@ -3667,9 +3674,14 @@ mod tests {
         } else {
             Vec::new()
         };
-        let operator =
-            Operation::from_operator_options(op_type, &input_operands, &attributes, &output_ids)
-                .expect("valid test op");
+        let operator = Operation::from_operator_options(
+            op_type,
+            &input_operands,
+            &attributes,
+            &output_ids,
+            OperationExtras::default(),
+        )
+        .expect("valid test op");
         operator
     }
     #[cfg(feature = "dynamic-inputs")]

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -20,7 +20,7 @@ use crate::converters::{ConvertedGraph, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
-use crate::operator_options::MLDimension;
+use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
 use crate::protos::onnx::{
     AttributeProto, GraphProto, ModelProto, NodeProto, OperatorSetIdProto, TensorProto,
@@ -1341,15 +1341,13 @@ impl OnnxConverter {
         graph: &GraphInfo,
     ) -> Vec<AttributeProto> {
         let mut attributes = Vec::new();
+        let default_pool = MLPool2dOptions::default();
         let opts = match &op {
             Operation::AveragePool2d { options, .. }
             | Operation::MaxPool2d { options, .. }
             | Operation::L2Pool2d { options, .. }
             | Operation::GlobalAveragePool { options, .. }
-            | Operation::GlobalMaxPool { options, .. } => match options.as_ref() {
-                Some(o) => o,
-                None => return attributes,
-            },
+            | Operation::GlobalMaxPool { options, .. } => options.as_ref().unwrap_or(&default_pool),
             _ => return attributes,
         };
 
@@ -1743,16 +1741,7 @@ impl OnnxConverter {
         let mut attributes = Vec::new();
 
         let (axis_opt, keep_dims) = match &op {
-            Operation::ArgMin {
-                axis,
-                options,
-                ..
-            }
-            | Operation::ArgMax {
-                axis,
-                options,
-                ..
-            } => (
+            Operation::ArgMin { axis, options, .. } | Operation::ArgMax { axis, options, .. } => (
                 Some(*axis as i64),
                 options.as_ref().map(|o| o.keep_dimensions).unwrap_or(false),
             ),
@@ -1783,9 +1772,7 @@ impl OnnxConverter {
         let mut attributes = Vec::new();
 
         let axis = match &op {
-            Operation::Concat { options, .. } => {
-                options.as_ref().map(|o| o.axis as i64).unwrap_or(0)
-            }
+            Operation::Concat { axis, .. } => *axis as i64,
             _ => 0,
         };
         attributes.push(AttributeProto {
@@ -2330,24 +2317,15 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 {
                     type_overrides.insert(output_id, input_operand.descriptor.data_type);
 
-                    // Check for newShape from typed options first
-                    if let Operation::Expand {
-                        options: Some(opts),
-                        ..
-                    } = &op
+                    if let Operation::Expand { new_shape, .. } = &op
+                        && !new_shape.is_empty()
                     {
-                        let shape = opts.new_shape_static_or_max();
-                        if !shape.is_empty() {
-                            shape_overrides.insert(output_id, shape.clone());
-                            operand_shapes.insert(output_id, shape);
-                        }
-                    }
-                    // Fall back to shape from second input operand (if present)
-                    else if op.input_operands().len() >= 2
-                        && let Some(shape) = operand_shapes.get(&op.input_operands()[1])
-                    {
+                        let shape: Vec<u32> = new_shape
+                            .iter()
+                            .map(crate::operator_options::MLDimension::static_or_max)
+                            .collect();
                         shape_overrides.insert(output_id, shape.clone());
-                        operand_shapes.insert(output_id, shape.clone());
+                        operand_shapes.insert(output_id, shape);
                     }
                 }
             } else if matches!(&op, Operation::Shape { .. }) {
@@ -2401,10 +2379,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     }
                     // WebNN slice has starts, sizes, strides; derive ends as starts[i] + sizes[i] for default stride 1
                     let starts: Vec<i64> = st.iter().map(|&u| u as i64).collect();
-                    let sizes: Vec<i64> = sz
-                        .iter()
-                        .map(|d| d.static_or_max() as i64)
-                        .collect();
+                    let sizes: Vec<i64> = sz.iter().map(|d| d.static_or_max() as i64).collect();
                     let strides: Vec<i64> = if opts.strides.is_empty() {
                         vec![1; starts.len()]
                     } else {
@@ -2621,9 +2596,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         .unwrap_or("unknown");
 
                     let axis = match &op {
-                        Operation::Concat { options, .. } => {
-                            options.as_ref().map(|o| o.axis).unwrap_or(0)
-                        }
+                        Operation::Concat { axis, .. } => *axis,
                         _ => 0,
                     };
 
@@ -5055,8 +5028,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         };
                         from_shape.ok_or_else(|| GraphError::ConversionFailed {
                             format: "onnx".to_string(),
-                            reason: "gru missing hiddenSize or weight shape not [3*hidden_size, ...]"
-                                .to_string(),
+                            reason:
+                                "gru missing hiddenSize or weight shape not [3*hidden_size, ...]"
+                                    .to_string(),
                         })?
                     }
                     _ => {
@@ -6457,7 +6431,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     _ => None,
                 };
                 let hidden_size = match &op {
-                    Operation::GruCell { hidden_size, .. } if *hidden_size > 0 => *hidden_size as u64,
+                    Operation::GruCell { hidden_size, .. } if *hidden_size > 0 => {
+                        *hidden_size as u64
+                    }
                     Operation::GruCell { .. } => graph
                         .operand(output_id)
                         .and_then(|o| {
@@ -7124,67 +7100,22 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     attribute: vec![], // No attributes for Reshape
                     ..Default::default()
                 });
-            } else if matches!(&op, Operation::Expand { .. }) {
-                // WebNN expand has two variants:
-                // 1. With 'axes' - adds dimensions (maps to ONNX Unsqueeze)
-                // 2. With 'newShape' - expands shape (maps to ONNX Expand or Reshape)
-
+            } else if let Operation::Expand { new_shape, .. } = &op {
                 debug_print!("[DEBUG] Processing WebNN expand operation:");
                 debug_print!("  Op name: {}", op_name);
-                if let Operation::Expand {
-                    options: Some(o), ..
-                } = &op
-                {
-                    debug_print!("  axes: {:?}, new_shape: {:?}", o.axes, o.new_shape);
+                debug_print!("  new_shape: {:?}", new_shape);
+
+                if new_shape.is_empty() {
+                    return Err(GraphError::ConversionFailed {
+                        format: "onnx".to_string(),
+                        reason: format!(
+                            "Expand requires non-empty newShape (method argument) in operation {}",
+                            op_name
+                        ),
+                    });
                 }
 
-                if let Operation::Expand {
-                    options: Some(opts),
-                    ..
-                } = &op
-                    && !opts.axes.is_empty()
-                {
-                    // WebNN expand with axes -> ONNX Unsqueeze
-                    // In ONNX opset 13+, axes must be provided as an input tensor, not attribute
-                    let axes_values: Vec<i64> = opts.axes.iter().map(|&u| u as i64).collect();
-
-                    let mut inputs: Vec<String> = op
-                        .input_operands()
-                        .iter()
-                        .map(|id| operand_name(graph, *id))
-                        .collect();
-
-                    // Create axes tensor name and add as second input
-                    let axes_name = format!("{}_axes", op_name);
-                    inputs.push(axes_name.clone());
-
-                    // Add axes as an initializer (constant tensor)
-                    initializers.push(TensorProto {
-                        name: axes_name,
-                        data_type: ProtoDataType::Int64 as i32,
-                        dims: vec![axes_values.len() as i64], // 1D tensor
-                        int64_data: axes_values,
-                        ..Default::default()
-                    });
-
-                    nodes.push(NodeProto {
-                        input: inputs,
-                        output: vec![operand_name(
-                            graph,
-                            op.output_operand()
-                                .expect("Single-output operation expected"),
-                        )],
-                        name: op_name.clone(),
-                        op_type: "Unsqueeze".to_string(),
-                        attribute: vec![], // No attributes for Unsqueeze in opset 13+
-                        ..Default::default()
-                    });
-                } else if let Some(new_shape_value) = match &op {
-                    Operation::Expand {
-                        options: Some(o), ..
-                    } if !o.new_shape.is_empty() => serde_json::to_value(&o.new_shape).ok(),
-                    _ => None,
-                } {
+                if let Some(new_shape_value) = serde_json::to_value(new_shape).ok() {
                     // WebNN expand with newShape can be either:
                     // 1. ONNX Expand (broadcasting-compatible shapes)
                     // 2. ONNX Reshape (arbitrary shape changes)
@@ -7367,7 +7298,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     return Err(GraphError::ConversionFailed {
                         format: "onnx".to_string(),
                         reason: format!(
-                            "Expand operation requires either 'axes' or 'newShape' attribute in operation {}",
+                            "Expand newShape serialization failed in operation {}",
                             op_name
                         ),
                     });
@@ -7574,10 +7505,12 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     } => (
                         beginning_padding,
                         ending_padding,
-                        options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
-                            format: "onnx".to_string(),
-                            reason: "pad operation requires typed options".to_string(),
-                        })?,
+                        options
+                            .as_ref()
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "onnx".to_string(),
+                                reason: "pad operation requires typed options".to_string(),
+                            })?,
                     ),
                     _ => {
                         return Err(GraphError::ConversionFailed {
@@ -7586,15 +7519,15 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         });
                     }
                 };
-                let pads_data: Vec<i64> = if !beginning_padding.is_empty() && !ending_padding.is_empty()
-                {
-                    let mut combined: Vec<i64> =
-                        beginning_padding.iter().map(|&u| u as i64).collect();
-                    combined.extend(ending_padding.iter().map(|&u| u as i64));
-                    combined
-                } else {
-                    vec![0; input_rank.saturating_mul(2)]
-                };
+                let pads_data: Vec<i64> =
+                    if !beginning_padding.is_empty() && !ending_padding.is_empty() {
+                        let mut combined: Vec<i64> =
+                            beginning_padding.iter().map(|&u| u as i64).collect();
+                        combined.extend(ending_padding.iter().map(|&u| u as i64));
+                        combined
+                    } else {
+                        vec![0; input_rank.saturating_mul(2)]
+                    };
 
                 let pads_name = format!("{}_pads", op_name);
                 initializers.push(TensorProto {
@@ -8053,10 +7986,12 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     } => (
                         starts,
                         sizes,
-                        options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
-                            format: "onnx".to_string(),
-                            reason: "slice operation requires typed options".to_string(),
-                        })?,
+                        options
+                            .as_ref()
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "onnx".to_string(),
+                                reason: "slice operation requires typed options".to_string(),
+                            })?,
                     ),
                     _ => {
                         return Err(GraphError::ConversionFailed {
@@ -8066,10 +8001,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     }
                 };
                 let starts: Vec<i64> = starts_u32.iter().map(|&u| u as i64).collect();
-                let sizes_max: Vec<i64> = sizes_ml
-                    .iter()
-                    .map(|d| d.static_or_max() as i64)
-                    .collect();
+                let sizes_max: Vec<i64> =
+                    sizes_ml.iter().map(|d| d.static_or_max() as i64).collect();
                 let steps: Option<Vec<i64>> = if o.strides.is_empty() {
                     None
                 } else {
@@ -8077,8 +8010,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 };
 
                 // Check if any size is dynamic
-                let has_dynamic_sizes =
-                    sizes_ml.iter().any(|s| matches!(s, MLDimension::Dynamic(_)));
+                let has_dynamic_sizes = sizes_ml
+                    .iter()
+                    .any(|s| matches!(s, MLDimension::Dynamic(_)));
 
                 // Special case: 0D tensor (scalar) cannot be sliced
                 if is_0d {
@@ -9519,11 +9453,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         let type_code: i64 = match match &op {
                             Operation::Cast { to, .. } => {
                                 let t = to.to_ascii_lowercase();
-                                if t.is_empty() {
-                                    None
-                                } else {
-                                    Some(t)
-                                }
+                                if t.is_empty() { None } else { Some(t) }
                             }
                             _ => None,
                         } {
@@ -9787,6 +9717,7 @@ mod tests {
     use crate::graph::{
         DataType, Dimension, DynamicDimension, GraphInfo, Operand, OperandDescriptor, OperandKind,
     };
+    #[cfg(feature = "dynamic-inputs")]
     use crate::operator_options::OperatorOptions;
     use crate::operators::Operation;
     use crate::protos::onnx::tensor_proto::DataType as ProtoDataType;
@@ -9842,6 +9773,56 @@ mod tests {
     fn test_max_min_map_to_onnx() {
         assert_eq!(OnnxConverter::onnx_op_type("max"), "Max");
         assert_eq!(OnnxConverter::onnx_op_type("min"), "Min");
+    }
+
+    #[test]
+    fn test_average_pool2d_null_attributes_onnx_has_kernel_shape() {
+        let operands = vec![
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[1, 3, 4, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("input".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[1, 3, 1, 1]),
+                    pending_permutation: vec![],
+                },
+                name: Some("output".to_string()),
+            },
+        ];
+        let op =
+            Operation::from_json_attributes("averagePool2d", &[0], &[1], &serde_json::Value::Null)
+                .expect("averagePool2d from null attrs");
+        let graph = GraphInfo {
+            operands,
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operations: vec![op],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+        let converted = OnnxConverter.convert(&graph).expect("convert");
+        let model = ModelProto::decode(converted.data.as_slice()).expect("decode");
+        let graph_proto = model.graph.expect("graph");
+        let node = graph_proto
+            .node
+            .iter()
+            .find(|n| n.op_type == "AveragePool")
+            .expect("AveragePool node");
+        let ks = node
+            .attribute
+            .iter()
+            .find(|a| a.name == "kernel_shape")
+            .expect("kernel_shape attr");
+        assert_eq!(ks.ints, vec![4_i64, 4]);
     }
 
     #[test]
@@ -10548,13 +10529,9 @@ mod tests {
             "bias": 4,
             "recurrentBias": 5
         });
-        let operator = Operation::from_json_attributes(
-            "gruCell",
-            &[0, 1, 2, 3, 4, 5],
-            &[6],
-            &attrs_val,
-        )
-        .expect("gruCell from JSON");
+        let operator =
+            Operation::from_json_attributes("gruCell", &[0, 1, 2, 3, 4, 5], &[6], &attrs_val)
+                .expect("gruCell from JSON");
         let operations = vec![operator];
 
         let graph = GraphInfo {
@@ -10718,8 +10695,10 @@ mod tests {
             },
         ];
 
-        let attrs = OperatorOptions::from_json_with_op_type(
+        let operator = Operation::from_json_attributes(
             "expand",
+            &[0],
+            &[1],
             &serde_json::json!({
                 "newShape": [
                     { "name": "batch", "maxSize": 8 },
@@ -10727,12 +10706,7 @@ mod tests {
                 ]
             }),
         )
-        .unwrap_or_default();
-        let operator = Operation::Expand {
-            input: 0,
-            options: attrs.as_expand().cloned(),
-            outputs: vec![1],
-        };
+        .expect("expand from_json_attributes");
         let operations = vec![operator];
 
         let graph = GraphInfo {
@@ -10829,18 +10803,6 @@ mod tests {
             &serde_json::json!({ "axes": [1] }),
         )
         .unwrap_or_default();
-        let exp_attrs = OperatorOptions::from_json_with_op_type(
-            "expand",
-            &serde_json::json!({
-                "newShape": [
-                    { "name": "batch_size", "maxSize": 8 },
-                    1,
-                    { "name": "sequence_length", "maxSize": 4096 },
-                    { "name": "past_sequence_length + 1", "maxSize": 4096 }
-                ]
-            }),
-        )
-        .unwrap_or_default();
         let operations = vec![
             Operation::Unsqueeze {
                 input: 0,
@@ -10852,11 +10814,20 @@ mod tests {
                 options: u1_attrs.as_unsqueeze().cloned(),
                 outputs: vec![2],
             },
-            Operation::Expand {
-                input: 2,
-                options: exp_attrs.as_expand().cloned(),
-                outputs: vec![3],
-            },
+            Operation::from_json_attributes(
+                "expand",
+                &[2],
+                &[3],
+                &serde_json::json!({
+                    "newShape": [
+                        { "name": "batch_size", "maxSize": 8 },
+                        1,
+                        { "name": "sequence_length", "maxSize": 4096 },
+                        { "name": "past_sequence_length + 1", "maxSize": 4096 }
+                    ]
+                }),
+            )
+            .expect("expand from_json_attributes"),
         ];
 
         let graph = GraphInfo {
@@ -10967,18 +10938,6 @@ mod tests {
             },
         ];
 
-        let exp_attrs = OperatorOptions::from_json_with_op_type(
-            "expand",
-            &serde_json::json!({
-                "newShape": [
-                    { "name": "batch_size", "maxSize": 8 },
-                    1,
-                    { "name": "sequence_length", "maxSize": 4096 },
-                    { "name": "past_sequence_length + 1", "maxSize": 4096 }
-                ]
-            }),
-        )
-        .unwrap_or_default();
         let operations = vec![
             Operation::Where {
                 condition: 0,
@@ -10987,11 +10946,20 @@ mod tests {
                 options: None,
                 outputs: vec![3],
             },
-            Operation::Expand {
-                input: 3,
-                options: exp_attrs.as_expand().cloned(),
-                outputs: vec![4],
-            },
+            Operation::from_json_attributes(
+                "expand",
+                &[3],
+                &[4],
+                &serde_json::json!({
+                    "newShape": [
+                        { "name": "batch_size", "maxSize": 8 },
+                        1,
+                        { "name": "sequence_length", "maxSize": 4096 },
+                        { "name": "past_sequence_length + 1", "maxSize": 4096 }
+                    ]
+                }),
+            )
+            .expect("expand from_json_attributes"),
         ];
 
         let graph = GraphInfo {

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -6740,10 +6740,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
                 // Repeats come from typed options or attribute. repetitions=[] or all 1s => no-op (Identity).
                 let repeats: Vec<i64> = match &op {
-                    Operation::Tile { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.repetitions.iter().map(|&u| u as i64).collect())
-                        .unwrap_or_default(),
+                    Operation::Tile { repetitions, .. } => {
+                        repetitions.iter().map(|&u| u as i64).collect()
+                    }
                     _ => vec![],
                 };
 

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -525,30 +525,6 @@ impl OnnxConverter {
 
         let mut inputs: Vec<String> = vec![normalized_input_name.clone()];
 
-        let (_has_scale, has_bias_norm) = match &op {
-            Operation::BatchNormalization { options, .. } => (
-                options.as_ref().and_then(|o| o.scale).is_some(),
-                options.as_ref().and_then(|o| o.bias).is_some(),
-            ),
-            Operation::InstanceNormalization { options, .. } => (
-                options.as_ref().and_then(|o| o.scale).is_some(),
-                options.as_ref().and_then(|o| o.bias).is_some(),
-            ),
-            Operation::LayerNormalization { options, .. } => {
-                let o = options.as_ref();
-                let scale_present = o.and_then(|x| x.scale).is_some();
-                let bias_present = o.and_then(|x| x.bias).is_some();
-                // Respect hasScale/hasBias when operands are omitted (WebNN 2-operand forms).
-                let scale_requested = !matches!(o.and_then(|x| x.has_scale), Some(false));
-                let bias_requested = !matches!(o.and_then(|x| x.has_bias), Some(false));
-                (
-                    scale_present || scale_requested,
-                    bias_present || bias_requested,
-                )
-            }
-            _ => (false, false),
-        };
-
         if is_layer_norm {
             let rank_ln = input_shape.len();
             let axes_raw: Option<Vec<serde_json::Value>> = match &op {
@@ -567,53 +543,43 @@ impl OnnxConverter {
                     op.output_operand()
                         .expect("Single-output operation expected"),
                 );
-                if has_bias_norm {
-                    let bias_id = match &op {
-                        Operation::LayerNormalization { options, .. } => {
-                            options.as_ref().and_then(|o| o.bias)
-                        }
-                        _ => None,
-                    };
-                    if let Some(id) = bias_id {
-                        nodes.push(NodeProto {
-                            input: vec![operand_name(graph, id)],
-                            output: vec![output_name],
-                            name: op_name.clone(),
-                            op_type: "Identity".to_string(),
-                            ..Default::default()
-                        });
-                    } else {
-                        let zero_name = format!("{}_zero", op_name);
-                        let shape_i64: Vec<i64> =
-                            normalized_input_shape.iter().map(|&d| d as i64).collect();
-                        if shape_i64.is_empty() {
-                            initializers.push(Self::create_scalar_initializer(
-                                zero_name.clone(),
-                                input_data_type,
-                                0.0,
-                            ));
-                        } else {
-                            initializers.push(Self::create_vector_initializer(
-                                zero_name.clone(),
-                                input_data_type,
-                                shape_i64,
-                                0.0,
-                            ));
-                        }
-                        nodes.push(NodeProto {
-                            input: vec![zero_name],
-                            output: vec![output_name],
-                            name: op_name.clone(),
-                            op_type: "Identity".to_string(),
-                            ..Default::default()
-                        });
+                let bias_id = match &op {
+                    Operation::LayerNormalization { options, .. } => {
+                        options.as_ref().and_then(|o| o.bias)
                     }
-                } else {
+                    _ => None,
+                };
+                if let Some(id) = bias_id {
                     nodes.push(NodeProto {
-                        input: vec![operand_name(graph, input_id), operand_name(graph, input_id)],
+                        input: vec![operand_name(graph, id)],
                         output: vec![output_name],
                         name: op_name.clone(),
-                        op_type: "Sub".to_string(),
+                        op_type: "Identity".to_string(),
+                        ..Default::default()
+                    });
+                } else {
+                    let zero_name = format!("{}_zero", op_name);
+                    let shape_i64: Vec<i64> =
+                        normalized_input_shape.iter().map(|&d| d as i64).collect();
+                    if shape_i64.is_empty() {
+                        initializers.push(Self::create_scalar_initializer(
+                            zero_name.clone(),
+                            input_data_type,
+                            0.0,
+                        ));
+                    } else {
+                        initializers.push(Self::create_vector_initializer(
+                            zero_name.clone(),
+                            input_data_type,
+                            shape_i64,
+                            0.0,
+                        ));
+                    }
+                    nodes.push(NodeProto {
+                        input: vec![zero_name],
+                        output: vec![output_name],
+                        name: op_name.clone(),
+                        op_type: "Identity".to_string(),
                         ..Default::default()
                     });
                 }
@@ -628,64 +594,53 @@ impl OnnxConverter {
                     op.output_operand()
                         .expect("Single-output operation expected"),
                 );
-                if has_bias_norm {
-                    let bias_id = match &op {
-                        Operation::LayerNormalization { options, .. } => {
-                            options.as_ref().and_then(|o| o.bias)
-                        }
-                        _ => None,
-                    };
-                    if let Some(id) = bias_id {
-                        let bias_name = operand_name(graph, id);
-                        let input_nm = operand_name(graph, input_id);
-                        let zero_like_name = format!("{}_zero_like", op_name);
-                        nodes.push(NodeProto {
-                            input: vec![input_nm.clone(), input_nm],
-                            output: vec![zero_like_name.clone()],
-                            name: format!("{}_zero_like_sub", op_name),
-                            op_type: "Sub".to_string(),
-                            ..Default::default()
-                        });
-                        nodes.push(NodeProto {
-                            input: vec![zero_like_name, bias_name],
-                            output: vec![output_name],
-                            name: op_name.clone(),
-                            op_type: "Add".to_string(),
-                            ..Default::default()
-                        });
-                    } else {
-                        let zero_name = format!("{}_zero", op_name);
-                        let shape_i64: Vec<i64> =
-                            normalized_input_shape.iter().map(|&d| d as i64).collect();
-                        if shape_i64.is_empty() {
-                            initializers.push(Self::create_scalar_initializer(
-                                zero_name.clone(),
-                                input_data_type,
-                                0.0,
-                            ));
-                        } else {
-                            initializers.push(Self::create_vector_initializer(
-                                zero_name.clone(),
-                                input_data_type,
-                                shape_i64,
-                                0.0,
-                            ));
-                        }
-                        nodes.push(NodeProto {
-                            input: vec![zero_name],
-                            output: vec![output_name],
-                            name: op_name.clone(),
-                            op_type: "Identity".to_string(),
-                            ..Default::default()
-                        });
+                let bias_id = match &op {
+                    Operation::LayerNormalization { options, .. } => {
+                        options.as_ref().and_then(|o| o.bias)
                     }
-                } else {
+                    _ => None,
+                };
+                if let Some(id) = bias_id {
+                    let bias_name = operand_name(graph, id);
                     let input_nm = operand_name(graph, input_id);
+                    let zero_like_name = format!("{}_zero_like", op_name);
                     nodes.push(NodeProto {
                         input: vec![input_nm.clone(), input_nm],
+                        output: vec![zero_like_name.clone()],
+                        name: format!("{}_zero_like_sub", op_name),
+                        op_type: "Sub".to_string(),
+                        ..Default::default()
+                    });
+                    nodes.push(NodeProto {
+                        input: vec![zero_like_name, bias_name],
                         output: vec![output_name],
                         name: op_name.clone(),
-                        op_type: "Sub".to_string(),
+                        op_type: "Add".to_string(),
+                        ..Default::default()
+                    });
+                } else {
+                    let zero_name = format!("{}_zero", op_name);
+                    let shape_i64: Vec<i64> =
+                        normalized_input_shape.iter().map(|&d| d as i64).collect();
+                    if shape_i64.is_empty() {
+                        initializers.push(Self::create_scalar_initializer(
+                            zero_name.clone(),
+                            input_data_type,
+                            0.0,
+                        ));
+                    } else {
+                        initializers.push(Self::create_vector_initializer(
+                            zero_name.clone(),
+                            input_data_type,
+                            shape_i64,
+                            0.0,
+                        ));
+                    }
+                    nodes.push(NodeProto {
+                        input: vec![zero_name],
+                        output: vec![output_name],
+                        name: op_name.clone(),
+                        op_type: "Identity".to_string(),
                         ..Default::default()
                     });
                 }
@@ -784,7 +739,7 @@ impl OnnxConverter {
                 _ => (None, None),
             };
             let ln_defaults_need_runtime = crate::graph::dynamic_inputs_enabled()
-                && (ln_scale_id.is_none() || has_bias_norm && ln_bias_id.is_none())
+                && (ln_scale_id.is_none() || ln_bias_id.is_none())
                 && input_operand.descriptor.has_dynamic_dimensions();
             let has_dynamic_norm_dims = match layernorm_axis_override {
                 Some(ln_axis) => {
@@ -950,7 +905,7 @@ impl OnnxConverter {
 
             if let Some(bias_input_id) = bias_input_id {
                 inputs.push(operand_name(graph, bias_input_id));
-            } else if !is_layer_norm || has_bias_norm {
+            } else {
                 let bias_name = if let Some(shape_vec) = &norm_dynamic_defaults_shape {
                     Self::create_runtime_filled_tensor(
                         &format!("{}_bias_default", op_name),
@@ -11123,8 +11078,6 @@ mod tests {
             "layerNormalization",
             &serde_json::json!({
                 "axes": [1],
-                "hasScale": false,
-                "hasBias": true,
                 "epsilon": 1e-5
             }),
         )

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -20,7 +20,7 @@ use crate::converters::{ConvertedGraph, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
-use crate::operator_options::{MLDimension, MLPool2dOptions};
+use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
 use crate::operators::Operation;
 use crate::protos::onnx::{
     AttributeProto, GraphProto, ModelProto, NodeProto, OperatorSetIdProto, TensorProto,
@@ -2639,13 +2639,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
             // Reshape: if newShape is present, set output shape (static or max for dynamic)
             else if matches!(&op, Operation::Reshape { .. }) {
                 if let Some(output_id) = op.output_operand()
-                    && let Operation::Reshape {
-                        options: Some(opts),
-                        ..
-                    } = &op
-                    && !opts.new_shape.is_empty()
+                    && let Operation::Reshape { new_shape, .. } = &op
+                    && !new_shape.is_empty()
                 {
-                    let shape = opts.new_shape_static_or_max();
+                    let shape = mldimensions_static_or_max(new_shape);
                     shape_overrides.insert(output_id, shape.clone());
                     operand_shapes.insert(output_id, shape);
                 }
@@ -6946,14 +6943,13 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     .map(|id| operand_name(graph, *id))
                     .collect();
 
-                // Handle newShape from typed options - can be array (static/dynamic), string (operand reference), or missing
+                // Handle newShape from the operation - can be array (static/dynamic), string (operand reference), or missing
                 let new_shape_attr = match &op {
-                    Operation::Reshape { options, .. } => {
-                        options.as_ref().filter(|o| !o.new_shape.is_empty())
-                    }
+                    Operation::Reshape { new_shape, .. } => (!new_shape.is_empty())
+                        .then(|| serde_json::to_value(new_shape).ok())
+                        .flatten(),
                     _ => None,
-                }
-                .and_then(|o| serde_json::to_value(&o.new_shape).ok());
+                };
                 if let Some(new_shape_attr) = new_shape_attr {
                     if let Some(shape_dims) = Self::parse_dimension_array(&new_shape_attr) {
                         // Case 1: newShape is an array (static or dynamic)
@@ -10576,8 +10572,10 @@ mod tests {
             },
         ];
 
-        let attrs = OperatorOptions::from_json_with_op_type(
+        let operator = Operation::from_json_attributes(
             "reshape",
+            &[0],
+            &[1],
             &serde_json::json!({
                 "newShape": [
                     { "name": "batch", "maxSize": 8 },
@@ -10585,12 +10583,7 @@ mod tests {
                 ]
             }),
         )
-        .unwrap_or_default();
-        let operator = Operation::Reshape {
-            input: 0,
-            options: attrs.as_reshape().cloned(),
-            outputs: vec![1],
-        };
+        .expect("reshape from_json_attributes");
         let operations = vec![operator];
 
         let graph = GraphInfo {

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -1743,10 +1743,19 @@ impl OnnxConverter {
         let mut attributes = Vec::new();
 
         let (axis_opt, keep_dims) = match &op {
-            Operation::ArgMin { options, .. } | Operation::ArgMax { options, .. } => options
-                .as_ref()
-                .map(|opts| (Some(opts.axis as i64), opts.keep_dimensions))
-                .unwrap_or((Some(0), false)),
+            Operation::ArgMin {
+                axis,
+                options,
+                ..
+            }
+            | Operation::ArgMax {
+                axis,
+                options,
+                ..
+            } => (
+                Some(*axis as i64),
+                options.as_ref().map(|o| o.keep_dimensions).unwrap_or(false),
+            ),
             _ => (Some(0), false),
         };
 
@@ -1793,10 +1802,7 @@ impl OnnxConverter {
         let mut attributes = Vec::new();
         // Axis is required by WebNN spec
         let axis = match &op {
-            Operation::Softmax { options, .. } => options
-                .as_ref()
-                .map(|o| o.axis as i64)
-                .expect("softmax operation must have options with axis"),
+            Operation::Softmax { axis, .. } => *axis as i64,
             _ => 0,
         };
         attributes.push(AttributeProto {
@@ -1852,12 +1858,10 @@ impl OnnxConverter {
     /// Create ONNX attributes for cast operation
     fn create_cast_attributes(op: &Operation) -> Vec<AttributeProto> {
         let mut attributes = Vec::new();
-        if let Operation::Cast {
-            options: Some(opts),
-            ..
-        } = &op
+        if let Operation::Cast { to, .. } = &op
+            && !to.is_empty()
         {
-            let to_type = opts.to.to_ascii_lowercase();
+            let to_type = to.to_ascii_lowercase();
             let type_code = match to_type.as_str() {
                 "float32" => ProtoDataType::Float as i64,
                 "float16" => ProtoDataType::Float16 as i64,
@@ -1961,27 +1965,8 @@ impl OnnxConverter {
     }
 
     /// Create ONNX attributes for hardSwish operation.
-    fn create_hardswish_attributes(op: &Operation) -> Vec<AttributeProto> {
-        let mut attributes = Vec::new();
-        if let Operation::HardSwish {
-            options: Some(opts),
-            ..
-        } = &op
-        {
-            attributes.push(AttributeProto {
-                name: "alpha".to_string(),
-                r#type: AttributeType::Float as i32,
-                f: opts.alpha as f32,
-                ..Default::default()
-            });
-            attributes.push(AttributeProto {
-                name: "beta".to_string(),
-                r#type: AttributeType::Float as i32,
-                f: opts.beta as f32,
-                ..Default::default()
-            });
-        }
-        attributes
+    fn create_hardswish_attributes(_op: &Operation) -> Vec<AttributeProto> {
+        Vec::new()
     }
 
     /// Create ONNX attributes for elu operation
@@ -2404,6 +2389,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     (op.input_operands().first(), op.output_operand())
                     && let Some(mut in_shape) = operand_shapes.get(&input_id).cloned()
                     && let Operation::Slice {
+                        starts: st,
+                        sizes: sz,
                         options: Some(opts),
                         ..
                     } = &op
@@ -2413,11 +2400,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         type_overrides.insert(output_id, input_operand.descriptor.data_type);
                     }
                     // WebNN slice has starts, sizes, strides; derive ends as starts[i] + sizes[i] for default stride 1
-                    let starts: Vec<i64> = opts.starts.iter().map(|&u| u as i64).collect();
-                    let sizes: Vec<i64> = opts
-                        .sizes_static_or_max()
+                    let starts: Vec<i64> = st.iter().map(|&u| u as i64).collect();
+                    let sizes: Vec<i64> = sz
                         .iter()
-                        .map(|&u| u as i64)
+                        .map(|d| d.static_or_max() as i64)
                         .collect();
                     let strides: Vec<i64> = if opts.strides.is_empty() {
                         vec![1; starts.len()]
@@ -4963,7 +4949,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     Operation::CumulativeSum { options, .. } => options.as_ref(),
                     _ => None,
                 };
-                let axis = opts.map(|o| o.axis as i64).unwrap_or(0);
+                let axis = match &op {
+                    Operation::CumulativeSum { axis, .. } => *axis as i64,
+                    _ => 0,
+                };
                 if rank > 0 && axis >= rank {
                     return Err(GraphError::ConversionFailed {
                         format: "onnx".to_string(),
@@ -5050,11 +5039,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     Operation::Gru { options, .. } => options.as_ref(),
                     _ => None,
                 };
-                let hidden_size = gru_opts
-                    .and_then(|o| o.hidden_size.map(|u| u as u64))
-                    .or_else(|| {
+                let hidden_size = match &op {
+                    Operation::Gru { hidden_size, .. } if *hidden_size > 0 => *hidden_size as u64,
+                    Operation::Gru { .. } => {
                         let shape = &weight_operand.descriptor.static_or_max_shape();
-                        if !shape.is_empty() {
+                        let from_shape = if !shape.is_empty() {
                             let dim = get_static_or_max_size(&weight_operand.descriptor.shape[0]);
                             if dim > 0 && dim.is_multiple_of(3) {
                                 Some((dim / 3) as u64)
@@ -5063,13 +5052,20 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             }
                         } else {
                             None
-                        }
-                    })
-                    .ok_or_else(|| GraphError::ConversionFailed {
-                        format: "onnx".to_string(),
-                        reason: "gru missing hiddenSize or weight shape not [3*hidden_size, ...]"
-                            .to_string(),
-                    })?;
+                        };
+                        from_shape.ok_or_else(|| GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "gru missing hiddenSize or weight shape not [3*hidden_size, ...]"
+                                .to_string(),
+                        })?
+                    }
+                    _ => {
+                        return Err(GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "internal: expected Gru operation".to_string(),
+                        });
+                    }
+                };
 
                 let input_dtype = Self::data_type_code(weight_operand.descriptor.data_type);
                 let gate_layout = gru_opts
@@ -6460,20 +6456,27 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     Operation::GruCell { options, .. } => options.as_ref(),
                     _ => None,
                 };
-                let hidden_size = gru_cell_opts
-                    .and_then(|o| o.hidden_size.map(|u| u as u64))
-                    .or_else(|| {
-                        graph.operand(output_id).and_then(|o| {
+                let hidden_size = match &op {
+                    Operation::GruCell { hidden_size, .. } if *hidden_size > 0 => *hidden_size as u64,
+                    Operation::GruCell { .. } => graph
+                        .operand(output_id)
+                        .and_then(|o| {
                             o.descriptor
                                 .shape
                                 .last()
                                 .map(|d| get_static_or_max_size(d) as u64)
                         })
-                    })
-                    .ok_or_else(|| GraphError::ConversionFailed {
-                        format: "onnx".to_string(),
-                        reason: "gruCell missing hiddenSize/hidden_size attribute".to_string(),
-                    })?;
+                        .ok_or_else(|| GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "gruCell missing hiddenSize/hidden_size attribute".to_string(),
+                        })?,
+                    _ => {
+                        return Err(GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "internal: expected gruCell operation".to_string(),
+                        });
+                    }
+                };
 
                 let hidden_state_operand = graph.operand(hidden_state_id).ok_or_else(|| {
                     Self::invalid_operand(
@@ -7562,15 +7565,20 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     });
                     continue;
                 }
-                let pad_opts = match &op {
-                    Operation::Pad { options, .. } => {
-                        options
-                            .as_ref()
-                            .ok_or_else(|| GraphError::ConversionFailed {
-                                format: "onnx".to_string(),
-                                reason: "pad operation requires typed options".to_string(),
-                            })?
-                    }
+                let (beginning_padding, ending_padding, pad_opts) = match &op {
+                    Operation::Pad {
+                        beginning_padding,
+                        ending_padding,
+                        options,
+                        ..
+                    } => (
+                        beginning_padding,
+                        ending_padding,
+                        options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "pad operation requires typed options".to_string(),
+                        })?,
+                    ),
                     _ => {
                         return Err(GraphError::ConversionFailed {
                             format: "onnx".to_string(),
@@ -7578,15 +7586,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         });
                     }
                 };
-                let pads_data: Vec<i64> = if !pad_opts.beginning_padding.is_empty()
-                    && !pad_opts.ending_padding.is_empty()
+                let pads_data: Vec<i64> = if !beginning_padding.is_empty() && !ending_padding.is_empty()
                 {
-                    let mut combined: Vec<i64> = pad_opts
-                        .beginning_padding
-                        .iter()
-                        .map(|&u| u as i64)
-                        .collect();
-                    combined.extend(pad_opts.ending_padding.iter().map(|&u| u as i64));
+                    let mut combined: Vec<i64> =
+                        beginning_padding.iter().map(|&u| u as i64).collect();
+                    combined.extend(ending_padding.iter().map(|&u| u as i64));
                     combined
                 } else {
                     vec![0; input_rank.saturating_mul(2)]
@@ -7996,10 +8000,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
                     let mut attrs = Vec::new();
                     if let Some(batch_dims) = match &op {
-                        Operation::Gather { options, .. }
-                        | Operation::GatherElements { options, .. } => {
-                            options.as_ref().and_then(|o| o.batch_dimensions)
-                        }
+                        Operation::GatherElements {
+                            batch_dimensions, ..
+                        } => *batch_dimensions,
                         _ => None,
                     } {
                         attrs.push(AttributeProto {
@@ -8040,16 +8043,21 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     .map(|id| operand_name(graph, *id))
                     .collect();
 
-                // Slice requires typed options (attributes deprecated).
-                let o = match &op {
-                    Operation::Slice { options, .. } => {
-                        options
-                            .as_ref()
-                            .ok_or_else(|| GraphError::ConversionFailed {
-                                format: "onnx".to_string(),
-                                reason: "slice operation requires typed options".to_string(),
-                            })?
-                    }
+                // Slice requires typed options (strides); starts/sizes are on the operation.
+                let (starts_u32, sizes_ml, o) = match &op {
+                    Operation::Slice {
+                        starts,
+                        sizes,
+                        options,
+                        ..
+                    } => (
+                        starts,
+                        sizes,
+                        options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: "slice operation requires typed options".to_string(),
+                        })?,
+                    ),
                     _ => {
                         return Err(GraphError::ConversionFailed {
                             format: "onnx".to_string(),
@@ -8057,9 +8065,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         });
                     }
                 };
-                let starts: Vec<i64> = o.starts.iter().map(|&u| u as i64).collect();
-                let sizes_max: Vec<i64> =
-                    o.sizes_static_or_max().iter().map(|&u| u as i64).collect();
+                let starts: Vec<i64> = starts_u32.iter().map(|&u| u as i64).collect();
+                let sizes_max: Vec<i64> = sizes_ml
+                    .iter()
+                    .map(|d| d.static_or_max() as i64)
+                    .collect();
                 let steps: Option<Vec<i64>> = if o.strides.is_empty() {
                     None
                 } else {
@@ -8068,7 +8078,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
                 // Check if any size is dynamic
                 let has_dynamic_sizes =
-                    o.sizes.iter().any(|s| matches!(s, MLDimension::Dynamic(_)));
+                    sizes_ml.iter().any(|s| matches!(s, MLDimension::Dynamic(_)));
 
                 // Special case: 0D tensor (scalar) cannot be sliced
                 if is_0d {
@@ -8104,8 +8114,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     // Convert sizes to end dimensions: end[i] = start[i] + size[i]
                     // For dynamic sizes, adjust the name to include the start offset.
                     use crate::graph::DynamicDimension as GraphDynDim;
-                    let end_dims: Vec<Dimension> = o
-                        .sizes
+                    let end_dims: Vec<Dimension> = sizes_ml
                         .iter()
                         .enumerate()
                         .map(|(i, sd)| {
@@ -8249,14 +8258,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 };
 
                 let split_sizes: Vec<i64> = match &op {
-                    Operation::Split {
-                        options: Some(opts),
-                        ..
-                    } => {
-                        if opts.splits.is_empty() {
-                            equal_sizes()
+                    Operation::Split { splits, .. } => {
+                        if !splits.is_empty() {
+                            splits.iter().map(|&u| u as i64).collect()
                         } else {
-                            opts.splits.iter().map(|&u| u as i64).collect()
+                            equal_sizes()
                         }
                     }
                     _ => equal_sizes(),
@@ -9511,10 +9517,14 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             .output_operand()
                             .expect("Single-output operation expected");
                         let type_code: i64 = match match &op {
-                            Operation::Cast { options, .. } => options
-                                .as_ref()
-                                .map(|o| o.to.to_ascii_lowercase())
-                                .filter(|s| !s.is_empty()),
+                            Operation::Cast { to, .. } => {
+                                let t = to.to_ascii_lowercase();
+                                if t.is_empty() {
+                                    None
+                                } else {
+                                    Some(t)
+                                }
+                            }
                             _ => None,
                         } {
                             Some(s) => match s.as_str() {
@@ -10219,12 +10229,10 @@ mod tests {
             name: Some("output".to_string()),
         });
 
-        let attrs =
-            OperatorOptions::from_json_with_op_type("cast", &serde_json::json!({ "to": "int4" }))
-                .unwrap_or_default();
         let operator = Operation::Cast {
             input: 0,
-            options: attrs.as_cast().cloned(),
+            to: "int4".to_string(),
+            options: None,
             outputs: vec![1],
         };
         operations.push(operator);
@@ -10410,20 +10418,13 @@ mod tests {
             },
         ];
 
-        let attrs = OperatorOptions::from_json_with_op_type(
-            "cumulativeSum",
-            &serde_json::json!({
-                "axis": 1,
-                "exclusive": true,
-                "reversed": true
-            }),
-        )
-        .unwrap_or_default();
-        let operator = Operation::CumulativeSum {
-            input: 0,
-            options: attrs.as_cumulative_sum().cloned(),
-            outputs: vec![1],
-        };
+        let attrs_val = serde_json::json!({
+            "axis": 1,
+            "exclusive": true,
+            "reversed": true
+        });
+        let operator = Operation::from_json_attributes("cumulativeSum", &[0], &[1], &attrs_val)
+            .expect("cumulativeSum from JSON");
         let operations = vec![operator];
 
         let graph = GraphInfo {
@@ -10539,27 +10540,21 @@ mod tests {
             },
         ];
 
-        let attrs = OperatorOptions::from_json_with_op_type(
+        let attrs_val = serde_json::json!({
+            "hiddenSize": 4,
+            "layout": "rzn",
+            "resetAfter": false,
+            "activations": ["relu", "relu"],
+            "bias": 4,
+            "recurrentBias": 5
+        });
+        let operator = Operation::from_json_attributes(
             "gruCell",
-            &serde_json::json!({
-                "hiddenSize": 4,
-                "layout": "rzn",
-                "resetAfter": false,
-                "activations": ["relu", "relu"]
-            }),
+            &[0, 1, 2, 3, 4, 5],
+            &[6],
+            &attrs_val,
         )
-        .unwrap_or_default();
-        let mut gru_opts = attrs.as_gru_cell().cloned().unwrap_or_default();
-        gru_opts.bias = Some(4);
-        gru_opts.recurrent_bias = Some(5);
-        let operator = Operation::GruCell {
-            input: 0,
-            weight: 1,
-            recurrence: 2,
-            hidden_state: 3,
-            options: Some(gru_opts),
-            outputs: vec![6],
-        };
+        .expect("gruCell from JSON");
         let operations = vec![operator];
 
         let graph = GraphInfo {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -29,6 +29,7 @@ use super::{ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
+use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use trtx::network::Layer;
 use trtx::{
@@ -4518,10 +4519,12 @@ impl TrtxConverter {
             } => (
                 starts,
                 sizes,
-                options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: "Slice operation missing options".to_string(),
-                })?,
+                options
+                    .as_ref()
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "Slice operation missing options".to_string(),
+                    })?,
             ),
             _ => {
                 return Err(GraphError::ConversionFailed {
@@ -4550,10 +4553,7 @@ impl TrtxConverter {
             return Ok(());
         }
         let starts: Vec<i32> = starts_u32.iter().map(|&u| u as i32).collect();
-        let sizes: Vec<i32> = sizes_ml
-            .iter()
-            .map(|d| d.static_or_max() as i32)
-            .collect();
+        let sizes: Vec<i32> = sizes_ml.iter().map(|d| d.static_or_max() as i32).collect();
         let strides: Vec<i32> = if opts.strides.is_empty() {
             vec![1; starts.len()]
         } else {
@@ -4824,18 +4824,18 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let opts = attrs
-            .as_expand()
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Expand operation missing options".to_string(),
-            })?;
-        let new_shape: Vec<i32> = opts
-            .new_shape_static_or_max()
-            .into_iter()
-            .map(|u| u as i32)
-            .collect();
+        let new_shape: Vec<i32> = match operation {
+            Operation::Expand { new_shape, .. } => new_shape
+                .iter()
+                .map(|d| MLDimension::static_or_max(d) as i32)
+                .collect(),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "Internal error: add_expand_op called for non-expand".to_string(),
+                });
+            }
+        };
 
         if new_shape.is_empty() {
             return Err(GraphError::ConversionFailed {
@@ -6197,10 +6197,12 @@ impl TrtxConverter {
             } => (
                 beginning_padding,
                 ending_padding,
-                options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: "Pad operation missing options".to_string(),
-                })?,
+                options
+                    .as_ref()
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "Pad operation missing options".to_string(),
+                    })?,
             ),
             _ => {
                 return Err(GraphError::ConversionFailed {
@@ -7851,18 +7853,15 @@ impl TrtxConverter {
                     reason: format!("Failed to add concatenation: {}", e),
                 })?;
 
-        // WebNN axis (default 0 per spec); use typed options when available
-        let axis_raw = operation
-            .attributes()
-            .as_concat()
-            .map(|opts| opts.axis as i64)
-            .or_else(|| {
-                operation
-                    .attributes()
-                    .get("axis")
-                    .and_then(|v| v.as_i64().or_else(|| v.as_u64().map(|u| u as i64)))
-            })
-            .unwrap_or(0);
+        // WebNN `axis` is a concat() method parameter (see spec).
+        let axis_raw = match operation {
+            Operation::Concat { axis, .. } => *axis as i64,
+            _ => operation
+                .attributes()
+                .get("axis")
+                .and_then(|v| v.as_i64().or_else(|| v.as_u64().map(|u| u as i64)))
+                .unwrap_or(0),
+        };
         let ndim = inputs[0]
             .dimensions()
             .map_err(|e| GraphError::ConversionFailed {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -7985,19 +7985,25 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        // Parse newShape attribute
-        let new_shape = operation
-            .attributes()
-            .get("newShape")
-            .and_then(|v| v.as_array().cloned())
-            .ok_or_else(|| GraphError::ConversionFailed {
+        let new_shape = match operation {
+            Operation::Reshape { new_shape, .. } => new_shape,
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "reshape operation expected".to_string(),
+                });
+            }
+        };
+        if new_shape.is_empty() {
+            return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: "reshape operation missing 'newShape' attribute".to_string(),
-            })?;
+                reason: "reshape operation missing 'newShape'".to_string(),
+            });
+        }
 
-        let dims: Vec<i32> = new_shape
-            .iter()
-            .map(|v| v.as_i64().unwrap_or(0) as i32)
+        let dims: Vec<i32> = crate::operator_options::mldimensions_static_or_max(new_shape)
+            .into_iter()
+            .map(|u| u as i32)
             .collect();
 
         // Use shuffle layer for reshape

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -3235,19 +3235,21 @@ impl TrtxConverter {
             vec![1]
         };
 
-        // Classify optional operands by name: WPT can pass [input, bias] or [input, scale] or [input, scale, bias].
-        let mut scale_id: Option<u32> = None;
-        let mut bias_id: Option<u32> = None;
-        for &operand_id in &operation.input_operands()[1..] {
-            let name = graph
-                .operand(operand_id)
-                .and_then(|o| o.name.as_deref())
-                .unwrap_or("");
-            let name_lower = name.to_lowercase();
-            if name_lower.contains("scale") {
-                scale_id = Some(operand_id);
-            } else if name_lower.contains("bias") {
-                bias_id = Some(operand_id);
+        // Scale/bias operand indices (WebNN MLInstanceNormalizationOptions); optional extras on legacy graphs.
+        let mut scale_id = opts.and_then(|o| o.scale);
+        let mut bias_id = opts.and_then(|o| o.bias);
+        if scale_id.is_none() || bias_id.is_none() {
+            for &operand_id in &operation.input_operands()[1..] {
+                let name = graph
+                    .operand(operand_id)
+                    .and_then(|o| o.name.as_deref())
+                    .unwrap_or("");
+                let name_lower = name.to_lowercase();
+                if scale_id.is_none() && name_lower.contains("scale") {
+                    scale_id = Some(operand_id);
+                } else if bias_id.is_none() && name_lower.contains("bias") {
+                    bias_id = Some(operand_id);
+                }
             }
         }
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -4509,15 +4509,29 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let opts = attrs
-            .as_slice()
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Slice operation missing options".to_string(),
-            })?;
+        let (starts_u32, sizes_ml, opts) = match operation {
+            Operation::Slice {
+                starts,
+                sizes,
+                options,
+                ..
+            } => (
+                starts,
+                sizes,
+                options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "Slice operation missing options".to_string(),
+                })?,
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected Slice operation".to_string(),
+                });
+            }
+        };
         // Empty starts/sizes: no-op (identity), e.g. 0D tensor with empty slices.
-        if opts.starts.is_empty() || opts.sizes.is_empty() {
+        if starts_u32.is_empty() || sizes_ml.is_empty() {
             let id_layer =
                 network
                     .add_identity(input)
@@ -4535,11 +4549,10 @@ impl TrtxConverter {
             tensor_map.insert(output_id, output);
             return Ok(());
         }
-        let starts: Vec<i32> = opts.starts.iter().map(|&u| u as i32).collect();
-        let sizes: Vec<i32> = opts
-            .sizes_static_or_max()
+        let starts: Vec<i32> = starts_u32.iter().map(|&u| u as i32).collect();
+        let sizes: Vec<i32> = sizes_ml
             .iter()
-            .map(|&u| u as i32)
+            .map(|d| d.static_or_max() as i32)
             .collect();
         let strides: Vec<i32> = if opts.strides.is_empty() {
             vec![1; starts.len()]
@@ -4618,7 +4631,16 @@ impl TrtxConverter {
         }
         axis = axis.max(0).min((ndim.saturating_sub(1)) as i32);
 
-        let splits: Vec<i32> = if opts.splits.is_empty() {
+        let split_sizes = match operation {
+            Operation::Split { splits, .. } => splits.as_slice(),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected Split operation".to_string(),
+                });
+            }
+        };
+        let splits: Vec<i32> = if split_sizes.is_empty() {
             let n = operation.output_operands_slice().len();
             if n == 0 {
                 return Err(GraphError::ConversionFailed {
@@ -4631,7 +4653,7 @@ impl TrtxConverter {
             let rem = (dim % n as i32) as usize;
             (0..n).map(|i| base + if i < rem { 1 } else { 0 }).collect()
         } else {
-            opts.splits.iter().map(|&u| u as i32).collect()
+            split_sizes.iter().map(|&u| u as i32).collect()
         };
 
         // One slice per split; start along axis advances by previous split sizes.
@@ -5578,10 +5600,18 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let opts = attrs.as_arg_min_max();
-        let axis = opts.map(|o| o.axis).unwrap_or(0);
-        let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
+        let (axis, keep_dims) = match operation {
+            Operation::ArgMax { axis, options, .. } => (
+                *axis,
+                options.as_ref().map(|o| o.keep_dimensions).unwrap_or(false),
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected ArgMax operation".to_string(),
+                });
+            }
+        };
 
         // TopK operation: 0=kMAX, 1=kMIN
         let layer = network
@@ -5642,10 +5672,18 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let opts = attrs.as_arg_min_max();
-        let axis = opts.map(|o| o.axis).unwrap_or(0);
-        let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
+        let (axis, keep_dims) = match operation {
+            Operation::ArgMin { axis, options, .. } => (
+                *axis,
+                options.as_ref().map(|o| o.keep_dimensions).unwrap_or(false),
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected ArgMin operation".to_string(),
+                });
+            }
+        };
 
         // TopK operation: 0=kMAX, 1=kMIN
         let layer = network
@@ -6150,13 +6188,29 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let opts = attrs.as_pad().ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: "Pad operation missing options".to_string(),
-        })?;
-        let pre_padding: Vec<i32> = opts.beginning_padding.iter().map(|&u| u as i32).collect();
-        let post_padding: Vec<i32> = opts.ending_padding.iter().map(|&u| u as i32).collect();
+        let (beginning_padding, ending_padding, opts) = match operation {
+            Operation::Pad {
+                beginning_padding,
+                ending_padding,
+                options,
+                ..
+            } => (
+                beginning_padding,
+                ending_padding,
+                options.as_ref().ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "Pad operation missing options".to_string(),
+                })?,
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected Pad operation".to_string(),
+                });
+            }
+        };
+        let pre_padding: Vec<i32> = beginning_padding.iter().map(|&u| u as i32).collect();
+        let post_padding: Vec<i32> = ending_padding.iter().map(|&u| u as i32).collect();
         if pre_padding.is_empty() || post_padding.is_empty() {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -7734,14 +7788,15 @@ impl TrtxConverter {
             })?;
 
         // Axis is required by WebNN spec (unsigned long)
-        let positive_axis = operation
-            .attributes()
-            .as_softmax()
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "softmax operation must have options with axis".to_string(),
-            })?
-            .axis;
+        let positive_axis = match operation {
+            Operation::Softmax { axis, .. } => *axis,
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "expected Softmax operation".to_string(),
+                });
+            }
+        };
 
         // TensorRT uses a bitmask where bit N represents axis N
 
@@ -8469,9 +8524,11 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let attrs = operation.attributes();
-        let cum_opts = attrs.as_cumulative_sum();
-        let axis = cum_opts.map(|o| o.axis as usize).unwrap_or(0);
+        let cum_opts = operation.attributes().as_cumulative_sum();
+        let axis = match operation {
+            Operation::CumulativeSum { axis, .. } => *axis as usize,
+            _ => 0,
+        };
         let exclusive = cum_opts.map(|o| o.exclusive).unwrap_or(false);
         let reverse = cum_opts.map(|o| o.reversed).unwrap_or(false);
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -4919,14 +4919,15 @@ impl TrtxConverter {
         tensor_map: &mut HashMap<u32, trtx::Tensor>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let attrs = operation.attributes();
-        let opts = attrs
-            .as_tile()
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Tile operation missing options".to_string(),
-            })?;
-        let repetitions = opts.repetitions.clone();
+        let repetitions = match operation {
+            Operation::Tile { repetitions, .. } => repetitions.clone(),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "Tile operation expected".to_string(),
+                });
+            }
+        };
         if repetitions.is_empty() {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -57,6 +57,12 @@ impl MLDimension {
     }
 }
 
+/// Static size or dynamic `maxSize` for each `MLDimension` (shape hints, CoreML, TRT static paths).
+#[inline]
+pub fn mldimensions_static_or_max(dims: &[MLDimension]) -> Vec<u32> {
+    dims.iter().map(MLDimension::static_or_max).collect()
+}
+
 /// Scalar and sequence parameters that belong on the WebNN graph builder operation
 /// (method arguments) rather than in the options dictionary, as extracted from interchange JSON.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -76,6 +82,8 @@ pub struct OperationExtras {
     pub expand_new_shape: Vec<MLDimension>,
     /// `tile()` method argument `repetitions` (not part of MLOperatorOptions).
     pub repetitions: Vec<u32>,
+    /// `reshape()` method argument `newShape` (not part of MLOperatorOptions).
+    pub reshape_new_shape: Vec<MLDimension>,
 }
 
 impl OperationExtras {
@@ -196,6 +204,13 @@ impl OperationExtras {
             "tile" => {
                 out.repetitions = remove_u32_vec(obj, "repetitions");
             }
+            "reshape" => {
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
+                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                        out.reshape_new_shape = parsed;
+                    }
+                }
+            }
             _ => {}
         }
         out
@@ -244,7 +259,6 @@ fn default_batch_norm_epsilon() -> f64 {
 pub struct MLBatchNormalizationOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX scale and bias are not optional
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
     #[serde(default = "default_batch_norm_axis")]
@@ -271,7 +285,7 @@ impl Default for MLBatchNormalizationOptions {
 pub struct MLClampOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX min_value and max_value are not optional
+    // TODO MTAX MLNumber is an union of any floating point or integral type
     pub min_value: Option<serde_json::Value>, // MLNumber
     pub max_value: Option<serde_json::Value>, // MLNumber
 }
@@ -298,7 +312,6 @@ pub struct MLConv2dOptions {
     pub input_layout: String, // "nchw" | "nhwc"
     #[serde(default)]
     pub filter_layout: String, // "oihw" | "hwio" | "ohwi" | "ihwo"
-    // TODO TMAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -462,7 +475,6 @@ impl Default for MLGemmOptions {
 pub struct MLGruOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX none of the arguments in this struct is optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub initial_hidden_state: Option<OperandIndex>,
@@ -667,7 +679,6 @@ pub struct MLLstmCellOptions {
     // TODO TMAX verify default
     #[serde(default)]
     pub layout: String,
-    // TODO TMAX does not make sense to have an optional vector?
     pub activations: Option<Vec<String>>,
 }
 
@@ -716,28 +727,6 @@ pub struct MLReduceOptions {
     pub axes: Option<Vec<u32>>,
     #[serde(default)]
     pub keep_dimensions: bool,
-}
-
-/// MLReshapeOptions. reshape (newShape from attributes for interchange).
-/// newShape uses MLDimension (static or dynamic) per WebNN IDL.
-// TODO TMAX this enum does not exist
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLReshapeOptions {
-    #[serde(default)]
-    pub label: String,
-    #[serde(default, rename = "newShape")]
-    pub new_shape: Vec<MLDimension>,
-}
-
-impl MLReshapeOptions {
-    /// Returns each dimension as u32 (static value or dynamic maxSize).
-    pub fn new_shape_static_or_max(&self) -> Vec<u32> {
-        self.new_shape
-            .iter()
-            .map(MLDimension::static_or_max)
-            .collect()
-    }
 }
 
 /// MLResample2dOptions. resample2d.
@@ -931,9 +920,6 @@ pub enum OperatorOptions {
     /// MLReduceOptions.
     Reduce(MLReduceOptions),
 
-    /// MLReshapeOptions.
-    Reshape(MLReshapeOptions),
-
     /// MLResample2dOptions.
     Resample2d(MLResample2dOptions),
 
@@ -1019,7 +1005,7 @@ impl OperatorOptions {
                 | "reduceSumSquare" => {
                     try_opt!(MLReduceOptions, Reduce)
                 }
-                "reshape" => try_opt!(MLReshapeOptions, Reshape),
+                "reshape" => try_opt!(MLOperatorOptions, Operator),
                 "resample2d" => try_opt!(MLResample2dOptions, Resample2d),
                 "reverse" => try_opt!(MLReverseOptions, Reverse),
                 "scatterElements" => try_opt!(MLScatterOptions, ScatterElements),
@@ -1207,12 +1193,6 @@ impl OperatorOptions {
     pub fn as_reduce(&self) -> Option<&MLReduceOptions> {
         match self {
             OperatorOptions::Reduce(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_reshape(&self) -> Option<&MLReshapeOptions> {
-        match self {
-            OperatorOptions::Reshape(o) => Some(o),
             _ => None,
         }
     }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -21,8 +21,7 @@
 //! [Web Neural Network API](https://www.w3.org/TR/webnn/) are represented
 //! as an enum: each variant holds the corresponding options struct.
 
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Operand reference (graph operand index). Used in option structs for MLOperand fields.
 pub type OperandIndex = u32;
@@ -73,6 +72,8 @@ pub struct OperationExtras {
     pub sizes: Vec<MLDimension>,
     pub splits: Vec<u32>,
     pub split_equal_parts: Option<u32>,
+    /// `expand()` method argument `newShape` (not part of MLOperatorOptions).
+    pub expand_new_shape: Vec<MLDimension>,
 }
 
 impl OperationExtras {
@@ -102,13 +103,27 @@ impl OperationExtras {
                 out.axis = remove_u32(obj, "axis");
             }
             "cast" => {
-                if let Some(s) = obj.remove("to").and_then(|x| x.as_str().map(|s| s.to_string())) {
+                if let Some(s) = obj
+                    .remove("to")
+                    .and_then(|x| x.as_str().map(|s| s.to_string()))
+                {
                     out.to_data_type = Some(s);
                 } else if let Some(s) = obj
                     .remove("dataType")
                     .and_then(|x| x.as_str().map(|s| s.to_string()))
                 {
                     out.to_data_type = Some(s);
+                }
+            }
+            "concat" => {
+                out.axis = remove_u32(obj, "axis");
+            }
+            "expand" => {
+                let _ = obj.remove("axes");
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
+                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                        out.expand_new_shape = parsed;
+                    }
                 }
             }
             "cumulativeSum" => {
@@ -120,12 +135,12 @@ impl OperationExtras {
             }
             "gru" => {
                 out.steps = remove_u32(obj, "steps");
-                out.hidden_size = remove_u32(obj, "hiddenSize")
-                    .or_else(|| remove_u32(obj, "hidden_size"));
+                out.hidden_size =
+                    remove_u32(obj, "hiddenSize").or_else(|| remove_u32(obj, "hidden_size"));
             }
             "gruCell" => {
-                out.hidden_size = remove_u32(obj, "hiddenSize")
-                    .or_else(|| remove_u32(obj, "hidden_size"));
+                out.hidden_size =
+                    remove_u32(obj, "hiddenSize").or_else(|| remove_u32(obj, "hidden_size"));
             }
             "pad" => {
                 out.beginning_padding = remove_u32_vec(obj, "beginningPadding");
@@ -298,8 +313,6 @@ pub struct MLConvTranspose2dOptions {
     pub dilations: Vec<u32>,
     #[serde(default)]
     pub output_padding: Vec<u32>,
-    /// Output spatial shape [H, W]. WebNN camelCase: outputSizes.
-    /// TOOD MTAX outputSizes is not optional
     pub output_sizes: Option<Vec<u32>>,
     #[serde(default = "default_conv_groups")]
     pub groups: u32,
@@ -307,7 +320,6 @@ pub struct MLConvTranspose2dOptions {
     pub input_layout: String,
     #[serde(default)]
     pub filter_layout: String, // "iohw" | "hwoi" | "ohwi"
-    // TODO TMAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -329,7 +341,7 @@ impl Default for MLConvTranspose2dOptions {
 }
 
 /// MLConstantOptions. constant (interchange: init, data, dataType, shape).
-// TODO TMAX non-existing struct
+// TODO MTAX non-existing struct
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConstantOptions {
@@ -343,17 +355,6 @@ pub struct MLConstantOptions {
     pub shape: Vec<u32>,
 }
 
-/// MLConcatOptions. concat.
-// TODO TMAX non-existing struct
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLConcatOptions {
-    #[serde(default)]
-    pub label: String,
-    #[serde(default)]
-    pub axis: u32,
-}
-
 /// MLCumulativeSumOptions. cumulativeSum (axis is a builder method parameter).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -364,31 +365,6 @@ pub struct MLCumulativeSumOptions {
     pub exclusive: bool,
     #[serde(default)]
     pub reversed: bool,
-}
-
-/// MLExpandOptions. expand (newShape or axes from attributes for interchange).
-/// newShape uses MLDimension (static or dynamic) per WebNN IDL.
-// TODO TMAX MLExpandOptions does not exist
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLExpandOptions {
-    #[serde(default)]
-    pub label: String,
-    #[serde(default, rename = "newShape")]
-    pub new_shape: Vec<MLDimension>,
-    /// TODO axis is not part of expand?
-    #[serde(default)]
-    pub axes: Vec<u32>,
-}
-
-impl MLExpandOptions {
-    /// Returns each dimension as u32 (static value or dynamic maxSize).
-    pub fn new_shape_static_or_max(&self) -> Vec<u32> {
-        self.new_shape
-            .iter()
-            .map(MLDimension::static_or_max)
-            .collect()
-    }
 }
 
 fn default_elu_alpha() -> f64 {
@@ -590,7 +566,7 @@ pub struct MLLayerNormalizationOptions {
     #[serde(default)]
     pub has_bias: Option<bool>,
     /// Omitted in JSON => None => use spec default [1..rank). Present (including []) => use as-is.
-    // TODO TMAX axis is not an option. 
+    // TODO TMAX axis is not an option.
     pub axes: Option<Vec<u32>>,
     #[serde(default = "default_layer_norm_epsilon")]
     pub epsilon: f64,
@@ -720,7 +696,7 @@ pub struct MLPadOptions {
 pub struct MLPool2dOptions {
     #[serde(default)]
     pub label: String,
-    /// TODOX MTAX the spec is below. I guess this can be interpreted as optional? 
+    /// TODO MTAX the spec is below. I guess this can be interpreted as optional?
     /// windowDimensions, of type sequence<[EnforceRange] unsigned long>
     /// A list of length 2: [windowHeight, windowWidth]. Specifies the dimensions of the sliding window. The default value for the window dimensions are the height and width dimensions of the input shape.
     pub window_dimensions: Option<Vec<u32>>,
@@ -813,7 +789,7 @@ pub struct MLReverseOptions {
 #[serde(rename_all = "camelCase")]
 pub struct MLScatterOptions {
     #[serde(default)]
-    pub label: String,  
+    pub label: String,
     #[serde(default)]
     pub axis: u32,
 }
@@ -935,14 +911,8 @@ pub enum OperatorOptions {
     /// MLConvTranspose2dOptions.
     ConvTranspose2d(MLConvTranspose2dOptions),
 
-    /// MLConcatOptions.
-    Concat(MLConcatOptions),
-
     /// MLCumulativeSumOptions.
     CumulativeSum(MLCumulativeSumOptions),
-
-    /// MLExpandOptions.
-    Expand(MLExpandOptions),
 
     /// MLEluOptions.
     Elu(MLEluOptions),
@@ -1053,10 +1023,10 @@ impl OperatorOptions {
                 "clamp" => try_opt!(MLClampOptions, Clamp),
                 "conv2d" => try_opt!(MLConv2dOptions, Conv2d),
                 "convTranspose2d" => try_opt!(MLConvTranspose2dOptions, ConvTranspose2d),
-                "concat" => try_opt!(MLConcatOptions, Concat),
+                "concat" => try_opt!(MLOperatorOptions, Operator),
                 "constant" => try_opt!(MLConstantOptions, Constant),
                 "cumulativeSum" => try_opt!(MLCumulativeSumOptions, CumulativeSum),
-                "expand" => try_opt!(MLExpandOptions, Expand),
+                "expand" => try_opt!(MLOperatorOptions, Operator),
                 "elu" => try_opt!(MLEluOptions, Elu),
                 "gather" | "gatherElements" => try_opt!(MLGatherOptions, Gather),
                 "gemm" => try_opt!(MLGemmOptions, Gemm),
@@ -1073,7 +1043,8 @@ impl OperatorOptions {
                 "lstm" => try_opt!(MLLstmOptions, Lstm),
                 "lstmCell" => try_opt!(MLLstmCellOptions, LstmCell),
                 "pad" => try_opt!(MLPadOptions, Pad),
-                "averagePool2d" | "maxPool2d" | "l2Pool2d" => try_opt!(MLPool2dOptions, Pool2d),
+                "averagePool2d" | "maxPool2d" | "l2Pool2d" | "globalAveragePool"
+                | "globalMaxPool" => try_opt!(MLPool2dOptions, Pool2d),
                 "reduceSum" | "reduceMean" | "reduceMax" | "reduceMin" | "reduceProduct"
                 | "reduceL1" | "reduceL2" | "reduceLogSum" | "reduceLogSumExp"
                 | "reduceSumSquare" => {
@@ -1159,12 +1130,6 @@ impl OperatorOptions {
     pub fn as_conv2d(&self) -> Option<&MLConv2dOptions> {
         match self {
             OperatorOptions::Conv2d(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_concat(&self) -> Option<&MLConcatOptions> {
-        match self {
-            OperatorOptions::Concat(o) => Some(o),
             _ => None,
         }
     }
@@ -1339,12 +1304,6 @@ impl OperatorOptions {
     pub fn as_triangular(&self) -> Option<&MLTriangularOptions> {
         match self {
             OperatorOptions::Triangular(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_expand(&self) -> Option<&MLExpandOptions> {
-        match self {
-            OperatorOptions::Expand(o) => Some(o),
             _ => None,
         }
     }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -142,6 +142,13 @@ impl OperationExtras {
                 out.hidden_size =
                     remove_u32(obj, "hiddenSize").or_else(|| remove_u32(obj, "hidden_size"));
             }
+            "instanceNormalization" => {
+                // Legacy interchange; not part of MLInstanceNormalizationOptions.
+                let _ = obj.remove("hasScale");
+                let _ = obj.remove("hasBias");
+                let _ = obj.remove("has_scale");
+                let _ = obj.remove("has_bias");
+            }
             "pad" => {
                 out.beginning_padding = remove_u32_vec(obj, "beginningPadding");
                 if out.beginning_padding.is_empty() {
@@ -465,14 +472,12 @@ pub struct MLGruOptions {
 pub struct MLGruCellOptions {
     #[serde(default)]
     pub label: String,
-    // TODO MTAX bias and recurrent_bias is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     #[serde(default)]
     pub reset_after: bool,
     #[serde(default)]
     pub layout: String,
-    // TODO TMAX activations is not optional. does it make sense to have an option instead of an empty vector
     pub activations: Option<Vec<String>>,
 }
 
@@ -516,16 +521,8 @@ fn default_instance_norm_epsilon() -> f64 {
 pub struct MLInstanceNormalizationOptions {
     #[serde(default)]
     pub label: String,
-    // TODO MTAX scale and bias are not optional
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
-    /// When exactly one of scale/bias is provided (2 operands), disambiguates so converters
-    /// know which optional is present. Omitted when 1 or 3 operands.
-    // TODO TMAX has_Scale, has_bias are not part of this struct
-    #[serde(default)]
-    pub has_scale: Option<bool>,
-    #[serde(default)]
-    pub has_bias: Option<bool>,
     #[serde(default = "default_instance_norm_epsilon")]
     pub epsilon: f64,
     #[serde(default)]
@@ -538,8 +535,6 @@ impl Default for MLInstanceNormalizationOptions {
             label: String::new(),
             scale: None,
             bias: None,
-            has_scale: None,
-            has_bias: None,
             epsilon: default_instance_norm_epsilon(),
             layout: String::new(), // TODO TMAX the default is "nchw"
         }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -222,6 +222,8 @@ impl OperationExtras {
 // ---------------------------------------------------------------------------
 
 /// MLOperatorOptions. Base type for all operator options (label only).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mloperatoroptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLOperatorOptions {
@@ -234,6 +236,8 @@ pub struct MLOperatorOptions {
 // ---------------------------------------------------------------------------
 
 /// MLArgMinMaxOptions. argMin / argMax (axis is a builder method parameter, not in this dictionary).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlargminmaxoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLArgMinMaxOptions {
@@ -254,6 +258,8 @@ fn default_batch_norm_epsilon() -> f64 {
 }
 
 /// MLBatchNormalizationOptions. batchNormalization.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlbatchnormalizationoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLBatchNormalizationOptions {
@@ -280,6 +286,8 @@ impl Default for MLBatchNormalizationOptions {
 }
 
 /// MLClampOptions. clamp.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlclampoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLClampOptions {
@@ -295,6 +303,8 @@ fn default_conv_groups() -> u32 {
 }
 
 /// MLConv2dOptions. conv2d.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlconv2doptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConv2dOptions {
@@ -372,7 +382,9 @@ impl Default for MLConvTranspose2dOptions {
 }
 
 /// MLConstantOptions. constant (interchange: init, data, dataType, shape).
-// TODO MTAX non-existing struct
+///
+/// Not an IDL dictionary; closest normative API is [`MLGraphBuilder`](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder) (`constant()` methods).
+// TODO MTAX non-existing struct. defer removal for now since it's not like any other operation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConstantOptions {
@@ -387,6 +399,8 @@ pub struct MLConstantOptions {
 }
 
 /// MLCumulativeSumOptions. cumulativeSum (axis is a builder method parameter).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlcumulativesumoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLCumulativeSumOptions {
@@ -403,6 +417,8 @@ fn default_elu_alpha() -> f64 {
 }
 
 /// MLEluOptions. elu.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mleluoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLEluOptions {
@@ -422,6 +438,8 @@ impl Default for MLEluOptions {
 }
 
 /// MLGatherOptions. gather / gatherElements (batchDimensions is a gatherElements parameter in WebNN).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlgatheroptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLGatherOptions {
@@ -440,6 +458,8 @@ fn default_gemm_beta() -> f64 {
 }
 
 /// MLGemmOptions. gemm.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlgemmoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLGemmOptions {
@@ -470,6 +490,8 @@ impl Default for MLGemmOptions {
 }
 
 /// MLGruOptions. gru.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlgruoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLGruOptions {
@@ -490,6 +512,8 @@ pub struct MLGruOptions {
 }
 
 /// MLGruCellOptions. gruCell.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlgrucelloptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLGruCellOptions {
@@ -513,6 +537,8 @@ fn default_hard_sigmoid_beta() -> f64 {
 }
 
 /// MLHardSigmoidOptions. hardSigmoid.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlhardsigmoidoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLHardSigmoidOptions {
@@ -539,6 +565,8 @@ fn default_instance_norm_epsilon() -> f64 {
 }
 
 /// MLInstanceNormalizationOptions. instanceNormalization.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlinstancenormalizationoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLInstanceNormalizationOptions {
@@ -570,6 +598,8 @@ fn default_layer_norm_epsilon() -> f64 {
 
 /// MLLayerNormalizationOptions. layerNormalization.
 /// `axes`: None = key omitted (spec default [1..rank)); Some(v) = use v (Some(vec![]) = reduce over no axes).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mllayernormalizationoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLayerNormalizationOptions {
@@ -599,6 +629,8 @@ fn default_leaky_relu_alpha() -> f64 {
 }
 
 /// MLLeakyReluOptions. leakyRelu.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlleakyreluoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLeakyReluOptions {
@@ -626,6 +658,8 @@ fn default_linear_beta() -> f64 {
 }
 
 /// MLLinearOptions. linear.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mllinearoptions>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLinearOptions {
@@ -648,6 +682,8 @@ impl Default for MLLinearOptions {
 }
 
 /// MLLstmOptions. lstm.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mllstmoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLstmOptions {
@@ -668,6 +704,8 @@ pub struct MLLstmOptions {
 }
 
 /// MLLstmCellOptions. lstmCell.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mllstmcelloptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLstmCellOptions {
@@ -683,6 +721,8 @@ pub struct MLLstmCellOptions {
 }
 
 /// MLPadOptions. pad (beginning/ending padding are builder method parameters).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlpadoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLPadOptions {
@@ -695,6 +735,8 @@ pub struct MLPadOptions {
 }
 
 /// MLPool2dOptions. averagePool2d / l2Pool2d / maxPool2d.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlpool2doptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLPool2dOptions {
@@ -719,6 +761,8 @@ pub struct MLPool2dOptions {
 
 /// MLReduceOptions. reduceL1, reduceL2, reduceLogSum, etc.
 /// `axes`: None = key omitted (spec default: all axes); Some(v) = use v (Some(vec![]) = reduce over no axes).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlreduceoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLReduceOptions {
@@ -730,6 +774,8 @@ pub struct MLReduceOptions {
 }
 
 /// MLResample2dOptions. resample2d.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlresample2doptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLResample2dOptions {
@@ -749,6 +795,8 @@ pub struct MLResample2dOptions {
 
 /// MLReverseOptions. reverse.
 /// axes: omitted => reverse all dimensions; present and [] => reverse none (identity); present and [..] => reverse those axes.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlreverseoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLReverseOptions {
@@ -758,7 +806,9 @@ pub struct MLReverseOptions {
     pub axes: Option<Vec<u32>>,
 }
 
-/// MLScatterOptions. scatterElements
+/// MLScatterOptions. scatterElements / scatterND.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlscatteroptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLScatterOptions {
@@ -769,6 +819,8 @@ pub struct MLScatterOptions {
 }
 
 /// MLSliceOptions. slice (starts and sizes are builder method parameters).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlsliceoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSliceOptions {
@@ -779,6 +831,8 @@ pub struct MLSliceOptions {
 }
 
 /// MLSplitOptions. split (splits is a builder method parameter).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlsplitoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSplitOptions {
@@ -789,6 +843,8 @@ pub struct MLSplitOptions {
 }
 
 /// MLTransposeOptions. transpose.
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mltransposeoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLTransposeOptions {
@@ -807,6 +863,8 @@ pub struct MLTransposeOptions {
 // TODO TMAX remove the unofficial ops!
 
 /// MLSqueezeOptions. squeeze (emulation-only; not in WebNN IDL).
+///
+/// WebNN emulation: <https://www.w3.org/TR/webnn/#squeeze>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSqueezeOptions {
@@ -817,6 +875,8 @@ pub struct MLSqueezeOptions {
 }
 
 /// MLUnsqueezeOptions. unsqueeze (emulation-only; not in WebNN IDL).
+///
+/// WebNN emulation: <https://www.w3.org/TR/webnn/#unsqueeze>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLUnsqueezeOptions {
@@ -828,13 +888,13 @@ pub struct MLUnsqueezeOptions {
 
 /// MLTriangularOptions. triangular.
 /// WebNN: when "upper" is not present, default is true (keep upper triangular).
+///
+/// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mltriangularoptions>
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLTriangularOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO upper is not optional
-    /// None = not present => default true (upper). Some(b) => use b.
     pub upper: Option<bool>,
     #[serde(default)]
     pub diagonal: i32,

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -58,6 +58,117 @@ impl MLDimension {
     }
 }
 
+/// Scalar and sequence parameters that belong on the WebNN graph builder operation
+/// (method arguments) rather than in the options dictionary, as extracted from interchange JSON.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct OperationExtras {
+    pub axis: Option<u32>,
+    pub to_data_type: Option<String>,
+    pub batch_dimensions: Option<u32>,
+    pub steps: Option<u32>,
+    pub hidden_size: Option<u32>,
+    pub beginning_padding: Vec<u32>,
+    pub ending_padding: Vec<u32>,
+    pub starts: Vec<u32>,
+    pub sizes: Vec<MLDimension>,
+    pub splits: Vec<u32>,
+    pub split_equal_parts: Option<u32>,
+}
+
+impl OperationExtras {
+    /// Remove operation-level keys from `v` (must be a JSON object) and return their values.
+    pub fn extract_and_strip(op_type: &str, v: &mut serde_json::Value) -> Self {
+        let mut out = Self::default();
+        let Some(obj) = v.as_object_mut() else {
+            return out;
+        };
+        let op = op_type.trim();
+        fn remove_u32(
+            obj: &mut serde_json::Map<String, serde_json::Value>,
+            key: &str,
+        ) -> Option<u32> {
+            obj.remove(key).and_then(|x| x.as_u64().map(|n| n as u32))
+        }
+        fn remove_u32_vec(
+            obj: &mut serde_json::Map<String, serde_json::Value>,
+            key: &str,
+        ) -> Vec<u32> {
+            obj.remove(key)
+                .and_then(|x| serde_json::from_value::<Vec<u32>>(x).ok())
+                .unwrap_or_default()
+        }
+        match op {
+            "argMin" | "argMax" => {
+                out.axis = remove_u32(obj, "axis");
+            }
+            "cast" => {
+                if let Some(s) = obj.remove("to").and_then(|x| x.as_str().map(|s| s.to_string())) {
+                    out.to_data_type = Some(s);
+                } else if let Some(s) = obj
+                    .remove("dataType")
+                    .and_then(|x| x.as_str().map(|s| s.to_string()))
+                {
+                    out.to_data_type = Some(s);
+                }
+            }
+            "cumulativeSum" => {
+                out.axis = remove_u32(obj, "axis");
+            }
+            "gather" | "gatherElements" => {
+                out.batch_dimensions = remove_u32(obj, "batchDimensions")
+                    .or_else(|| remove_u32(obj, "batch_dimensions"));
+            }
+            "gru" => {
+                out.steps = remove_u32(obj, "steps");
+                out.hidden_size = remove_u32(obj, "hiddenSize")
+                    .or_else(|| remove_u32(obj, "hidden_size"));
+            }
+            "gruCell" => {
+                out.hidden_size = remove_u32(obj, "hiddenSize")
+                    .or_else(|| remove_u32(obj, "hidden_size"));
+            }
+            "pad" => {
+                out.beginning_padding = remove_u32_vec(obj, "beginningPadding");
+                if out.beginning_padding.is_empty() {
+                    out.beginning_padding = remove_u32_vec(obj, "beginning_padding");
+                }
+                out.ending_padding = remove_u32_vec(obj, "endingPadding");
+                if out.ending_padding.is_empty() {
+                    out.ending_padding = remove_u32_vec(obj, "ending_padding");
+                }
+            }
+            "softmax" => {
+                out.axis = remove_u32(obj, "axis");
+            }
+            "slice" => {
+                out.starts = remove_u32_vec(obj, "starts");
+                if let Some(s) = obj.remove("sizes") {
+                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
+                        out.sizes = parsed;
+                    }
+                }
+            }
+            "split" => {
+                if let Some(sv) = obj.remove("splits") {
+                    match sv {
+                        serde_json::Value::Number(n) => {
+                            out.split_equal_parts = n.as_u64().map(|u| u as u32);
+                        }
+                        serde_json::Value::Array(_) => {
+                            if let Ok(parsed) = serde_json::from_value::<Vec<u32>>(sv) {
+                                out.splits = parsed;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+        out
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Base: MLOperatorOptions
 // ---------------------------------------------------------------------------
@@ -74,16 +185,12 @@ pub struct MLOperatorOptions {
 // Dictionaries extending MLOperatorOptions (spec order)
 // ---------------------------------------------------------------------------
 
-/// TODO MTAX put in link to w3c spec for all structss
-/// MLArgMinMaxOptions. argMin / argMax.
+/// MLArgMinMaxOptions. argMin / argMax (axis is a builder method parameter, not in this dictionary).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLArgMinMaxOptions {
     #[serde(default)]
     pub label: String,
-    // TODO MTAX axis and keep_dimensions is not part of the orignal struct
-    #[serde(default)]
-    pub axis: u32,
     #[serde(default)]
     pub keep_dimensions: bool,
     #[serde(default)]
@@ -104,7 +211,7 @@ fn default_batch_norm_epsilon() -> f64 {
 pub struct MLBatchNormalizationOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX scale and bias are not optional
+    // TODO TMAX scale and bias are not optional
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
     #[serde(default = "default_batch_norm_axis")]
@@ -125,26 +232,13 @@ impl Default for MLBatchNormalizationOptions {
     }
 }
 
-/// MLCastOptions. cast.
-/// TODO MTAX there is no MLCastOptions. The operator uses MLOperatorOptions
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLCastOptions {
-    #[serde(default)]
-    pub label: String,
-    /// Target data type (e.g. "float32", "int32").
-    /// TODO MTAX to is part of the operator
-    #[serde(default)]
-    pub to: String, 
-}
-
 /// MLClampOptions. clamp.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLClampOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX min_value and max_value are not optional
+    // TODO TMAX min_value and max_value are not optional
     pub min_value: Option<serde_json::Value>, // MLNumber
     pub max_value: Option<serde_json::Value>, // MLNumber
 }
@@ -171,7 +265,7 @@ pub struct MLConv2dOptions {
     pub input_layout: String, // "nchw" | "nhwc"
     #[serde(default)]
     pub filter_layout: String, // "oihw" | "hwio" | "ohwi" | "ihwo"
-    /// TODO MTAX bias is not optional
+    // TODO TMAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -213,7 +307,7 @@ pub struct MLConvTranspose2dOptions {
     pub input_layout: String,
     #[serde(default)]
     pub filter_layout: String, // "iohw" | "hwoi" | "ohwi"
-    /// TODO MTAX bias is not optional
+    // TODO TMAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -235,7 +329,7 @@ impl Default for MLConvTranspose2dOptions {
 }
 
 /// MLConstantOptions. constant (interchange: init, data, dataType, shape).
-/// TODO MTAX non-existing struct
+// TODO TMAX non-existing struct
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConstantOptions {
@@ -250,7 +344,7 @@ pub struct MLConstantOptions {
 }
 
 /// MLConcatOptions. concat.
-/// TODO MTAX non-existing struct
+// TODO TMAX non-existing struct
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConcatOptions {
@@ -260,16 +354,12 @@ pub struct MLConcatOptions {
     pub axis: u32,
 }
 
-/// MLCumulativeSumOptions. cumulativeSum.
+/// MLCumulativeSumOptions. cumulativeSum (axis is a builder method parameter).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLCumulativeSumOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX axis is not part of the struct
-    #[serde(default)]
-    pub axis: u32,
-    /// TODO MTAX exclusive and reserved have a default value of false
     #[serde(default)]
     pub exclusive: bool,
     #[serde(default)]
@@ -278,7 +368,7 @@ pub struct MLCumulativeSumOptions {
 
 /// MLExpandOptions. expand (newShape or axes from attributes for interchange).
 /// newShape uses MLDimension (static or dynamic) per WebNN IDL.
-/// TODO MTAX MLExpandOptions does not exist
+// TODO TMAX MLExpandOptions does not exist
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLExpandOptions {
@@ -324,7 +414,7 @@ impl Default for MLEluOptions {
     }
 }
 
-/// MLGatherOptions. gather / gatherElements.
+/// MLGatherOptions. gather / gatherElements (batchDimensions is a gatherElements parameter in WebNN).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLGatherOptions {
@@ -332,9 +422,6 @@ pub struct MLGatherOptions {
     pub label: String,
     #[serde(default)]
     pub axis: u32,
-    /// gatherElements: batchDimensions (optional).
-    /// TODO MTAX batch_dimensions is not part of this struct
-    pub batch_dimensions: Option<u32>,
 }
 
 fn default_gemm_alpha() -> f64 {
@@ -381,7 +468,7 @@ impl Default for MLGemmOptions {
 pub struct MLGruOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX none of the arguments in this struct is optional
+    // TODO TMAX none of the arguments in this struct is optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub initial_hidden_state: Option<OperandIndex>,
@@ -394,8 +481,6 @@ pub struct MLGruOptions {
     #[serde(default)]
     pub layout: String, // "zrn" | "rzn"
     pub activations: Option<Vec<String>>, // MLRecurrentNetworkActivation
-    /// TODO MTAX hidden_size is not part of this struct. it is passed to the operator.
-    pub hidden_size: Option<u32>,
 }
 
 /// MLGruCellOptions. gruCell.
@@ -411,10 +496,8 @@ pub struct MLGruCellOptions {
     pub reset_after: bool,
     #[serde(default)]
     pub layout: String,
-    /// TODO MTAX activations is not optional. does it make sense to have an option instead of an empty vector
+    // TODO TMAX activations is not optional. does it make sense to have an option instead of an empty vector
     pub activations: Option<Vec<String>>,
-    /// TODO MTAX hidden_size is not part of this struct. it is part of the operator.
-    pub hidden_size: Option<u32>,
 }
 
 fn default_hard_sigmoid_alpha() -> f64 {
@@ -447,37 +530,6 @@ impl Default for MLHardSigmoidOptions {
     }
 }
 
-fn default_hard_swish_alpha() -> f64 {
-    1.0 / 6.0
-}
-
-fn default_hard_swish_beta() -> f64 {
-    0.5
-}
-
-/// MLHardSwishOptions. hardSwish (optional alpha/beta for interchange).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLHardSwishOptions {
-    #[serde(default)]
-    pub label: String,
-    // TODO MTAX alpha and beta are not part of this struct. the default functions could go as well.
-    #[serde(default = "default_hard_swish_alpha")]
-    pub alpha: f64,
-    #[serde(default = "default_hard_swish_beta")]
-    pub beta: f64,
-}
-
-impl Default for MLHardSwishOptions {
-    fn default() -> Self {
-        Self {
-            label: String::new(),
-            alpha: default_hard_swish_alpha(),
-            beta: default_hard_swish_beta(),
-        }
-    }
-}
-
 fn default_instance_norm_epsilon() -> f64 {
     1e-5
 }
@@ -493,7 +545,7 @@ pub struct MLInstanceNormalizationOptions {
     pub bias: Option<OperandIndex>,
     /// When exactly one of scale/bias is provided (2 operands), disambiguates so converters
     /// know which optional is present. Omitted when 1 or 3 operands.
-    /// TODO MTAX has_Scale, has_bias are not part of this struct
+    // TODO TMAX has_Scale, has_bias are not part of this struct
     #[serde(default)]
     pub has_scale: Option<bool>,
     #[serde(default)]
@@ -513,7 +565,7 @@ impl Default for MLInstanceNormalizationOptions {
             has_scale: None,
             has_bias: None,
             epsilon: default_instance_norm_epsilon(),
-            layout: String::new(), /// TODO MTAX the default is "nchw"
+            layout: String::new(), // TODO TMAX the default is "nchw"
         }
     }
 }
@@ -538,7 +590,7 @@ pub struct MLLayerNormalizationOptions {
     #[serde(default)]
     pub has_bias: Option<bool>,
     /// Omitted in JSON => None => use spec default [1..rank). Present (including []) => use as-is.
-    /// TODO MTAX axis is not an option. 
+    // TODO TMAX axis is not an option. 
     pub axes: Option<Vec<u32>>,
     #[serde(default = "default_layer_norm_epsilon")]
     pub epsilon: f64,
@@ -612,13 +664,13 @@ impl Default for MLLinearOptions {
 }
 
 /// MLLstmOptions. lstm.
-/// TODO MTAX where is the default implementation for this struct?
+// TODO TMAX where is the default implementation for this struct?
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLstmOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX bias, recurrent_bias and peephole_weight is not optional
+    // TODO TMAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
@@ -639,34 +691,27 @@ pub struct MLLstmOptions {
 pub struct MLLstmCellOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX bias, recurrent_bias and peephole_weight is not optional
+    // TODO TMAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
-    /// TODO MTAX verify default
+    // TODO TMAX verify default
     #[serde(default)]
     pub layout: String,
-    /// TODO MTAX does not make sense to have an optional vector?
+    // TODO TMAX does not make sense to have an optional vector?
     pub activations: Option<Vec<String>>,
 }
 
-/// MLPadOptions. pad.
-/// Note: In WebNN, padding lengths are MLOperands; we also support serializing them as
-/// beginning_padding/ending_padding arrays for graph interchange.
+/// MLPadOptions. pad (beginning/ending padding are builder method parameters).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLPadOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX mode is an enum of type MLPaddingMode
+    // TODO TMAX mode is an enum of type MLPaddingMode
     #[serde(default)]
     pub mode: String, // "constant" | "edge" | "reflection"
     pub value: Option<serde_json::Value>, // MLNumber
-    /// TODO MTAX beginning_padding and ending_pading are part of the Operator
-    #[serde(default, rename = "beginningPadding")]
-    pub beginning_padding: Vec<u32>,
-    #[serde(default, rename = "endingPadding")]
-    pub ending_padding: Vec<u32>,
 }
 
 /// MLPool2dOptions. averagePool2d / l2Pool2d / maxPool2d.
@@ -679,21 +724,21 @@ pub struct MLPool2dOptions {
     /// windowDimensions, of type sequence<[EnforceRange] unsigned long>
     /// A list of length 2: [windowHeight, windowWidth]. Specifies the dimensions of the sliding window. The default value for the window dimensions are the height and width dimensions of the input shape.
     pub window_dimensions: Option<Vec<u32>>,
-    /// TODO MTAX check default value
+    // TODO TMAX check default value
     #[serde(default)]
     pub padding: Vec<u32>,
     #[serde(default)]
     pub strides: Vec<u32>,
     #[serde(default)]
     pub dilations: Vec<u32>,
-    /// TODO MTAX layout is enum MLInputOperandLayout
+    // TODO TMAX layout is enum MLInputOperandLayout
     #[serde(default)]
     pub layout: String,
     /// "floor" | "ceil". WebNN spec and WPT use "roundingType"; we accept both keys.
-    /// TODO MTAX enum MLRoundingType
+    // TODO TMAX enum MLRoundingType
     #[serde(default, alias = "roundingType")]
     pub output_shape_rounding: String,
-    /// TODO MTAX the specs reads 'if specified'. it's unclear what unspecified means
+    // TODO TMAX the specs reads 'if specified'. it's unclear what unspecified means
     /// outputSizes, of type sequence<[EnforceRange] unsigned long>
     /// A list of length 2: [outputHeight, outputWidth] Specifies the sizes of the two spatial dimensions of the output tensor. When the output sizes are explicitly specified, the outputShapeRounding is ignored. If not specified, the output sizes are automatically computed.
     pub output_sizes: Option<Vec<u32>>,
@@ -714,7 +759,7 @@ pub struct MLReduceOptions {
 
 /// MLReshapeOptions. reshape (newShape from attributes for interchange).
 /// newShape uses MLDimension (static or dynamic) per WebNN IDL.
-/// TODO MTAX this enum does not exist
+// TODO TMAX this enum does not exist
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLReshapeOptions {
@@ -740,10 +785,10 @@ impl MLReshapeOptions {
 pub struct MLResample2dOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX enum MLInterpolationMode
+    // TODO TMAX enum MLInterpolationMode
     #[serde(default)]
     pub mode: String, // "nearest-neighbor" | "linear"
-    /// TODO MTAX defaults for scales and sizes?
+    // TODO TMAX defaults for scales and sizes?
     #[serde(default)]
     pub scales: Vec<f32>,
     pub sizes: Option<Vec<u32>>,
@@ -763,17 +808,6 @@ pub struct MLReverseOptions {
     pub axes: Option<Vec<u32>>,
 }
 
-/// MLSoftmaxOptions. softmax.
-/// TODO MTAX not actual struct, axis is part of the operator
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLSoftmaxOptions {
-    #[serde(default)]
-    pub label: String,
-    #[serde(default)]
-    pub axis: u32,
-}
-
 /// MLScatterOptions. scatterElements
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -784,59 +818,17 @@ pub struct MLScatterOptions {
     pub axis: u32,
 }
 
-/// MLSliceOptions. slice.
-/// In WebNN, starts/sizes are MLOperands; we also support them as arrays for interchange.
-/// `sizes` uses MLDimension (static or dynamic) per WebNN IDL.
+/// MLSliceOptions. slice (starts and sizes are builder method parameters).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSliceOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX starts, sizes are part of the operator.
-    #[serde(default)]
-    pub starts: Vec<u32>,
-    #[serde(default)]
-    pub sizes: Vec<MLDimension>,
     #[serde(default)]
     pub strides: Vec<u32>,
 }
 
-impl MLSliceOptions {
-    /// Returns each size dimension as u32 (static value or dynamic maxSize).
-    pub fn sizes_static_or_max(&self) -> Vec<u32> {
-        self.sizes.iter().map(MLDimension::static_or_max).collect()
-    }
-}
-
-/// Deserialize splits as either a number (equal-split count; store empty vec, TRTX uses output count)
-/// or an array of sizes.
-fn deserialize_splits<'de, D>(d: D) -> Result<Vec<u32>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let v = serde_json::Value::deserialize(d)?;
-    match v {
-        serde_json::Value::Number(n) => {
-            let _ = n
-                .as_u64()
-                .ok_or_else(|| D::Error::custom("splits number out of range"))?;
-            Ok(Vec::new())
-        }
-        serde_json::Value::Array(arr) => arr
-            .iter()
-            .map(|e| {
-                e.as_u64()
-                    .ok_or_else(|| D::Error::custom("splits array element not u64"))
-                    .map(|u| u as u32)
-            })
-            .collect::<Result<Vec<u32>, _>>(),
-        serde_json::Value::Null => Ok(Vec::new()),
-        _ => Err(D::Error::custom("splits must be number or array")),
-    }
-}
-
-/// MLSplitOptions. split.
-/// Splits array from attributes for interchange (WebNN also has splits as MLOperand or number).
+/// MLSplitOptions. split (splits is a builder method parameter).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSplitOptions {
@@ -844,9 +836,6 @@ pub struct MLSplitOptions {
     pub label: String,
     #[serde(default)]
     pub axis: u32,
-    /// TODO MTAX splits are part of the operator
-    #[serde(default, deserialize_with = "deserialize_splits")]
-    pub splits: Vec<u32>,
 }
 
 /// MLTransposeOptions. transpose.
@@ -865,7 +854,7 @@ pub struct MLTransposeOptions {
 // § 11 Operation Emulation and can be implemented via reshape().
 // ---------------------------------------------------------------------------
 
-/// TODO MTAX remove the unofficial ops!
+// TODO TMAX remove the unofficial ops!
 
 /// MLSqueezeOptions. squeeze (emulation-only; not in WebNN IDL).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -887,10 +876,10 @@ pub struct MLUnsqueezeOptions {
     pub axes: Vec<u32>,
 }
 
-/// TODO MTAX do not forget to remove flatten as well which is somewhere else
+// TODO TMAX do not forget to remove flatten as well which is somewhere else
 
 /// MLTileOptions. tile (repetitions from attributes for interchange).
-/// TODO MTAX tile options is not part of the spec
+// TODO TMAX tile options is not part of the spec
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLTileOptions {
@@ -934,9 +923,6 @@ pub enum OperatorOptions {
     /// MLBatchNormalizationOptions.
     BatchNormalization(MLBatchNormalizationOptions),
 
-    /// MLCastOptions.
-    Cast(MLCastOptions),
-
     /// MLClampOptions.
     Clamp(MLClampOptions),
 
@@ -976,9 +962,6 @@ pub enum OperatorOptions {
     /// MLHardSigmoidOptions.
     HardSigmoid(MLHardSigmoidOptions),
 
-    /// MLHardSwishOptions.
-    HardSwish(MLHardSwishOptions),
-
     /// MLInstanceNormalizationOptions.
     InstanceNormalization(MLInstanceNormalizationOptions),
 
@@ -1017,9 +1000,6 @@ pub enum OperatorOptions {
 
     /// MLScatterOptions.
     ScatterElements(MLScatterOptions),
-
-    /// MLSoftmaxOptions.
-    Softmax(MLSoftmaxOptions),
 
     /// MLSliceOptions.
     Slice(MLSliceOptions),
@@ -1069,7 +1049,7 @@ impl OperatorOptions {
             match normalized {
                 "argMin" | "argMax" => try_opt!(MLArgMinMaxOptions, ArgMinMax),
                 "batchNormalization" => try_opt!(MLBatchNormalizationOptions, BatchNormalization),
-                "cast" => try_opt!(MLCastOptions, Cast),
+                "cast" => try_opt!(MLOperatorOptions, Operator),
                 "clamp" => try_opt!(MLClampOptions, Clamp),
                 "conv2d" => try_opt!(MLConv2dOptions, Conv2d),
                 "convTranspose2d" => try_opt!(MLConvTranspose2dOptions, ConvTranspose2d),
@@ -1083,7 +1063,7 @@ impl OperatorOptions {
                 "gru" => try_opt!(MLGruOptions, Gru),
                 "gruCell" => try_opt!(MLGruCellOptions, GruCell),
                 "hardSigmoid" => try_opt!(MLHardSigmoidOptions, HardSigmoid),
-                "hardSwish" => try_opt!(MLHardSwishOptions, HardSwish),
+                "hardSwish" => try_opt!(MLOperatorOptions, Operator),
                 "instanceNormalization" => {
                     try_opt!(MLInstanceNormalizationOptions, InstanceNormalization)
                 }
@@ -1103,7 +1083,7 @@ impl OperatorOptions {
                 "resample2d" => try_opt!(MLResample2dOptions, Resample2d),
                 "reverse" => try_opt!(MLReverseOptions, Reverse),
                 "scatterElements" => try_opt!(MLScatterOptions, ScatterElements),
-                "softmax" => try_opt!(MLSoftmaxOptions, Softmax),
+                "softmax" => try_opt!(MLOperatorOptions, Operator),
                 "slice" => try_opt!(MLSliceOptions, Slice),
                 "split" => try_opt!(MLSplitOptions, Split),
                 "transpose" => try_opt!(MLTransposeOptions, Transpose),
@@ -1119,6 +1099,21 @@ impl OperatorOptions {
             None
         };
         try_from(value).or_else(|| Some(OperatorOptions::Operator(MLOperatorOptions::default())))
+    }
+
+    /// Like [`Self::from_json_with_op_type`], but strips operation-level fields into [`OperationExtras`]
+    /// (axis, cast target type, padding lengths, etc.) before deserializing the options dictionary.
+    ///
+    /// For building an [`crate::operators::Operation`], prefer [`crate::operators::Operation::from_json_attributes`],
+    /// which calls this and [`crate::operators::Operation::from_operator_options`] in one step.
+    pub fn from_json_with_op_type_and_extras(
+        op_type: &str,
+        value: &serde_json::Value,
+    ) -> (Self, OperationExtras) {
+        let mut v = value.clone();
+        let extras = OperationExtras::extract_and_strip(op_type, &mut v);
+        let opts = Self::from_json_with_op_type(op_type, &v).unwrap_or_default();
+        (opts, extras)
     }
 
     /// Return attributes as a JSON value (for code that expects a `serde_json::Value`).
@@ -1152,12 +1147,6 @@ impl OperatorOptions {
     pub fn as_batch_normalization(&self) -> Option<&MLBatchNormalizationOptions> {
         match self {
             OperatorOptions::BatchNormalization(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_cast(&self) -> Option<&MLCastOptions> {
-        match self {
-            OperatorOptions::Cast(o) => Some(o),
             _ => None,
         }
     }
@@ -1230,12 +1219,6 @@ impl OperatorOptions {
     pub fn as_hard_sigmoid(&self) -> Option<&MLHardSigmoidOptions> {
         match self {
             OperatorOptions::HardSigmoid(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_hard_swish(&self) -> Option<&MLHardSwishOptions> {
-        match self {
-            OperatorOptions::HardSwish(o) => Some(o),
             _ => None,
         }
     }
@@ -1314,12 +1297,6 @@ impl OperatorOptions {
     pub fn as_scatter_elements(&self) -> Option<&MLScatterOptions> {
         match self {
             OperatorOptions::ScatterElements(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_softmax(&self) -> Option<&MLSoftmaxOptions> {
-        match self {
-            OperatorOptions::Softmax(o) => Some(o),
             _ => None,
         }
     }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -149,6 +149,12 @@ impl OperationExtras {
                 let _ = obj.remove("has_scale");
                 let _ = obj.remove("has_bias");
             }
+            "layerNormalization" => {
+                let _ = obj.remove("hasScale");
+                let _ = obj.remove("hasBias");
+                let _ = obj.remove("has_scale");
+                let _ = obj.remove("has_bias");
+            }
             "pad" => {
                 out.beginning_padding = remove_u32_vec(obj, "beginningPadding");
                 if out.beginning_padding.is_empty() {
@@ -552,16 +558,8 @@ fn default_layer_norm_epsilon() -> f64 {
 pub struct MLLayerNormalizationOptions {
     #[serde(default)]
     pub label: String,
-    // TODO MTAX scale and bias are not optional, has_scale and has_bias has to go
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
-    /// When exactly one of scale/bias is provided (2 operands), disambiguates for converters.
-    #[serde(default)]
-    pub has_scale: Option<bool>,
-    #[serde(default)]
-    pub has_bias: Option<bool>,
-    /// Omitted in JSON => None => use spec default [1..rank). Present (including []) => use as-is.
-    // TODO TMAX axis is not an option.
     pub axes: Option<Vec<u32>>,
     #[serde(default = "default_layer_norm_epsilon")]
     pub epsilon: f64,
@@ -573,8 +571,6 @@ impl Default for MLLayerNormalizationOptions {
             label: String::new(),
             scale: None,
             bias: None,
-            has_scale: None,
-            has_bias: None,
             axes: None,
             epsilon: default_layer_norm_epsilon(),
         }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -631,13 +631,11 @@ impl Default for MLLinearOptions {
 }
 
 /// MLLstmOptions. lstm.
-// TODO TMAX where is the default implementation for this struct?
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLstmOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
@@ -658,7 +656,6 @@ pub struct MLLstmOptions {
 pub struct MLLstmCellOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
@@ -675,7 +672,7 @@ pub struct MLLstmCellOptions {
 pub struct MLPadOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX mode is an enum of type MLPaddingMode
+    // TODO MTAX mode is an enum of type MLPaddingMode
     #[serde(default)]
     pub mode: String, // "constant" | "edge" | "reflection"
     pub value: Option<serde_json::Value>, // MLNumber
@@ -687,27 +684,20 @@ pub struct MLPadOptions {
 pub struct MLPool2dOptions {
     #[serde(default)]
     pub label: String,
-    /// TODO MTAX the spec is below. I guess this can be interpreted as optional?
-    /// windowDimensions, of type sequence<[EnforceRange] unsigned long>
-    /// A list of length 2: [windowHeight, windowWidth]. Specifies the dimensions of the sliding window. The default value for the window dimensions are the height and width dimensions of the input shape.
     pub window_dimensions: Option<Vec<u32>>,
-    // TODO TMAX check default value
+    // TODO MTAX check default value
     #[serde(default)]
     pub padding: Vec<u32>,
     #[serde(default)]
     pub strides: Vec<u32>,
     #[serde(default)]
     pub dilations: Vec<u32>,
-    // TODO TMAX layout is enum MLInputOperandLayout
+    // TODO MTAX layout is enum MLInputOperandLayout
     #[serde(default)]
     pub layout: String,
-    /// "floor" | "ceil". WebNN spec and WPT use "roundingType"; we accept both keys.
-    // TODO TMAX enum MLRoundingType
-    #[serde(default, alias = "roundingType")]
+    // TODO MTAX enum MLRoundingType
+    #[serde(default)]
     pub output_shape_rounding: String,
-    // TODO TMAX the specs reads 'if specified'. it's unclear what unspecified means
-    /// outputSizes, of type sequence<[EnforceRange] unsigned long>
-    /// A list of length 2: [outputHeight, outputWidth] Specifies the sizes of the two spatial dimensions of the output tensor. When the output sizes are explicitly specified, the outputShapeRounding is ignored. If not specified, the output sizes are automatically computed.
     pub output_sizes: Option<Vec<u32>>,
 }
 
@@ -718,7 +708,6 @@ pub struct MLPool2dOptions {
 pub struct MLReduceOptions {
     #[serde(default)]
     pub label: String,
-    /// Omitted in JSON => None => reduce over all axes. Present (including []) => use as-is ([] = no reduction).
     pub axes: Option<Vec<u32>>,
     #[serde(default)]
     pub keep_dimensions: bool,

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -74,12 +74,14 @@ pub struct MLOperatorOptions {
 // Dictionaries extending MLOperatorOptions (spec order)
 // ---------------------------------------------------------------------------
 
+/// TODO MTAX put in link to w3c spec for all structss
 /// MLArgMinMaxOptions. argMin / argMax.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLArgMinMaxOptions {
     #[serde(default)]
     pub label: String,
+    // TODO MTAX axis and keep_dimensions is not part of the orignal struct
     #[serde(default)]
     pub axis: u32,
     #[serde(default)]
@@ -102,6 +104,7 @@ fn default_batch_norm_epsilon() -> f64 {
 pub struct MLBatchNormalizationOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX scale and bias are not optional
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
     #[serde(default = "default_batch_norm_axis")]
@@ -123,14 +126,16 @@ impl Default for MLBatchNormalizationOptions {
 }
 
 /// MLCastOptions. cast.
+/// TODO MTAX there is no MLCastOptions. The operator uses MLOperatorOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLCastOptions {
     #[serde(default)]
     pub label: String,
     /// Target data type (e.g. "float32", "int32").
+    /// TODO MTAX to is part of the operator
     #[serde(default)]
-    pub to: String,
+    pub to: String, 
 }
 
 /// MLClampOptions. clamp.
@@ -139,6 +144,7 @@ pub struct MLCastOptions {
 pub struct MLClampOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX min_value and max_value are not optional
     pub min_value: Option<serde_json::Value>, // MLNumber
     pub max_value: Option<serde_json::Value>, // MLNumber
 }
@@ -165,6 +171,7 @@ pub struct MLConv2dOptions {
     pub input_layout: String, // "nchw" | "nhwc"
     #[serde(default)]
     pub filter_layout: String, // "oihw" | "hwio" | "ohwi" | "ihwo"
+    /// TODO MTAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -198,6 +205,7 @@ pub struct MLConvTranspose2dOptions {
     #[serde(default)]
     pub output_padding: Vec<u32>,
     /// Output spatial shape [H, W]. WebNN camelCase: outputSizes.
+    /// TOOD MTAX outputSizes is not optional
     pub output_sizes: Option<Vec<u32>>,
     #[serde(default = "default_conv_groups")]
     pub groups: u32,
@@ -205,6 +213,7 @@ pub struct MLConvTranspose2dOptions {
     pub input_layout: String,
     #[serde(default)]
     pub filter_layout: String, // "iohw" | "hwoi" | "ohwi"
+    /// TODO MTAX bias is not optional
     pub bias: Option<OperandIndex>,
 }
 
@@ -226,6 +235,7 @@ impl Default for MLConvTranspose2dOptions {
 }
 
 /// MLConstantOptions. constant (interchange: init, data, dataType, shape).
+/// TODO MTAX non-existing struct
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConstantOptions {
@@ -240,6 +250,7 @@ pub struct MLConstantOptions {
 }
 
 /// MLConcatOptions. concat.
+/// TODO MTAX non-existing struct
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLConcatOptions {
@@ -255,8 +266,10 @@ pub struct MLConcatOptions {
 pub struct MLCumulativeSumOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX axis is not part of the struct
     #[serde(default)]
     pub axis: u32,
+    /// TODO MTAX exclusive and reserved have a default value of false
     #[serde(default)]
     pub exclusive: bool,
     #[serde(default)]
@@ -265,6 +278,7 @@ pub struct MLCumulativeSumOptions {
 
 /// MLExpandOptions. expand (newShape or axes from attributes for interchange).
 /// newShape uses MLDimension (static or dynamic) per WebNN IDL.
+/// TODO MTAX MLExpandOptions does not exist
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLExpandOptions {
@@ -272,6 +286,7 @@ pub struct MLExpandOptions {
     pub label: String,
     #[serde(default, rename = "newShape")]
     pub new_shape: Vec<MLDimension>,
+    /// TODO axis is not part of expand?
     #[serde(default)]
     pub axes: Vec<u32>,
 }
@@ -318,6 +333,7 @@ pub struct MLGatherOptions {
     #[serde(default)]
     pub axis: u32,
     /// gatherElements: batchDimensions (optional).
+    /// TODO MTAX batch_dimensions is not part of this struct
     pub batch_dimensions: Option<u32>,
 }
 
@@ -365,6 +381,7 @@ impl Default for MLGemmOptions {
 pub struct MLGruOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX none of the arguments in this struct is optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub initial_hidden_state: Option<OperandIndex>,
@@ -377,6 +394,7 @@ pub struct MLGruOptions {
     #[serde(default)]
     pub layout: String, // "zrn" | "rzn"
     pub activations: Option<Vec<String>>, // MLRecurrentNetworkActivation
+    /// TODO MTAX hidden_size is not part of this struct. it is passed to the operator.
     pub hidden_size: Option<u32>,
 }
 
@@ -386,13 +404,16 @@ pub struct MLGruOptions {
 pub struct MLGruCellOptions {
     #[serde(default)]
     pub label: String,
+    // TODO MTAX bias and recurrent_bias is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     #[serde(default)]
     pub reset_after: bool,
     #[serde(default)]
     pub layout: String,
+    /// TODO MTAX activations is not optional. does it make sense to have an option instead of an empty vector
     pub activations: Option<Vec<String>>,
+    /// TODO MTAX hidden_size is not part of this struct. it is part of the operator.
     pub hidden_size: Option<u32>,
 }
 
@@ -440,6 +461,7 @@ fn default_hard_swish_beta() -> f64 {
 pub struct MLHardSwishOptions {
     #[serde(default)]
     pub label: String,
+    // TODO MTAX alpha and beta are not part of this struct. the default functions could go as well.
     #[serde(default = "default_hard_swish_alpha")]
     pub alpha: f64,
     #[serde(default = "default_hard_swish_beta")]
@@ -466,10 +488,12 @@ fn default_instance_norm_epsilon() -> f64 {
 pub struct MLInstanceNormalizationOptions {
     #[serde(default)]
     pub label: String,
+    // TODO MTAX scale and bias are not optional
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
     /// When exactly one of scale/bias is provided (2 operands), disambiguates so converters
     /// know which optional is present. Omitted when 1 or 3 operands.
+    /// TODO MTAX has_Scale, has_bias are not part of this struct
     #[serde(default)]
     pub has_scale: Option<bool>,
     #[serde(default)]
@@ -489,7 +513,7 @@ impl Default for MLInstanceNormalizationOptions {
             has_scale: None,
             has_bias: None,
             epsilon: default_instance_norm_epsilon(),
-            layout: String::new(),
+            layout: String::new(), /// TODO MTAX the default is "nchw"
         }
     }
 }
@@ -505,6 +529,7 @@ fn default_layer_norm_epsilon() -> f64 {
 pub struct MLLayerNormalizationOptions {
     #[serde(default)]
     pub label: String,
+    // TODO MTAX scale and bias are not optional, has_scale and has_bias has to go
     pub scale: Option<OperandIndex>,
     pub bias: Option<OperandIndex>,
     /// When exactly one of scale/bias is provided (2 operands), disambiguates for converters.
@@ -513,6 +538,7 @@ pub struct MLLayerNormalizationOptions {
     #[serde(default)]
     pub has_bias: Option<bool>,
     /// Omitted in JSON => None => use spec default [1..rank). Present (including []) => use as-is.
+    /// TODO MTAX axis is not an option. 
     pub axes: Option<Vec<u32>>,
     #[serde(default = "default_layer_norm_epsilon")]
     pub epsilon: f64,
@@ -586,11 +612,13 @@ impl Default for MLLinearOptions {
 }
 
 /// MLLstmOptions. lstm.
+/// TODO MTAX where is the default implementation for this struct?
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLLstmOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
@@ -611,11 +639,14 @@ pub struct MLLstmOptions {
 pub struct MLLstmCellOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX bias, recurrent_bias and peephole_weight is not optional
     pub bias: Option<OperandIndex>,
     pub recurrent_bias: Option<OperandIndex>,
     pub peephole_weight: Option<OperandIndex>,
+    /// TODO MTAX verify default
     #[serde(default)]
     pub layout: String,
+    /// TODO MTAX does not make sense to have an optional vector?
     pub activations: Option<Vec<String>>,
 }
 
@@ -627,9 +658,11 @@ pub struct MLLstmCellOptions {
 pub struct MLPadOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX mode is an enum of type MLPaddingMode
     #[serde(default)]
     pub mode: String, // "constant" | "edge" | "reflection"
     pub value: Option<serde_json::Value>, // MLNumber
+    /// TODO MTAX beginning_padding and ending_pading are part of the Operator
     #[serde(default, rename = "beginningPadding")]
     pub beginning_padding: Vec<u32>,
     #[serde(default, rename = "endingPadding")]
@@ -642,18 +675,27 @@ pub struct MLPadOptions {
 pub struct MLPool2dOptions {
     #[serde(default)]
     pub label: String,
+    /// TODOX MTAX the spec is below. I guess this can be interpreted as optional? 
+    /// windowDimensions, of type sequence<[EnforceRange] unsigned long>
+    /// A list of length 2: [windowHeight, windowWidth]. Specifies the dimensions of the sliding window. The default value for the window dimensions are the height and width dimensions of the input shape.
     pub window_dimensions: Option<Vec<u32>>,
+    /// TODO MTAX check default value
     #[serde(default)]
     pub padding: Vec<u32>,
     #[serde(default)]
     pub strides: Vec<u32>,
     #[serde(default)]
     pub dilations: Vec<u32>,
+    /// TODO MTAX layout is enum MLInputOperandLayout
     #[serde(default)]
     pub layout: String,
     /// "floor" | "ceil". WebNN spec and WPT use "roundingType"; we accept both keys.
+    /// TODO MTAX enum MLRoundingType
     #[serde(default, alias = "roundingType")]
     pub output_shape_rounding: String,
+    /// TODO MTAX the specs reads 'if specified'. it's unclear what unspecified means
+    /// outputSizes, of type sequence<[EnforceRange] unsigned long>
+    /// A list of length 2: [outputHeight, outputWidth] Specifies the sizes of the two spatial dimensions of the output tensor. When the output sizes are explicitly specified, the outputShapeRounding is ignored. If not specified, the output sizes are automatically computed.
     pub output_sizes: Option<Vec<u32>>,
 }
 
@@ -672,6 +714,7 @@ pub struct MLReduceOptions {
 
 /// MLReshapeOptions. reshape (newShape from attributes for interchange).
 /// newShape uses MLDimension (static or dynamic) per WebNN IDL.
+/// TODO MTAX this enum does not exist
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLReshapeOptions {
@@ -697,11 +740,14 @@ impl MLReshapeOptions {
 pub struct MLResample2dOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX enum MLInterpolationMode
     #[serde(default)]
     pub mode: String, // "nearest-neighbor" | "linear"
+    /// TODO MTAX defaults for scales and sizes?
     #[serde(default)]
     pub scales: Vec<f32>,
     pub sizes: Option<Vec<u32>>,
+
     #[serde(default)]
     pub axes: Vec<u32>,
 }
@@ -718,6 +764,7 @@ pub struct MLReverseOptions {
 }
 
 /// MLSoftmaxOptions. softmax.
+/// TODO MTAX not actual struct, axis is part of the operator
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLSoftmaxOptions {
@@ -727,12 +774,12 @@ pub struct MLSoftmaxOptions {
     pub axis: u32,
 }
 
-/// MLScatterOptions. scatterElements.
+/// MLScatterOptions. scatterElements
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLScatterOptions {
     #[serde(default)]
-    pub label: String,
+    pub label: String,  
     #[serde(default)]
     pub axis: u32,
 }
@@ -745,6 +792,7 @@ pub struct MLScatterOptions {
 pub struct MLSliceOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO MTAX starts, sizes are part of the operator.
     #[serde(default)]
     pub starts: Vec<u32>,
     #[serde(default)]
@@ -796,6 +844,7 @@ pub struct MLSplitOptions {
     pub label: String,
     #[serde(default)]
     pub axis: u32,
+    /// TODO MTAX splits are part of the operator
     #[serde(default, deserialize_with = "deserialize_splits")]
     pub splits: Vec<u32>,
 }
@@ -815,6 +864,8 @@ pub struct MLTransposeOptions {
 // These ops are not part of the official WebNN API; they are defined in
 // § 11 Operation Emulation and can be implemented via reshape().
 // ---------------------------------------------------------------------------
+
+/// TODO MTAX remove the unofficial ops!
 
 /// MLSqueezeOptions. squeeze (emulation-only; not in WebNN IDL).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -836,7 +887,10 @@ pub struct MLUnsqueezeOptions {
     pub axes: Vec<u32>,
 }
 
+/// TODO MTAX do not forget to remove flatten as well which is somewhere else
+
 /// MLTileOptions. tile (repetitions from attributes for interchange).
+/// TODO MTAX tile options is not part of the spec
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MLTileOptions {
@@ -853,6 +907,7 @@ pub struct MLTileOptions {
 pub struct MLTriangularOptions {
     #[serde(default)]
     pub label: String,
+    /// TODO upper is not optional
     /// None = not present => default true (upper). Some(b) => use b.
     pub upper: Option<bool>,
     #[serde(default)]

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -74,6 +74,8 @@ pub struct OperationExtras {
     pub split_equal_parts: Option<u32>,
     /// `expand()` method argument `newShape` (not part of MLOperatorOptions).
     pub expand_new_shape: Vec<MLDimension>,
+    /// `tile()` method argument `repetitions` (not part of MLOperatorOptions).
+    pub repetitions: Vec<u32>,
 }
 
 impl OperationExtras {
@@ -190,6 +192,9 @@ impl OperationExtras {
                         _ => {}
                     }
                 }
+            }
+            "tile" => {
+                out.repetitions = remove_u32_vec(obj, "repetitions");
             }
             _ => {}
         }
@@ -741,12 +746,12 @@ impl MLReshapeOptions {
 pub struct MLResample2dOptions {
     #[serde(default)]
     pub label: String,
-    // TODO TMAX enum MLInterpolationMode
+    // TODO MTAX enum MLInterpolationMode
     #[serde(default)]
     pub mode: String, // "nearest-neighbor" | "linear"
-    // TODO TMAX defaults for scales and sizes?
     #[serde(default)]
     pub scales: Vec<f32>,
+    #[serde(default)]
     pub sizes: Option<Vec<u32>>,
 
     #[serde(default)]
@@ -830,19 +835,6 @@ pub struct MLUnsqueezeOptions {
     pub label: String,
     #[serde(default)]
     pub axes: Vec<u32>,
-}
-
-// TODO TMAX do not forget to remove flatten as well which is somewhere else
-
-/// MLTileOptions. tile (repetitions from attributes for interchange).
-// TODO TMAX tile options is not part of the spec
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MLTileOptions {
-    #[serde(default)]
-    pub label: String,
-    #[serde(default)]
-    pub repetitions: Vec<u32>,
 }
 
 /// MLTriangularOptions. triangular.
@@ -966,9 +958,6 @@ pub enum OperatorOptions {
     /// MLUnsqueezeOptions. unsqueeze.
     Unsqueeze(MLUnsqueezeOptions),
 
-    /// MLTileOptions.
-    Tile(MLTileOptions),
-
     /// MLTriangularOptions.
     Triangular(MLTriangularOptions),
 }
@@ -1040,7 +1029,7 @@ impl OperatorOptions {
                 "transpose" => try_opt!(MLTransposeOptions, Transpose),
                 "squeeze" => try_opt!(MLSqueezeOptions, Squeeze),
                 "unsqueeze" => try_opt!(MLUnsqueezeOptions, Unsqueeze),
-                "tile" => try_opt!(MLTileOptions, Tile),
+                "tile" => try_opt!(MLOperatorOptions, Operator),
                 "triangular" => try_opt!(MLTriangularOptions, Triangular),
                 _ => {}
             }
@@ -1272,12 +1261,6 @@ impl OperatorOptions {
     pub fn as_unsqueeze(&self) -> Option<&MLUnsqueezeOptions> {
         match self {
             OperatorOptions::Unsqueeze(o) => Some(o),
-            _ => None,
-        }
-    }
-    pub fn as_tile(&self) -> Option<&MLTileOptions> {
-        match self {
-            OperatorOptions::Tile(o) => Some(o),
             _ => None,
         }
     }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -22,6 +22,10 @@
 //! ambiguity), and the corresponding ML*Options struct. All option types and MLDimension
 //! are reused from [crate::operator_options].
 //!
+//! Graph interchange JSON should use [`Operation::from_json_attributes`] (op type string,
+//! input/output operand ids, and one attributes object); it parses options and method-level
+//! fields and returns a complete [`Operation`].
+//!
 //! # Spec reference
 //!
 //! - [Web Neural Network API](https://www.w3.org/TR/webnn/)
@@ -37,16 +41,15 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::operator_options::{
-    MLArgMinMaxOptions, MLBatchNormalizationOptions, MLCastOptions, MLClampOptions,
-    MLConcatOptions, MLConstantOptions, MLConv2dOptions, MLConvTranspose2dOptions,
-    MLCumulativeSumOptions, MLEluOptions, MLExpandOptions, MLGatherOptions, MLGemmOptions,
-    MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions, MLHardSwishOptions,
-    MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
-    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
-    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions, MLReverseOptions,
-    MLScatterOptions, MLSliceOptions, MLSoftmaxOptions, MLSplitOptions, MLSqueezeOptions,
+    MLDimension, MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConcatOptions,
+    MLConstantOptions, MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions,
+    MLEluOptions, MLExpandOptions, MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions,
+    MLHardSigmoidOptions, MLInstanceNormalizationOptions, MLLayerNormalizationOptions,
+    MLLeakyReluOptions, MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions,
+    MLPadOptions, MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions,
+    MLReverseOptions, MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions,
     MLTileOptions, MLTransposeOptions, MLTriangularOptions, MLUnsqueezeOptions, OperandIndex,
-    OperatorOptions,
+    OperationExtras, OperatorOptions,
 };
 
 // ---------------------------------------------------------------------------
@@ -306,12 +309,14 @@ pub enum Operation {
     /// [argMin()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-argmin)
     ArgMin {
         input: OperandIndex,
+        axis: u32,
         options: Option<MLArgMinMaxOptions>,
         outputs: Vec<OperandIndex>,
     },
     /// [argMax()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-argmax)
     ArgMax {
         input: OperandIndex,
+        axis: u32,
         options: Option<MLArgMinMaxOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -330,7 +335,8 @@ pub enum Operation {
     /// [cast()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cast)
     Cast {
         input: OperandIndex,
-        options: Option<MLCastOptions>,
+        to: String,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -379,6 +385,7 @@ pub enum Operation {
     /// [cumulativeSum()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cumulativesum)
     CumulativeSum {
         input: OperandIndex,
+        axis: u32,
         options: Option<MLCumulativeSumOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -404,6 +411,7 @@ pub enum Operation {
     Gather {
         input: OperandIndex,
         indices: OperandIndex,
+        batch_dimensions: Option<u32>,
         options: Option<MLGatherOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -411,6 +419,7 @@ pub enum Operation {
     GatherElements {
         input: OperandIndex,
         indices: OperandIndex,
+        batch_dimensions: Option<u32>,
         options: Option<MLGatherOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -430,6 +439,8 @@ pub enum Operation {
         input: OperandIndex,
         weight: OperandIndex,
         recurrence: OperandIndex,
+        steps: u32,
+        hidden_size: u32,
         options: Option<MLGruOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -439,6 +450,7 @@ pub enum Operation {
         weight: OperandIndex,
         recurrence: OperandIndex,
         hidden_state: OperandIndex,
+        hidden_size: u32,
         options: Option<MLGruCellOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -453,7 +465,7 @@ pub enum Operation {
     /// [hardSwish()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-hardswish)
     HardSwish {
         input: OperandIndex,
-        options: Option<MLHardSwishOptions>,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -513,6 +525,8 @@ pub enum Operation {
     /// [pad()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-pad)
     Pad {
         input: OperandIndex,
+        beginning_padding: Vec<u32>,
+        ending_padding: Vec<u32>,
         options: Option<MLPadOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -649,7 +663,8 @@ pub enum Operation {
     /// [softmax()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-softmax)
     Softmax {
         input: OperandIndex,
-        options: Option<MLSoftmaxOptions>,
+        axis: u32,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -657,6 +672,8 @@ pub enum Operation {
     /// [slice()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-slice)
     Slice {
         input: OperandIndex,
+        starts: Vec<u32>,
+        sizes: Vec<MLDimension>,
         options: Option<MLSliceOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -665,6 +682,8 @@ pub enum Operation {
     /// [split()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-split)
     Split {
         input: OperandIndex,
+        splits: Vec<u32>,
+        split_equal_parts: Option<u32>,
         options: Option<MLSplitOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -829,7 +848,8 @@ impl Serialize for Operation {
         S: Serializer,
     {
         use serde::ser::SerializeStruct;
-        let (op_type, input_operands, attributes) = self.to_legacy();
+        let (op_type, input_operands, _) = self.to_legacy();
+        let attributes = self.attributes_json_value();
         let outs = self.outputs();
         let output_operands: Vec<u32> = outs.to_vec();
         let output_operand = outs.first().copied();
@@ -865,19 +885,6 @@ impl<'de> Deserialize<'de> for Operation {
         }
         let h = OperationHelper::deserialize(deserializer)?;
         let attributes_value = merge_top_level_label_into_attributes(h.attributes, h.label);
-        let attributes = if attributes_value.is_null() {
-            OperatorOptions::default()
-        } else if let Some(obj) = attributes_value.as_object() {
-            if obj.is_empty() {
-                OperatorOptions::default()
-            } else {
-                OperatorOptions::from_json_with_op_type(&h.op_type, &attributes_value)
-                    .unwrap_or_default()
-            }
-        } else {
-            OperatorOptions::from_json_with_op_type(&h.op_type, &attributes_value)
-                .unwrap_or_default()
-        };
         let output_ids: Vec<u32> = if !h.output_operands.is_empty() {
             h.output_operands.clone()
         } else if let Some(o) = h.output_operand {
@@ -885,7 +892,7 @@ impl<'de> Deserialize<'de> for Operation {
         } else {
             Vec::new()
         };
-        Operation::from_operator_options(&h.op_type, &h.input_operands, &attributes, &output_ids)
+        Operation::from_json_attributes(&h.op_type, &h.input_operands, &output_ids, &attributes_value)
             .ok_or_else(|| {
                 serde::de::Error::custom(format!("unknown or invalid op_type: {}", h.op_type))
             })
@@ -1264,6 +1271,83 @@ impl Operation {
         self.attributes().to_value()
     }
 
+    /// Serialized `attributes` for JSON interchange: options dictionary plus operation-level parameters
+    /// (axis, cast target type, padding lengths, etc.).
+    pub fn attributes_json_value(&self) -> serde_json::Value {
+        let mut v = self.to_legacy().2.to_value();
+        let Some(obj) = v.as_object_mut() else {
+            return v;
+        };
+        match self {
+            Operation::ArgMin { axis, .. } | Operation::ArgMax { axis, .. } => {
+                obj.insert("axis".to_string(), serde_json::json!(axis));
+            }
+            Operation::Cast { to, .. } => {
+                if !to.is_empty() {
+                    obj.insert("to".to_string(), serde_json::Value::String(to.clone()));
+                }
+            }
+            Operation::CumulativeSum { axis, .. } => {
+                obj.insert("axis".to_string(), serde_json::json!(axis));
+            }
+            Operation::Gather {
+                batch_dimensions, ..
+            }
+            | Operation::GatherElements {
+                batch_dimensions, ..
+            } => {
+                if let Some(bd) = batch_dimensions {
+                    obj.insert("batchDimensions".to_string(), serde_json::json!(bd));
+                }
+            }
+            Operation::Gru {
+                steps,
+                hidden_size,
+                ..
+            } => {
+                obj.insert("steps".to_string(), serde_json::json!(steps));
+                obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
+            }
+            Operation::GruCell { hidden_size, .. } => {
+                obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
+            }
+            Operation::Pad {
+                beginning_padding,
+                ending_padding,
+                ..
+            } => {
+                obj.insert(
+                    "beginningPadding".to_string(),
+                    serde_json::json!(beginning_padding),
+                );
+                obj.insert(
+                    "endingPadding".to_string(),
+                    serde_json::json!(ending_padding),
+                );
+            }
+            Operation::Softmax { axis, .. } => {
+                obj.insert("axis".to_string(), serde_json::json!(axis));
+            }
+            Operation::Slice { starts, sizes, .. } => {
+                obj.insert("starts".to_string(), serde_json::json!(starts));
+                obj.insert("sizes".to_string(), serde_json::json!(sizes));
+            }
+            Operation::Split {
+                splits,
+                split_equal_parts,
+                ..
+            } => {
+                if let Some(n) = split_equal_parts {
+                    obj.insert("splits".to_string(), serde_json::json!(n));
+                } else if !splits.is_empty() {
+                    obj.insert("splits".to_string(), serde_json::json!(splits));
+                }
+            }
+            _ => {}
+        }
+        v
+    }
+
     /// Get a single attribute by key as JSON value. Use for code that still expects key-based lookup.
     pub fn get_attr(&self, key: &str) -> Option<serde_json::Value> {
         self.attributes().get(key)
@@ -1494,7 +1578,7 @@ impl Operation {
             Operation::Cast { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::Cast(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Clamp { input, options, .. } => (
                 tag.clone(),
@@ -1610,7 +1694,7 @@ impl Operation {
             Operation::HardSwish { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::HardSwish(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::InstanceNormalization { input, options, .. } => (
                 tag.clone(),
@@ -1765,7 +1849,7 @@ impl Operation {
             Operation::Softmax { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::Softmax(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Slice { input, options, .. } => (
                 tag.clone(),
@@ -1905,11 +1989,40 @@ impl Operation {
         }
     }
 
+    /// Parse WebNN-style attributes JSON (method parameters and options keys in one object),
+    /// wire operand indices, and return a fully built [`Operation`].
+    ///
+    /// This is the preferred entry point for graph interchange: callers do not handle
+    /// [`OperatorOptions`] or [`OperationExtras`] separately. Null or empty object attributes
+    /// deserialize as default options with no stripped extras.
+    ///
+    /// Returns `None` if `op_type` is unknown or operand lengths do not match.
+    pub fn from_json_attributes(
+        op_type: &str,
+        input_operands: &[u32],
+        outputs: &[OperandIndex],
+        attributes: &serde_json::Value,
+    ) -> Option<Self> {
+        let (opts, extras) = if attributes.is_null() {
+            (OperatorOptions::default(), OperationExtras::default())
+        } else if let Some(obj) = attributes.as_object() {
+            if obj.is_empty() {
+                (OperatorOptions::default(), OperationExtras::default())
+            } else {
+                OperatorOptions::from_json_with_op_type_and_extras(op_type, attributes)
+            }
+        } else {
+            OperatorOptions::from_json_with_op_type_and_extras(op_type, attributes)
+        };
+        Self::from_operator_options(op_type, input_operands, &opts, outputs, extras)
+    }
+
     /// Parses WebNN interchange: builder/JSON `op_type` string (e.g. camelCase `batchNormalization`
     /// or lowercase `add`), operand indices in spec order, and typed [`OperatorOptions`].
     ///
-    /// This is the **supported** way to construct an [`Operation`] from serialized graphs (JSON, WPT,
-    /// etc.). Prefer constructing enum variants directly only in native Rust graph builders.
+    /// For JSON that mixes method-level keys with options, use [`Self::from_json_attributes`]
+    /// instead; this function is for callers that already have [`OperatorOptions`] and
+    /// [`OperationExtras`] (e.g. custom tooling).
     ///
     /// Returns `None` if `op_type` is unknown or operand lengths do not match.
     pub fn from_operator_options(
@@ -1917,6 +2030,7 @@ impl Operation {
         input_operands: &[u32],
         attributes: &OperatorOptions,
         outputs: &[OperandIndex],
+        extras: OperationExtras,
     ) -> Option<Self> {
         fn at(inputs: &[u32], i: usize) -> Option<u32> {
             inputs.get(i).copied()
@@ -2135,11 +2249,13 @@ impl Operation {
             }),
             "argMax" if !input_operands.is_empty() => Some(Operation::ArgMax {
                 input: at(input_operands, 0)?,
+                axis: extras.axis.unwrap_or(0),
                 options: attributes.as_arg_min_max().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "argMin" if !input_operands.is_empty() => Some(Operation::ArgMin {
                 input: at(input_operands, 0)?,
+                axis: extras.axis.unwrap_or(0),
                 options: attributes.as_arg_min_max().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2154,7 +2270,8 @@ impl Operation {
             }
             "cast" if !input_operands.is_empty() => Some(Operation::Cast {
                 input: at(input_operands, 0)?,
-                options: attributes.as_cast().cloned(),
+                to: extras.to_data_type.unwrap_or_default(),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "clamp" if !input_operands.is_empty() => Some(Operation::Clamp {
@@ -2185,6 +2302,7 @@ impl Operation {
             }),
             "cumulativeSum" if !input_operands.is_empty() => Some(Operation::CumulativeSum {
                 input: at(input_operands, 0)?,
+                axis: extras.axis.unwrap_or(0),
                 options: attributes.as_cumulative_sum().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2201,12 +2319,14 @@ impl Operation {
             "gather" if input_operands.len() >= 2 => Some(Operation::Gather {
                 input: at(input_operands, 0)?,
                 indices: at(input_operands, 1)?,
+                batch_dimensions: extras.batch_dimensions,
                 options: attributes.as_gather().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "gatherElements" if input_operands.len() >= 2 => Some(Operation::GatherElements {
                 input: at(input_operands, 0)?,
                 indices: at(input_operands, 1)?,
+                batch_dimensions: extras.batch_dimensions,
                 options: attributes.as_gather().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2220,6 +2340,8 @@ impl Operation {
                 input: at(input_operands, 0)?,
                 weight: at(input_operands, 1)?,
                 recurrence: at(input_operands, 2)?,
+                steps: extras.steps.unwrap_or(0),
+                hidden_size: extras.hidden_size.unwrap_or(0),
                 options: attributes.as_gru().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2247,6 +2369,7 @@ impl Operation {
                     weight: at(input_operands, 1)?,
                     recurrence: at(input_operands, 2)?,
                     hidden_state: at(input_operands, 3)?,
+                    hidden_size: extras.hidden_size.unwrap_or(0),
                     options,
                     outputs: outputs.to_vec(),
                 })
@@ -2258,7 +2381,7 @@ impl Operation {
             }),
             "hardSwish" if !input_operands.is_empty() => Some(Operation::HardSwish {
                 input: at(input_operands, 0)?,
-                options: attributes.as_hard_swish().cloned(),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "instanceNormalization" if !input_operands.is_empty() => {
@@ -2303,6 +2426,8 @@ impl Operation {
             }),
             "pad" if !input_operands.is_empty() => Some(Operation::Pad {
                 input: at(input_operands, 0)?,
+                beginning_padding: extras.beginning_padding,
+                ending_padding: extras.ending_padding,
                 options: attributes.as_pad().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2417,16 +2542,21 @@ impl Operation {
             }),
             "softmax" if !input_operands.is_empty() => Some(Operation::Softmax {
                 input: at(input_operands, 0)?,
-                options: attributes.as_softmax().cloned(),
+                axis: extras.axis.unwrap_or(0),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "slice" if !input_operands.is_empty() => Some(Operation::Slice {
                 input: at(input_operands, 0)?,
+                starts: extras.starts,
+                sizes: extras.sizes,
                 options: attributes.as_slice().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "split" if !input_operands.is_empty() => Some(Operation::Split {
                 input: at(input_operands, 0)?,
+                splits: extras.splits,
+                split_equal_parts: extras.split_equal_parts,
                 options: attributes.as_split().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2555,6 +2685,6 @@ impl Operation {
         input_operands: &[u32],
         attributes: &OperatorOptions,
     ) -> Option<Self> {
-        Self::from_operator_options(op_type, input_operands, attributes, &[])
+        Self::from_operator_options(op_type, input_operands, attributes, &[], OperationExtras::default())
     }
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -46,10 +46,9 @@ use crate::operator_options::{
     MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions,
     MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
     MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
-    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions, MLReverseOptions,
-    MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions,
-    MLTriangularOptions, MLUnsqueezeOptions, OperandIndex, OperationExtras,
-    OperatorOptions,
+    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions, MLScatterOptions,
+    MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions, MLTriangularOptions,
+    MLUnsqueezeOptions, OperandIndex, OperationExtras, OperatorOptions,
 };
 
 // ---------------------------------------------------------------------------
@@ -632,7 +631,8 @@ pub enum Operation {
     /// [reshape()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reshape)
     Reshape {
         input: OperandIndex,
-        options: Option<MLReshapeOptions>,
+        new_shape: Vec<MLDimension>,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -1365,6 +1365,13 @@ impl Operation {
                     obj.insert("repetitions".to_string(), serde_json::json!(repetitions));
                 }
             }
+            Operation::Reshape { new_shape, .. } => {
+                if !new_shape.is_empty() {
+                    if let Ok(val) = serde_json::to_value(new_shape) {
+                        obj.insert("newShape".to_string(), val);
+                    }
+                }
+            }
             _ => {}
         }
         v
@@ -1845,7 +1852,7 @@ impl Operation {
             Operation::Reshape { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::Reshape(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Resample2d { input, options, .. } => (
                 tag.clone(),
@@ -2541,7 +2548,8 @@ impl Operation {
             }
             "reshape" if !input_operands.is_empty() => Some(Operation::Reshape {
                 input: at(input_operands, 0)?,
-                options: attributes.as_reshape().cloned(),
+                new_shape: extras.reshape_new_shape.clone(),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "resample2d" if !input_operands.is_empty() => Some(Operation::Resample2d {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -41,9 +41,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::operator_options::{
-    MLDimension, MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConcatOptions,
-    MLConstantOptions, MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions,
-    MLEluOptions, MLExpandOptions, MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions,
+    MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
+    MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions,
+    MLDimension, MLEluOptions, MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions,
     MLHardSigmoidOptions, MLInstanceNormalizationOptions, MLLayerNormalizationOptions,
     MLLeakyReluOptions, MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions,
     MLPadOptions, MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions,
@@ -374,10 +374,12 @@ pub enum Operation {
     },
 
     // ---------- Concat ----------
-    /// [concat()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-concat)
+    /// [concat()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-concat) —
+    /// `axis` is a method parameter; `options` is [`MLOperatorOptions`] (label only).
     Concat {
         inputs: Vec<OperandIndex>,
-        options: Option<MLConcatOptions>,
+        axis: u32,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -394,7 +396,8 @@ pub enum Operation {
     /// [expand()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-expand)
     Expand {
         input: OperandIndex,
-        options: Option<MLExpandOptions>,
+        new_shape: Vec<MLDimension>,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -892,10 +895,15 @@ impl<'de> Deserialize<'de> for Operation {
         } else {
             Vec::new()
         };
-        Operation::from_json_attributes(&h.op_type, &h.input_operands, &output_ids, &attributes_value)
-            .ok_or_else(|| {
-                serde::de::Error::custom(format!("unknown or invalid op_type: {}", h.op_type))
-            })
+        Operation::from_json_attributes(
+            &h.op_type,
+            &h.input_operands,
+            &output_ids,
+            &attributes_value,
+        )
+        .ok_or_else(|| {
+            serde::de::Error::custom(format!("unknown or invalid op_type: {}", h.op_type))
+        })
     }
 }
 
@@ -1290,6 +1298,16 @@ impl Operation {
             Operation::CumulativeSum { axis, .. } => {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
+            Operation::Concat { axis, .. } => {
+                obj.insert("axis".to_string(), serde_json::json!(axis));
+            }
+            Operation::Expand { new_shape, .. } => {
+                if !new_shape.is_empty() {
+                    if let Ok(v) = serde_json::to_value(new_shape) {
+                        obj.insert("newShape".to_string(), v);
+                    }
+                }
+            }
             Operation::Gather {
                 batch_dimensions, ..
             }
@@ -1301,9 +1319,7 @@ impl Operation {
                 }
             }
             Operation::Gru {
-                steps,
-                hidden_size,
-                ..
+                steps, hidden_size, ..
             } => {
                 obj.insert("steps".to_string(), serde_json::json!(steps));
                 obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
@@ -1615,7 +1631,7 @@ impl Operation {
             } => (
                 tag.clone(),
                 inputs.clone(),
-                OO::Concat(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::CumulativeSum { input, options, .. } => (
                 tag.clone(),
@@ -1625,7 +1641,7 @@ impl Operation {
             Operation::Expand { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::Expand(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Elu { input, options, .. } => (
                 tag.clone(),
@@ -2003,14 +2019,11 @@ impl Operation {
         outputs: &[OperandIndex],
         attributes: &serde_json::Value,
     ) -> Option<Self> {
+        // Null must not map to OperatorOptions::default() (generic MLOperatorOptions): ops like
+        // averagePool2d need Pool2d(MLPool2dOptions::default()) so ONNX can infer kernel_shape.
+        let empty_obj = serde_json::Value::Object(Default::default());
         let (opts, extras) = if attributes.is_null() {
-            (OperatorOptions::default(), OperationExtras::default())
-        } else if let Some(obj) = attributes.as_object() {
-            if obj.is_empty() {
-                (OperatorOptions::default(), OperationExtras::default())
-            } else {
-                OperatorOptions::from_json_with_op_type_and_extras(op_type, attributes)
-            }
+            OperatorOptions::from_json_with_op_type_and_extras(op_type, &empty_obj)
         } else {
             OperatorOptions::from_json_with_op_type_and_extras(op_type, attributes)
         };
@@ -2297,7 +2310,8 @@ impl Operation {
             }),
             "concat" => Some(Operation::Concat {
                 inputs: input_operands.to_vec(),
-                options: attributes.as_concat().cloned(),
+                axis: extras.axis.unwrap_or(0),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "cumulativeSum" if !input_operands.is_empty() => Some(Operation::CumulativeSum {
@@ -2308,7 +2322,8 @@ impl Operation {
             }),
             "expand" if !input_operands.is_empty() => Some(Operation::Expand {
                 input: at(input_operands, 0)?,
-                options: attributes.as_expand().cloned(),
+                new_shape: extras.expand_new_shape,
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "elu" if !input_operands.is_empty() => Some(Operation::Elu {
@@ -2685,6 +2700,12 @@ impl Operation {
         input_operands: &[u32],
         attributes: &OperatorOptions,
     ) -> Option<Self> {
-        Self::from_operator_options(op_type, input_operands, attributes, &[], OperationExtras::default())
+        Self::from_operator_options(
+            op_type,
+            input_operands,
+            attributes,
+            &[],
+            OperationExtras::default(),
+        )
     }
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -42,14 +42,14 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::operator_options::{
     MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
-    MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions,
-    MLDimension, MLEluOptions, MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions,
-    MLHardSigmoidOptions, MLInstanceNormalizationOptions, MLLayerNormalizationOptions,
-    MLLeakyReluOptions, MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions,
-    MLPadOptions, MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions,
-    MLReverseOptions, MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions,
-    MLTileOptions, MLTransposeOptions, MLTriangularOptions, MLUnsqueezeOptions, OperandIndex,
-    OperationExtras, OperatorOptions,
+    MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions, MLDimension, MLEluOptions,
+    MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions,
+    MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
+    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
+    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions, MLReverseOptions,
+    MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTileOptions,
+    MLTransposeOptions, MLTriangularOptions, MLUnsqueezeOptions, OperandIndex, OperationExtras,
+    OperatorOptions,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -47,8 +47,8 @@ use crate::operator_options::{
     MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
     MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
     MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReshapeOptions, MLReverseOptions,
-    MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTileOptions,
-    MLTransposeOptions, MLTriangularOptions, MLUnsqueezeOptions, OperandIndex, OperationExtras,
+    MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions,
+    MLTriangularOptions, MLUnsqueezeOptions, OperandIndex, OperationExtras,
     OperatorOptions,
 };
 
@@ -717,7 +717,8 @@ pub enum Operation {
     /// [tile()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-tile)
     Tile {
         input: OperandIndex,
-        options: Option<MLTileOptions>,
+        repetitions: Vec<u32>,
+        options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
 
@@ -1359,6 +1360,11 @@ impl Operation {
                     obj.insert("splits".to_string(), serde_json::json!(splits));
                 }
             }
+            Operation::Tile { repetitions, .. } => {
+                if !repetitions.is_empty() {
+                    obj.insert("repetitions".to_string(), serde_json::json!(repetitions));
+                }
+            }
             _ => {}
         }
         v
@@ -1895,7 +1901,7 @@ impl Operation {
             Operation::Tile { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
-                OO::Tile(options.clone().unwrap_or_default()),
+                OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Triangular { input, options, .. } => (
                 tag.clone(),
@@ -2592,7 +2598,8 @@ impl Operation {
             }),
             "tile" if !input_operands.is_empty() => Some(Operation::Tile {
                 input: at(input_operands, 0)?,
-                options: attributes.as_tile().cloned(),
+                repetitions: extras.repetitions.clone(),
+                options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),
             "triangular" if !input_operands.is_empty() => Some(Operation::Triangular {

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -611,10 +611,10 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     }
                 }
 
-                // Reshape - use newShape from operator options if available
+                // Reshape - use newShape from the operation (builder method argument).
                 "reshape" => match &op {
-                    Operation::Reshape { options, .. } => options.as_ref().map(|o| {
-                        o.new_shape
+                    Operation::Reshape { new_shape, .. } => (!new_shape.is_empty()).then(|| {
+                        new_shape
                             .iter()
                             .map(|d| Dimension::from(d.clone()))
                             .collect::<Vec<_>>()

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -579,101 +579,33 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     }
                 }
 
-                // Concat
                 "concat" => {
-                    let axis_u32 = {
-                        let axis_i64 = match &op {
-                            Operation::Concat { options, .. } => {
-                                options.as_ref().map(|o| o.axis as i64)
-                            }
-                            _ => None,
-                        };
-                        if let Some(axis) = axis_i64 {
-                            // Convert to u32, handling negative indices
-                            if axis < 0 {
-                                // Negative index: convert relative to rank
-                                if !input_shapes.is_empty() {
-                                    let rank = input_shapes[0].len() as i64;
-                                    if axis + rank >= 0 {
-                                        Some((axis + rank) as u32)
-                                    } else {
-                                        None // Invalid negative index
-                                    }
-                                } else {
-                                    None
-                                }
-                            } else {
-                                Some(axis as u32)
-                            }
-                        } else {
-                            None
-                        }
+                    let axis_val = match &op {
+                        Operation::Concat { axis, .. } => *axis,
+                        _ => 0,
                     };
-
-                    if let Some(axis_val) = axis_u32 {
-                        if input_shapes.iter().all(|s| s.is_empty()) && axis_val == 0 {
-                            Some(vec![Dimension::Static(input_shapes.len() as u32)])
-                        } else {
-                            infer_concat_shape_dimensions(&input_shapes, axis_val).ok()
-                        }
+                    if input_shapes.iter().all(|s| s.is_empty()) && axis_val == 0 {
+                        Some(vec![Dimension::Static(input_shapes.len() as u32)])
                     } else {
-                        None
+                        infer_concat_shape_dimensions(&input_shapes, axis_val).ok()
                     }
                 }
 
-                // Expand: use axes for unsqueeze-style or newShape for broadcast
-                // Only use axes path when axes is non-empty; otherwise use newShape (default axes is []).
+                // Expand: `newShape` is a method argument (see expand() in the WebNN spec).
                 "expand" => {
                     if input_shapes.len() == 1 {
-                        let (axes_opt, new_shape_opt) = match &op {
-                            Operation::Expand { options, .. } => options
-                                .as_ref()
-                                .map(|o| {
-                                    let axes: Vec<i64> = o.axes.iter().map(|&u| u as i64).collect();
-                                    let new_shape: Vec<Dimension> = o
-                                        .new_shape
-                                        .iter()
-                                        .map(|d| Dimension::from(d.clone()))
-                                        .collect();
-                                    (
-                                        if axes.is_empty() { None } else { Some(axes) },
-                                        if new_shape.is_empty() {
-                                            None
-                                        } else {
-                                            Some(new_shape)
-                                        },
-                                    )
-                                })
-                                .unwrap_or((None, None)),
-                            _ => (None, None),
+                        let new_shape_opt: Option<Vec<Dimension>> = match &op {
+                            Operation::Expand { new_shape, .. } if !new_shape.is_empty() => Some(
+                                new_shape
+                                    .iter()
+                                    .map(|d| Dimension::from(d.clone()))
+                                    .collect(),
+                            ),
+                            _ => None,
                         };
-                        if let Some(axes) = axes_opt
-                            && !axes.is_empty()
-                        {
-                            let rank = input_shapes[0].len() as i64;
-                            let mut normalized = Vec::with_capacity(axes.len());
-                            let mut valid = true;
-                            for axis in axes {
-                                let mut axis = axis;
-                                if axis < 0 {
-                                    axis += rank + 1;
-                                }
-                                if axis < 0 || axis > rank {
-                                    valid = false;
-                                    break;
-                                }
-                                normalized.push(axis as u32);
-                            }
-                            if valid {
-                                infer_unsqueeze_shape_dimensions(&input_shapes[0], &normalized).ok()
-                            } else {
-                                None
-                            }
-                        } else if let Some(new_shape) = new_shape_opt {
+                        new_shape_opt.and_then(|new_shape| {
                             infer_expand_shape_dimensions(&input_shapes[0], &new_shape).ok()
-                        } else {
-                            None
-                        }
+                        })
                     } else {
                         None
                     }

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -376,19 +376,12 @@ pub fn from_graph_json(graph_json: &GraphJson) -> Result<GraphInfo, GraphError> 
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Convert options to attributes (tagged union) and build operator
         let attrs_value = serde_json::Value::Object(node.options.clone());
-        let attributes = crate::operator_options::OperatorOptions::from_json_with_op_type(
-            &node.op,
-            &attrs_value,
-        )
-        .unwrap_or_default();
-
-        let operator = Operation::from_operator_options(
+        let operator = Operation::from_json_attributes(
             &node.op,
             &input_operands,
-            &attributes,
             &output_operand_ids,
+            &attrs_value,
         )
         .expect("unknown op type in JSON");
 
@@ -571,8 +564,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         Some(hidden_state_shape.clone())
                     } else if let Some(input_shape) = input_shapes.first() {
                         let hidden_size = match &op {
-                            Operation::GruCell { options, .. } => {
-                                options.as_ref().and_then(|o| o.hidden_size)
+                            Operation::GruCell { hidden_size, .. } => {
+                                (*hidden_size > 0).then_some(*hidden_size)
                             }
                             _ => None,
                         };
@@ -845,26 +838,25 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     }
                 }
 
-                // Slice: use starts/sizes from operator options (WebNN slice has no axes/ends/steps)
+                // Slice: starts/sizes are operation parameters (not MLSliceOptions).
                 "slice" => {
                     if let Some(input_shape) = input_shapes.first() {
                         match &op {
-                            Operation::Slice { options, .. } => options.as_ref().and_then(|opts| {
-                                if opts.starts.is_empty() || opts.sizes.is_empty() {
-                                    return None;
-                                }
-                                let sizes_u32 = opts.sizes_static_or_max();
-                                if opts.starts.len() != sizes_u32.len() {
-                                    return None;
-                                }
-                                let mut output = input_shape.clone();
-                                for (i, &sz) in sizes_u32.iter().enumerate() {
-                                    if i < output.len() {
-                                        output[i] = Dimension::Static(sz);
+                            Operation::Slice { starts, sizes, .. } => {
+                                if starts.is_empty() || sizes.is_empty() {
+                                    None
+                                } else if starts.len() != sizes.len() {
+                                    None
+                                } else {
+                                    let mut output = input_shape.clone();
+                                    for (i, sz) in sizes.iter().enumerate() {
+                                        if i < output.len() {
+                                            output[i] = Dimension::Static(sz.static_or_max());
+                                        }
                                     }
+                                    Some(output)
                                 }
-                                Some(output)
-                            }),
+                            }
                             _ => None,
                         }
                     } else {
@@ -918,9 +910,13 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         _ => None,
                     },
                     "cast" => match &op {
-                        Operation::Cast { options, .. } => options
-                            .as_ref()
-                            .and_then(|o| parse_dtype(&serde_json::Value::String(o.to.clone()))),
+                        Operation::Cast { to, .. } => {
+                            if to.is_empty() {
+                                None
+                            } else {
+                                parse_dtype(&serde_json::Value::String(to.clone()))
+                            }
+                        }
                         _ => None,
                     },
                     "dequantizelinear" => input_types.get(1).cloned().or(Some(DataType::Float32)),

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -502,8 +502,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             // Normalize tile inputs: if shape rank is missing, set to repeats length (filled with 1s)
             if op_type == "tile"
                 && let Some(repeats_len) = match &op {
-                    Operation::Tile { options, .. } => {
-                        options.as_ref().map(|o| o.repetitions.len())
+                    Operation::Tile { repetitions, .. } => {
+                        (!repetitions.is_empty()).then_some(repetitions.len())
                     }
                     _ => None,
                 }

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -12,7 +12,7 @@ mod tests {
     use rustnn::graph::{
         ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
     };
-    use rustnn::operator_options::{MLConv2dOptions, OperatorOptions};
+    use rustnn::operator_options::MLConv2dOptions;
     use rustnn::operators::Operation;
     use std::collections::HashMap;
     use trtx::cuda::DeviceBuffer;
@@ -35,11 +35,6 @@ mod tests {
         if let Some(l) = label {
             attr_obj.insert("label".to_string(), serde_json::Value::String(l));
         }
-        let opts = OperatorOptions::from_json_with_op_type(
-            webnn_op_type,
-            &serde_json::Value::Object(attr_obj),
-        )
-        .unwrap_or_default();
         let output_ids: Vec<u32> = if !output_operands.is_empty() {
             output_operands
         } else if let Some(o) = output_operand {
@@ -47,16 +42,15 @@ mod tests {
         } else {
             Vec::new()
         };
-        let operator = Operation::from_operator_options(
+        Operation::from_json_attributes(
             webnn_op_type,
             input_operands,
-            &opts,
             &output_ids,
+            &serde_json::Value::Object(attr_obj),
         )
         .unwrap_or_else(|| {
             panic!("trtx_operation: unsupported op {webnn_op_type} for operands {input_operands:?}")
-        });
-        operator
+        })
     }
 
     /// Helper to create a simple unary operation graph

--- a/tests/wpt_conformance/wpt_to_graph.rs
+++ b/tests/wpt_conformance/wpt_to_graph.rs
@@ -17,15 +17,13 @@
  */
 //! Convert WPT graph description to rustnn GraphInfo and prepare ONNX inputs.
 //!
-//! Operations are built as [`rustnn::operators::Operation`] with [`rustnn::operator_options::OperatorOptions`]:
-//! options are deserialized via [`OperatorOptions::from_json_with_op_type`], then operands are wired with
-//! [`Operation::from_operator_options`] (WebNN camelCase op names, as in JSON).
+//! Operations are built with [`rustnn::operators::Operation::from_json_attributes`]: one JSON attributes
+//! object per op (WebNN camelCase names) plus operand wiring.
 
 use rustnn::graph::{
     ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
     get_static_or_max_size, to_dimension_vector,
 };
-use rustnn::operator_options::OperatorOptions;
 use rustnn::operators::Operation;
 #[cfg(feature = "onnx-runtime")]
 use rustnn::{OnnxInput, TensorData};
@@ -33,32 +31,6 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::wpt_types::{WptGraph, WptOperator, WptTensorSpec};
-
-/// Build an [`Operation`] from WebNN JSON op name (camelCase), ordered operand ids, typed options,
-/// and output operand ids for this operation.
-fn operator_from_wpt_parts(
-    webnn_op_type: &str,
-    operand_ids: &[u32],
-    operator_options: &OperatorOptions,
-    output_ids: &[u32],
-) -> Result<Operation, String> {
-    Operation::from_operator_options(webnn_op_type, operand_ids, operator_options, output_ids)
-        .ok_or_else(|| {
-            format!(
-                "unsupported WPT op or operand layout for Operation::from_operator_options: {webnn_op_type} (operands: {operand_ids:?})"
-            )
-        })
-}
-
-/// Deserialize attributes map using the WebNN camelCase operation name expected by
-/// [`rustnn::operator_options::OperatorOptions`].
-fn operator_options_from_wpt_attrs(
-    webnn_op_type: &str,
-    attributes: serde_json::Map<String, serde_json::Value>,
-) -> OperatorOptions {
-    let attrs_value = serde_json::Value::Object(attributes);
-    OperatorOptions::from_json_with_op_type(webnn_op_type, &attrs_value).unwrap_or_default()
-}
 
 /// WPT camelCase operation name to rustnn snake_case op_type (matches Python method_name_map).
 fn wpt_op_name_to_rustnn(name: &str) -> String {
@@ -929,8 +901,8 @@ pub fn wpt_graph_to_graph_info(graph: &WptGraph) -> Result<(GraphInfo, Vec<Strin
             output_ids.push(id);
         }
 
-        // WebNN JSON / OperatorOptions::from_json_with_op_type expect camelCase op names.
-        // Internal control flow uses snake_case `op_type`; map back for typed options + Operation.
+        // WebNN JSON / Operation::from_json_attributes expect camelCase op names.
+        // Internal control flow uses snake_case `op_type`; map back for deserialization.
         let webnn_op_type = match op_type.as_str() {
             "batch_normalization" => "batchNormalization",
             "instance_normalization" => "instanceNormalization",
@@ -971,9 +943,13 @@ pub fn wpt_graph_to_graph_info(graph: &WptGraph) -> Result<(GraphInfo, Vec<Strin
             "label".to_string(),
             serde_json::Value::String(format!("{}_op", op.name)),
         );
-        let operator_options = operator_options_from_wpt_attrs(webnn_op_type, attributes);
-        let operator =
-            operator_from_wpt_parts(webnn_op_type, &input_ids, &operator_options, &output_ids)?;
+        let attrs_value = serde_json::Value::Object(attributes);
+        let operator = Operation::from_json_attributes(webnn_op_type, &input_ids, &output_ids, &attrs_value)
+            .ok_or_else(|| {
+                format!(
+                    "unsupported WPT op or operand layout for Operation::from_json_attributes: {webnn_op_type} (operands: {input_ids:?})"
+                )
+            })?;
         operations.push(operator);
     }
 

--- a/tests/wpt_conformance/wpt_to_graph.rs
+++ b/tests/wpt_conformance/wpt_to_graph.rs
@@ -846,13 +846,6 @@ pub fn wpt_graph_to_graph_info(graph: &WptGraph) -> Result<(GraphInfo, Vec<Strin
             if !ordered.is_empty() {
                 input_ids = ordered;
             }
-            // When exactly one of scale/bias is provided, set hasScale/hasBias for converter disambiguation.
-            let has_scale = args.get("scale").and_then(|v| v.as_str()).is_some();
-            let has_bias = args.get("bias").and_then(|v| v.as_str()).is_some();
-            if has_scale ^ has_bias {
-                attributes.insert("hasScale".to_string(), serde_json::Value::Bool(has_scale));
-                attributes.insert("hasBias".to_string(), serde_json::Value::Bool(has_bias));
-            }
         }
         // conv2d / conv_transpose2d: only input and filter are positional; bias is in options.
         if op_type == "conv2d" || op_type == "conv_transpose2d" {


### PR DESCRIPTION
## Summary

Nearly all operator options are now spec conformant when it comes to attributes present. Hallucinated operator options generated by the AI has been removed and the corresponding fields moved to the corresponding operation. On top of that the documentation now adds a link to the WebNN API spec documentation for each operator option

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [x] Updated docs if behavior changed
- [x] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

