### PR TITLE
Strong enums

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -28,6 +28,10 @@
 use crate::converters::operand_name;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension as GraphDimension, GraphInfo};
+use crate::operator_enums::{
+    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLInputOperandLayout,
+    MLRoundingType,
+};
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use crate::protos::coreml::mil_spec::{
@@ -1612,22 +1616,13 @@ impl CoremlMlProgramConverter {
             } => {
                 // CoreML MLProgram pooling path currently assumes NCHW input layout.
                 // Reject NHWC explicitly to avoid invalid model/runtime crashes.
-                let layout = pool_opts
-                    .as_ref()
-                    .map(|o| {
-                        if o.layout.is_empty() {
-                            "nchw"
-                        } else {
-                            o.layout.as_str()
-                        }
-                    })
-                    .unwrap_or("nchw");
-                if !layout.eq_ignore_ascii_case("nchw") {
+                let layout = pool_opts.as_ref().map(|o| o.layout).unwrap_or_default();
+                if layout != MLInputOperandLayout::Nchw {
                     return Err(GraphError::ConversionFailed {
                         format: "coreml_mlprogram".to_string(),
                         reason: format!(
                             "CoreML pooling currently supports only NCHW layout; got '{}' for {}",
-                            layout,
+                            layout.as_str(),
                             op.op_type(),
                         ),
                     });
@@ -1656,7 +1651,7 @@ impl CoremlMlProgramConverter {
                 // outputShapeRounding: "floor" (default) or "ceil"
                 let ceil_mode = pool_opts
                     .as_ref()
-                    .map(|o| o.output_shape_rounding.eq_ignore_ascii_case("ceil"))
+                    .map(|o| matches!(o.output_shape_rounding, MLRoundingType::Ceil))
                     .unwrap_or(false);
                 inputs.insert(
                     "ceil_mode".to_string(),
@@ -2544,107 +2539,121 @@ impl super::GraphConverter for CoremlMlProgramConverter {
             if (op_type_lower == "conv2d" || op_type_lower == "convtranspose2d")
                 && op.input_operands().len() >= 2
             {
-                let filter_layout = match &op {
-                    Operation::Conv2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.filter_layout.as_str())
-                        .unwrap_or(""),
-                    Operation::ConvTranspose2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.filter_layout.as_str())
-                        .unwrap_or(""),
-                    _ => "",
+                let needs_filter_transpose = match &op {
+                    Operation::Conv2d { options, .. } => {
+                        options
+                            .as_ref()
+                            .map(|o| o.filter_layout)
+                            .unwrap_or_default()
+                            != MLConv2dFilterOperandLayout::Oihw
+                    }
+                    Operation::ConvTranspose2d { options, .. } => {
+                        options
+                            .as_ref()
+                            .map(|o| o.filter_layout)
+                            .unwrap_or_default()
+                            != MLConvTranspose2dFilterOperandLayout::Iohw
+                    }
+                    _ => false,
                 };
-                if !filter_layout.is_empty() {
-                    let expected_layout = if op_type_lower == "conv2d" {
-                        "oihw"
-                    } else {
-                        "iohw"
-                    };
 
-                    if filter_layout != expected_layout {
-                        let filter_operand_id = op.input_operands()[1];
+                if needs_filter_transpose {
+                    let filter_operand_id = op.input_operands()[1];
 
-                        if let Some(filter_operand) = graph_info.operand(filter_operand_id) {
-                            // Calculate transpose permutation
-                            let perm = match (op_type_lower.as_str(), filter_layout) {
-                                // Conv2d conversions to oihw [O, I, H, W]
-                                ("conv2d", "hwio") => vec![3, 2, 0, 1], // [H, W, I, O] -> [O, I, H, W]
-                                ("conv2d", "ohwi") => vec![0, 3, 1, 2], // [O, H, W, I] -> [O, I, H, W]
-                                ("conv2d", "ihwo") => vec![3, 0, 1, 2], // [I, H, W, O] -> [O, I, H, W]
+                    if let Some(filter_operand) = graph_info.operand(filter_operand_id) {
+                        let perm_opt = match &op {
+                            Operation::Conv2d { options, .. } => {
+                                match options
+                                    .as_ref()
+                                    .map(|o| o.filter_layout)
+                                    .unwrap_or_default()
+                                {
+                                    MLConv2dFilterOperandLayout::Oihw => None,
+                                    MLConv2dFilterOperandLayout::Hwio => Some(vec![3, 2, 0, 1]),
+                                    MLConv2dFilterOperandLayout::Ohwi => Some(vec![0, 3, 1, 2]),
+                                    MLConv2dFilterOperandLayout::Ihwo => Some(vec![3, 0, 1, 2]),
+                                }
+                            }
+                            Operation::ConvTranspose2d { options, .. } => {
+                                match options
+                                    .as_ref()
+                                    .map(|o| o.filter_layout)
+                                    .unwrap_or_default()
+                                {
+                                    MLConvTranspose2dFilterOperandLayout::Iohw => None,
+                                    MLConvTranspose2dFilterOperandLayout::Hwoi => {
+                                        Some(vec![3, 2, 0, 1])
+                                    }
+                                    MLConvTranspose2dFilterOperandLayout::Ohwi => {
+                                        Some(vec![3, 0, 1, 2])
+                                    }
+                                }
+                            }
+                            _ => None,
+                        };
+                        let Some(perm) = perm_opt else {
+                            continue;
+                        };
 
-                                // Conv_transpose2d conversions to iohw [I, O, H, W]
-                                ("convtranspose2d", "hwoi") => vec![3, 2, 0, 1], // [H, W, O, I] -> [I, O, H, W]
-                                ("convtranspose2d", "ohwi") => vec![3, 0, 1, 2], // [O, H, W, I] -> [I, O, H, W]
-                                ("convtranspose2d", "hwio") => vec![2, 3, 0, 1], // [H, W, I, O] -> [I, O, H, W]
+                        // Create transpose operation for filter
+                        let filter_name = operand_name(graph_info, filter_operand_id);
+                        let transposed_filter_name = format!("{}_transposed", filter_name);
 
-                                _ => continue, // Skip unsupported layouts
-                            };
+                        // Store the override mapping
+                        operand_name_overrides
+                            .insert(filter_operand_id, transposed_filter_name.clone());
 
-                            // Create transpose operation for filter
-                            let filter_name = operand_name(graph_info, filter_operand_id);
-                            let transposed_filter_name = format!("{}_transposed", filter_name);
+                        let mut transpose_inputs: HashMap<String, Argument> = HashMap::new();
+                        transpose_inputs
+                            .insert("x".to_string(), Self::create_name_argument(filter_name));
+                        transpose_inputs
+                            .insert("perm".to_string(), Self::create_immediate_int_array(&perm));
 
-                            // Store the override mapping
-                            operand_name_overrides
-                                .insert(filter_operand_id, transposed_filter_name.clone());
+                        // Create tensor type for transposed filter
+                        let dtype = Self::mil_data_type(&filter_operand.descriptor.data_type)?;
+                        let transposed_shape =
+                            Self::permute_graph_shape(&filter_operand.descriptor.shape, &perm);
+                        let dimensions =
+                            Self::mil_dimensions_from_graph_shape(&transposed_shape, false);
 
-                            let mut transpose_inputs: HashMap<String, Argument> = HashMap::new();
-                            transpose_inputs
-                                .insert("x".to_string(), Self::create_name_argument(filter_name));
-                            transpose_inputs.insert(
-                                "perm".to_string(),
-                                Self::create_immediate_int_array(&perm),
-                            );
-
-                            // Create tensor type for transposed filter
-                            let dtype = Self::mil_data_type(&filter_operand.descriptor.data_type)?;
-                            let transposed_shape =
-                                Self::permute_graph_shape(&filter_operand.descriptor.shape, &perm);
-                            let dimensions =
-                                Self::mil_dimensions_from_graph_shape(&transposed_shape, false);
-
-                            let value_type = ValueType {
-                                r#type: Some(
-                                    crate::protos::coreml::mil_spec::value_type::Type::TensorType(
-                                        TensorType {
-                                            rank: dimensions.len() as i64,
-                                            data_type: dtype,
-                                            dimensions,
-                                            attributes: HashMap::new(),
-                                        },
-                                    ),
+                        let value_type = ValueType {
+                            r#type: Some(
+                                crate::protos::coreml::mil_spec::value_type::Type::TensorType(
+                                    TensorType {
+                                        rank: dimensions.len() as i64,
+                                        data_type: dtype,
+                                        dimensions,
+                                        attributes: HashMap::new(),
+                                    },
                                 ),
-                            };
+                            ),
+                        };
 
-                            let transpose_output_type = NamedValueType {
-                                name: transposed_filter_name.clone(),
-                                r#type: Some(value_type),
-                            };
+                        let transpose_output_type = NamedValueType {
+                            name: transposed_filter_name.clone(),
+                            r#type: Some(value_type),
+                        };
 
-                            let transpose_op = Self::create_mil_operation(
-                                "transpose",
-                                transpose_inputs,
-                                vec![transpose_output_type],
-                            );
+                        let transpose_op = Self::create_mil_operation(
+                            "transpose",
+                            transpose_inputs,
+                            vec![transpose_output_type],
+                        );
 
-                            main_block.operations.push(transpose_op);
-                        }
+                        main_block.operations.push(transpose_op);
                     }
                 }
 
                 let input_layout = match &op {
-                    Operation::Conv2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.input_layout.as_str())
-                        .unwrap_or(""),
-                    Operation::ConvTranspose2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.input_layout.as_str())
-                        .unwrap_or(""),
-                    _ => "",
+                    Operation::Conv2d { options, .. } => {
+                        options.as_ref().map(|o| o.input_layout).unwrap_or_default()
+                    }
+                    Operation::ConvTranspose2d { options, .. } => {
+                        options.as_ref().map(|o| o.input_layout).unwrap_or_default()
+                    }
+                    _ => MLInputOperandLayout::Nchw,
                 };
-                if input_layout == "nhwc" && !op.input_operands().is_empty() {
+                if input_layout == MLInputOperandLayout::Nhwc && !op.input_operands().is_empty() {
                     let input_operand_id = op.input_operands()[0];
 
                     // Only transpose if not already transposed

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -20,6 +20,11 @@ use crate::converters::{ConvertedGraph, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
+use crate::operator_enums::{
+    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLGruWeightLayout,
+    MLInputOperandLayout, MLInterpolationMode, MLPaddingMode, MLRecurrentNetworkActivation,
+    MLRecurrentNetworkDirection, MLRoundingType,
+};
 use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
 use crate::operators::Operation;
 use crate::protos::onnx::{
@@ -51,6 +56,14 @@ impl OnnxConverter {
             "tanh" => "Tanh".to_string(),
             "relu" => "Relu".to_string(),
             other => other.to_string(),
+        }
+    }
+
+    fn recurrent_activation_enum_to_onnx(act: MLRecurrentNetworkActivation) -> String {
+        match act {
+            MLRecurrentNetworkActivation::Sigmoid => "Sigmoid".to_string(),
+            MLRecurrentNetworkActivation::Tanh => "Tanh".to_string(),
+            MLRecurrentNetworkActivation::Relu => "Relu".to_string(),
         }
     }
 
@@ -1211,8 +1224,8 @@ impl OnnxConverter {
         if input_shape.len() != 4 {
             return None;
         }
-        let layout = opts.layout.to_ascii_lowercase();
-        let (input_h, input_w) = if layout == "nhwc" {
+        let layout = opts.layout;
+        let (input_h, input_w) = if layout == MLInputOperandLayout::Nhwc {
             (
                 get_static_or_max_size(&input_shape[1]) as i64,
                 get_static_or_max_size(&input_shape[2]) as i64,
@@ -1229,7 +1242,7 @@ impl OnnxConverter {
             .as_ref()
             .map(|v| v.iter().map(|&u| u as i64).collect())
             .or_else(|| {
-                if layout == "nhwc" {
+                if layout == MLInputOperandLayout::Nhwc {
                     Some(vec![
                         get_static_or_max_size(&input_shape[1]) as i64,
                         get_static_or_max_size(&input_shape[2]) as i64,
@@ -1306,7 +1319,7 @@ impl OnnxConverter {
             _ => return attributes,
         };
 
-        let layout = opts.layout.to_ascii_lowercase();
+        let layout = opts.layout;
         let mut kernel_shape: Option<Vec<i64>> = opts
             .window_dimensions
             .as_ref()
@@ -1321,7 +1334,7 @@ impl OnnxConverter {
                     if input_shape.len() != 4 {
                         return None;
                     }
-                    let (h, w) = if layout == "nhwc" {
+                    let (h, w) = if layout == MLInputOperandLayout::Nhwc {
                         (
                             get_static_or_max_size(&input_shape[1]) as i64,
                             get_static_or_max_size(&input_shape[2]) as i64,
@@ -1349,7 +1362,7 @@ impl OnnxConverter {
             && in_operand.descriptor.shape.len() == 4
             && out_operand.descriptor.shape.len() == 4
         {
-            let (in_h, in_w, _out_h, _out_w) = if layout == "nhwc" {
+            let (in_h, in_w, _out_h, _out_w) = if layout == MLInputOperandLayout::Nhwc {
                 (
                     get_static_or_max_size(&in_operand.descriptor.shape[1]),
                     get_static_or_max_size(&in_operand.descriptor.shape[2]),
@@ -1405,7 +1418,7 @@ impl OnnxConverter {
         }
         let ceil_mode = if opts.output_sizes.is_some() {
             Self::infer_pool_ceil_mode_from_output_sizes(op, graph)
-        } else if opts.output_shape_rounding.eq_ignore_ascii_case("ceil") {
+        } else if matches!(opts.output_shape_rounding, MLRoundingType::Ceil) {
             Some(1)
         } else {
             Some(0)
@@ -3910,9 +3923,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     | Operation::GlobalMaxPool { options, .. } => options.as_ref(),
                     _ => None,
                 };
-                let layout = pool_opts
-                    .map(|o| o.layout.to_ascii_lowercase())
-                    .unwrap_or_else(|| "nchw".to_string());
+                let layout = pool_opts.map(|o| o.layout).unwrap_or_default();
 
                 // ONNX AveragePool does not support dilations. Emulate dilated average pool
                 // (for no-padding cases) with depthwise Conv using sparse kernel taps.
@@ -3965,7 +3976,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     })?;
                     let input_shape = input_operand.descriptor.static_or_max_shape();
                     if input_shape.len() == 4 {
-                        let channels = if layout == "nhwc" {
+                        let channels = if layout == MLInputOperandLayout::Nhwc {
                             input_shape[3] as i64
                         } else {
                             input_shape[1] as i64
@@ -3981,7 +3992,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             let denom = (kh * kw) as f32;
 
                             let mut conv_input_name = input_name.clone();
-                            if layout == "nhwc" {
+                            if layout == MLInputOperandLayout::Nhwc {
                                 let nchw_input = format!("{}_nchw_in", op_name);
                                 nodes.push(NodeProto {
                                     input: vec![input_name],
@@ -4025,7 +4036,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                                 ..Default::default()
                             });
 
-                            let conv_output_name = if layout == "nhwc" {
+                            let conv_output_name = if layout == MLInputOperandLayout::Nhwc {
                                 format!("{}_nchw_out", op_name)
                             } else {
                                 output_name.clone()
@@ -4071,7 +4082,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                                 ));
                             }
 
-                            if layout == "nhwc" {
+                            if layout == MLInputOperandLayout::Nhwc {
                                 nodes.push(NodeProto {
                                     input: vec![conv_output_name],
                                     output: vec![output_name],
@@ -4094,7 +4105,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
                 let attributes = Self::create_pool2d_attributes_with_graph(op, graph);
 
-                if layout == "nhwc" {
+                if layout == MLInputOperandLayout::Nhwc {
                     let nchw_input = format!("{}_nchw_in", op_name);
                     nodes.push(NodeProto {
                         input: vec![input_name],
@@ -5421,7 +5432,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 };
                 let direction_str = match direction.as_str() {
                     "backward" => "reverse",
-                    "both" => "bidirectional",
+                    "both" | "bidirectional" => "bidirectional",
                     _ => "forward",
                 };
 
@@ -5645,16 +5656,15 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 })?;
                 let input_dtype = Self::data_type_code(weight_operand.descriptor.data_type);
                 let direction = match &op {
-                    Operation::Lstm { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.direction.to_ascii_lowercase())
-                        .unwrap_or_else(|| "forward".to_string()),
-                    _ => "forward".to_string(),
+                    Operation::Lstm { options, .. } => {
+                        options.as_ref().map(|o| o.direction).unwrap_or_default()
+                    }
+                    _ => MLRecurrentNetworkDirection::Forward,
                 };
-                let direction_str = match direction.as_str() {
-                    "both" | "bidirectional" => "bidirectional",
-                    "backward" => "reverse",
-                    _ => "forward",
+                let direction_str = match direction {
+                    MLRecurrentNetworkDirection::Backward => "reverse",
+                    MLRecurrentNetworkDirection::Both => "bidirectional",
+                    MLRecurrentNetworkDirection::Forward => "forward",
                 };
                 let axes0_name = format!("{}_axes0", op_name);
                 initializers.push(TensorProto {
@@ -5852,7 +5862,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 };
                 // For bidirectional, ONNX initial_h/initial_c must be [2, batch, hidden]. WebNN sends [1, batch, hidden]; duplicate on axis 0.
                 let (lstm_initial_h_name, lstm_initial_c_name) =
-                    if direction == "both" || direction == "bidirectional" {
+                    if matches!(direction, MLRecurrentNetworkDirection::Both) {
                         let h_bidi = format!("{}_initial_h_bidi", op_name);
                         let c_bidi = format!("{}_initial_c_bidi", op_name);
                         nodes.push(NodeProto {
@@ -5910,15 +5920,15 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 } {
                     let strings: Vec<Vec<u8>> = activations
                         .iter()
-                        .map(|s| Self::recurrent_activation_to_onnx(s).into_bytes())
+                        .map(|a| Self::recurrent_activation_enum_to_onnx(*a).into_bytes())
                         .collect();
                     if !strings.is_empty() {
-                        let num_directions = if direction == "both" || direction == "bidirectional"
-                        {
-                            2
-                        } else {
-                            1
-                        };
+                        let num_directions =
+                            if matches!(direction, MLRecurrentNetworkDirection::Both) {
+                                2
+                            } else {
+                                1
+                            };
                         let strings: Vec<Vec<u8>> = (0..num_directions)
                             .flat_map(|_| strings.iter().cloned())
                             .collect();
@@ -5952,7 +5962,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     ..Default::default()
                 });
                 // Wire by name: outputs[0]=Y_h, outputs[1]=Y_c, outputs[2]=sequence when returnSequence.
-                let unidirectional = direction != "both" && direction != "bidirectional";
+                let unidirectional = !matches!(direction, MLRecurrentNetworkDirection::Both);
                 let axes1_name = format!("{}_lstm_axes1", op_name);
                 initializers.push(TensorProto {
                     name: axes1_name.clone(),
@@ -6415,10 +6425,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 })?;
                 let input_dtype = Self::data_type_code(hidden_state_operand.descriptor.data_type);
 
-                let gate_layout = gru_cell_opts
-                    .map(|o| o.layout.to_ascii_lowercase())
-                    .unwrap_or_else(|| "zrn".to_string());
-                let needs_rzn_to_zrn = gate_layout == "rzn";
+                let gate_layout = gru_cell_opts.map(|o| o.layout).unwrap_or_default();
+                let needs_rzn_to_zrn = gate_layout == MLGruWeightLayout::Rzn;
 
                 let axes0_name = format!("{}_axes0", op_name);
                 initializers.push(TensorProto {
@@ -7489,11 +7497,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 });
 
                 let mut inputs = vec![data_input_name, pads_name];
-                let mode = pad_opts.mode.to_ascii_lowercase();
-                let onnx_mode = match mode.as_str() {
-                    "edge" => "edge",
-                    "reflection" => "reflect",
-                    _ => "constant",
+                let onnx_mode = match pad_opts.mode {
+                    MLPaddingMode::Edge => "edge",
+                    MLPaddingMode::Reflection => "reflect",
+                    MLPaddingMode::Constant => "constant",
                 };
                 if onnx_mode == "constant" {
                     let data_dtype = graph
@@ -7660,13 +7667,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     ..Default::default()
                 });
 
-                let mode = resample_opts
-                    .map(|o| o.mode.to_ascii_lowercase())
-                    .unwrap_or_else(|| "nearest-neighbor".to_string());
-                let onnx_mode = if mode == "linear" {
-                    "linear"
-                } else {
-                    "nearest"
+                let mode = resample_opts.map(|o| o.mode).unwrap_or_default();
+                let onnx_mode = match mode {
+                    MLInterpolationMode::Linear => "linear",
+                    MLInterpolationMode::NearestNeighbor => "nearest",
                 };
                 let coord_mode = if onnx_mode == "linear" {
                     "half_pixel"
@@ -8326,21 +8330,17 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 let mut conv_inputs: Vec<String> = Vec::new();
 
                 let input_layout = match &op {
-                    Operation::Conv2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.input_layout.clone())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_else(|| "nchw".to_string()),
-                    Operation::ConvTranspose2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.input_layout.clone())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_else(|| "nchw".to_string()),
-                    _ => "nchw".to_string(),
+                    Operation::Conv2d { options, .. } => {
+                        options.as_ref().map(|o| o.input_layout).unwrap_or_default()
+                    }
+                    Operation::ConvTranspose2d { options, .. } => {
+                        options.as_ref().map(|o| o.input_layout).unwrap_or_default()
+                    }
+                    _ => MLInputOperandLayout::default(),
                 };
 
                 let input_name = operand_name(graph, op.input_operands()[0]);
-                let transposed_input = if input_layout.eq_ignore_ascii_case("nhwc") {
+                let transposed_input = if input_layout == MLInputOperandLayout::Nhwc {
                     // Insert Transpose node: NHWC → NCHW
                     let transpose_output = format!("{}_input_transposed", op_name);
                     nodes.push(NodeProto {
@@ -8362,54 +8362,58 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 };
                 conv_inputs.push(transposed_input);
 
-                let filter_layout = match &op {
-                    Operation::Conv2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.filter_layout.clone())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_else(|| "oihw".to_string()),
-                    Operation::ConvTranspose2d { options, .. } => options
-                        .as_ref()
-                        .map(|o| o.filter_layout.clone())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_else(|| "iohw".to_string()),
-                    _ => {
-                        if matches!(&op, Operation::ConvTranspose2d { .. }) {
-                            "iohw".to_string()
-                        } else {
-                            "oihw".to_string()
-                        }
-                    }
-                };
-
                 let filter_name = operand_name(graph, op.input_operands()[1]);
 
-                let is_transpose = matches!(&op, Operation::ConvTranspose2d { .. });
-                let needs_transpose = if is_transpose {
-                    // ConvTranspose: ONNX expects IOHW (Input, Output, H, W)
-                    filter_layout != "iohw"
-                } else {
-                    // Conv: ONNX expects OIHW (Output, Input, H, W)
-                    filter_layout != "oihw"
+                let needs_transpose = match &op {
+                    Operation::ConvTranspose2d { options, .. } => {
+                        options
+                            .as_ref()
+                            .map(|o| o.filter_layout)
+                            .unwrap_or_default()
+                            != MLConvTranspose2dFilterOperandLayout::Iohw
+                    }
+                    Operation::Conv2d { options, .. } => {
+                        options
+                            .as_ref()
+                            .map(|o| o.filter_layout)
+                            .unwrap_or_default()
+                            != MLConv2dFilterOperandLayout::Oihw
+                    }
+                    _ => unreachable!(),
                 };
 
                 let transposed_filter = if needs_transpose {
-                    let perm = if is_transpose {
-                        // ConvTranspose filter layout conversions → IOHW
-                        match filter_layout.as_str() {
-                            "hwoi" => vec![3, 2, 0, 1], // HWOI (H,W,O,I) → IOHW (I,O,H,W)
-                            "ohwi" => vec![3, 0, 1, 2], // OHWI (O,H,W,I) → IOHW (I,O,H,W)
-                            "oihw" => vec![1, 0, 2, 3], // OIHW (O,I,H,W) → IOHW (I,O,H,W)
-                            _ => vec![0, 1, 2, 3],      // Default: no transpose
+                    let perm = match &op {
+                        Operation::ConvTranspose2d { options, .. } => {
+                            match options
+                                .as_ref()
+                                .map(|o| o.filter_layout)
+                                .unwrap_or_default()
+                            {
+                                MLConvTranspose2dFilterOperandLayout::Hwoi => {
+                                    vec![3, 2, 0, 1]
+                                }
+                                MLConvTranspose2dFilterOperandLayout::Ohwi => {
+                                    vec![3, 0, 1, 2]
+                                }
+                                MLConvTranspose2dFilterOperandLayout::Iohw => {
+                                    vec![1, 0, 2, 3]
+                                }
+                            }
                         }
-                    } else {
-                        // Conv2d filter layout conversions → OIHW
-                        match filter_layout.as_str() {
-                            "hwio" => vec![3, 2, 0, 1], // HWIO (H,W,I,O) → OIHW (O,I,H,W)
-                            "ohwi" => vec![0, 3, 1, 2], // OHWI (O,H,W,I) → OIHW (O,I,H,W)
-                            "ihwo" => vec![3, 0, 1, 2], // IHWO (I,H,W,O) → OIHW (O,I,H,W)
-                            _ => vec![0, 1, 2, 3],      // Default: no transpose
+                        Operation::Conv2d { options, .. } => {
+                            match options
+                                .as_ref()
+                                .map(|o| o.filter_layout)
+                                .unwrap_or_default()
+                            {
+                                MLConv2dFilterOperandLayout::Hwio => vec![3, 2, 0, 1],
+                                MLConv2dFilterOperandLayout::Ohwi => vec![0, 3, 1, 2],
+                                MLConv2dFilterOperandLayout::Ihwo => vec![3, 0, 1, 2],
+                                MLConv2dFilterOperandLayout::Oihw => vec![0, 1, 2, 3],
+                            }
                         }
+                        _ => unreachable!(),
                     };
 
                     let transpose_output = format!("{}_filter_transposed", op_name);
@@ -8449,7 +8453,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     op.output_operand()
                         .expect("Single-output operation expected"),
                 );
-                let conv_output_name = if input_layout.eq_ignore_ascii_case("nhwc") {
+                let conv_output_name = if input_layout == MLInputOperandLayout::Nhwc {
                     format!("{}_conv_output_nchw", op_name)
                 } else {
                     final_output_name.clone()
@@ -8465,7 +8469,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     ..Default::default()
                 });
 
-                if input_layout.eq_ignore_ascii_case("nhwc") {
+                if input_layout == MLInputOperandLayout::Nhwc {
                     nodes.push(NodeProto {
                         input: vec![conv_output_name],
                         output: vec![final_output_name],

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -29,6 +29,9 @@ use super::{ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
+use crate::operator_enums::{
+    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLInputOperandLayout,
+};
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use trtx::network::Layer;
@@ -6680,22 +6683,12 @@ impl TrtxConverter {
         let fs = filter_operand.descriptor.static_or_max_shape();
         let attrs = operation.attributes();
         let conv_opts = attrs.as_conv2d();
-        let filter_layout = conv_opts
-            .map(|o| o.filter_layout.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("oihw");
+        let filter_layout = conv_opts.map(|o| o.filter_layout).unwrap_or_default();
         let (o, _i, h, w): (u32, u32, u32, u32) = match filter_layout {
-            "oihw" => (fs[0], fs[1], fs[2], fs[3]),
-            "hwio" => (fs[3], fs[2], fs[0], fs[1]),
-            "ohwi" => (fs[0], fs[3], fs[1], fs[2]),
-            "ihwo" => (fs[3], fs[0], fs[1], fs[2]),
-            "hwoi" => (fs[2], fs[3], fs[0], fs[1]),
-            _ => {
-                return Err(GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Unsupported filter_layout: {}", filter_layout),
-                });
-            }
+            MLConv2dFilterOperandLayout::Oihw => (fs[0], fs[1], fs[2], fs[3]),
+            MLConv2dFilterOperandLayout::Hwio => (fs[3], fs[2], fs[0], fs[1]),
+            MLConv2dFilterOperandLayout::Ohwi => (fs[0], fs[3], fs[1], fs[2]),
+            MLConv2dFilterOperandLayout::Ihwo => (fs[3], fs[0], fs[1], fs[2]),
         };
         let num_output_maps = o as i32;
         let kernel_size: [i32; 2] = [h as i32, w as i32];
@@ -6736,18 +6729,25 @@ impl TrtxConverter {
             let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
                 (DataType::Float16, _) => {
                     let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
-                    let oihw = if filter_layout == "oihw" {
+                    let oihw = if filter_layout == MLConv2dFilterOperandLayout::Oihw {
                         f32_bytes
                     } else {
-                        Self::conv_filter_to_oihw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                        Self::conv_filter_to_oihw(
+                            &f32_bytes,
+                            filter_layout.as_str(),
+                            &filter_shape_u32,
+                        )?
                     };
                     temp_weights.push(oihw);
                     Some(temp_weights.len() - 1)
                 }
-                (DataType::Float32, "oihw") => None,
+                (DataType::Float32, MLConv2dFilterOperandLayout::Oihw) => None,
                 (DataType::Float32, _) => {
-                    let oihw =
-                        Self::conv_filter_to_oihw(filter_data, filter_layout, &filter_shape_u32)?;
+                    let oihw = Self::conv_filter_to_oihw(
+                        filter_data,
+                        filter_layout.as_str(),
+                        &filter_shape_u32,
+                    )?;
                     temp_weights.push(oihw);
                     Some(temp_weights.len() - 1)
                 }
@@ -6772,7 +6772,7 @@ impl TrtxConverter {
             (Some(filter_data_to_use), bias_data)
         } else {
             // Non-constant filter: use tensor inputs (setInput(1)=kernel, setInput(2)=bias). TensorRT expects OIHW for kernel.
-            if filter_layout != "oihw" {
+            if filter_layout != MLConv2dFilterOperandLayout::Oihw {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: "conv2d with non-constant filter requires filter_layout \"oihw\""
@@ -6791,10 +6791,7 @@ impl TrtxConverter {
         };
 
         // Input layout: nchw (default) or nhwc. TensorRT conv is NCHW; we use IShuffleLayer::setFirstTranspose for NHWC.
-        let input_layout = conv_opts
-            .map(|o| o.input_layout.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("nchw");
+        let input_layout = conv_opts.map(|o| o.input_layout).unwrap_or_default();
         let input_id = operation.input_operands()[0];
         let input_dtype = graph
             .operand(input_id)
@@ -6808,7 +6805,7 @@ impl TrtxConverter {
             })?;
 
         // NHWC input: TensorRT conv expects NCHW. Insert shuffle to transpose NHWC->NCHW before conv.
-        let nhwc_shuffle_output = if input_layout == "nhwc" {
+        let nhwc_shuffle_output = if input_layout == MLInputOperandLayout::Nhwc {
             let mut shuffle =
                 network
                     .add_shuffle(input)
@@ -7084,7 +7081,7 @@ impl TrtxConverter {
         };
 
         // If input was NHWC, transpose output back to NHWC.
-        let output = if input_layout == "nhwc" {
+        let output = if input_layout == MLInputOperandLayout::Nhwc {
             let mut shuffle =
                 network
                     .add_shuffle(&conv_output)
@@ -7146,23 +7143,11 @@ impl TrtxConverter {
         let fs = filter_operand.descriptor.static_or_max_shape();
         let attrs = operation.attributes();
         let deconv_opts = attrs.as_conv_transpose2d();
-        let filter_layout = deconv_opts
-            .map(|o| o.filter_layout.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("iohw");
+        let filter_layout = deconv_opts.map(|o| o.filter_layout).unwrap_or_default();
         let (_i, o, h, w): (u32, u32, u32, u32) = match filter_layout {
-            "iohw" => (fs[0], fs[1], fs[2], fs[3]),
-            "oihw" => (fs[1], fs[0], fs[2], fs[3]),
-            "hwio" => (fs[2], fs[3], fs[0], fs[1]),
-            "ohwi" => (fs[3], fs[0], fs[1], fs[2]),
-            "ihwo" => (fs[0], fs[3], fs[1], fs[2]),
-            "hwoi" => (fs[3], fs[2], fs[0], fs[1]),
-            _ => {
-                return Err(GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Unsupported filter_layout: {}", filter_layout),
-                });
-            }
+            MLConvTranspose2dFilterOperandLayout::Iohw => (fs[0], fs[1], fs[2], fs[3]),
+            MLConvTranspose2dFilterOperandLayout::Hwoi => (fs[3], fs[2], fs[0], fs[1]),
+            MLConvTranspose2dFilterOperandLayout::Ohwi => (fs[3], fs[0], fs[1], fs[2]),
         };
         let groups = deconv_opts.map(|o| o.groups as i32).unwrap_or(1);
         // WebNN filter shape is [inputChannels, outputChannels/groups, H, W]; TensorRT expects total output maps.
@@ -7203,18 +7188,25 @@ impl TrtxConverter {
             let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
                 (DataType::Float16, _) => {
                     let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
-                    let iohw = if filter_layout == "iohw" {
+                    let iohw = if filter_layout == MLConvTranspose2dFilterOperandLayout::Iohw {
                         f32_bytes
                     } else {
-                        Self::deconv_filter_to_iohw(&f32_bytes, filter_layout, &filter_shape_u32)?
+                        Self::deconv_filter_to_iohw(
+                            &f32_bytes,
+                            filter_layout.as_str(),
+                            &filter_shape_u32,
+                        )?
                     };
                     temp_weights.push(iohw);
                     Some(temp_weights.len() - 1)
                 }
-                (DataType::Float32, "iohw") => None,
+                (DataType::Float32, MLConvTranspose2dFilterOperandLayout::Iohw) => None,
                 (DataType::Float32, _) => {
-                    let iohw =
-                        Self::deconv_filter_to_iohw(filter_data, filter_layout, &filter_shape_u32)?;
+                    let iohw = Self::deconv_filter_to_iohw(
+                        filter_data,
+                        filter_layout.as_str(),
+                        &filter_shape_u32,
+                    )?;
                     temp_weights.push(iohw);
                     Some(temp_weights.len() - 1)
                 }
@@ -7238,7 +7230,7 @@ impl TrtxConverter {
             };
             (Some(filter_data_to_use), bias_data)
         } else {
-            if filter_layout != "iohw" {
+            if filter_layout != MLConvTranspose2dFilterOperandLayout::Iohw {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason:
@@ -7257,10 +7249,7 @@ impl TrtxConverter {
             (None, None)
         };
 
-        let input_layout = deconv_opts
-            .map(|o| o.input_layout.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("nchw");
+        let input_layout = deconv_opts.map(|o| o.input_layout).unwrap_or_default();
         let input_id = operation.input_operands()[0];
         let input_dtype = graph
             .operand(input_id)
@@ -7273,7 +7262,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let nhwc_shuffle_output = if input_layout == "nhwc" {
+        let nhwc_shuffle_output = if input_layout == MLInputOperandLayout::Nhwc {
             let mut shuffle =
                 network
                     .add_shuffle(input)
@@ -7584,30 +7573,32 @@ impl TrtxConverter {
                 if in_shape.len() != 4 || out_shape.len() != 4 {
                     deconv_output
                 } else {
-                    let (input_h, input_w): (i32, i32) = if input_layout == "nhwc" {
-                        (
-                            get_static_or_max_size(&in_shape[1]) as i32,
-                            get_static_or_max_size(&in_shape[2]) as i32,
-                        )
-                    } else {
-                        (
-                            get_static_or_max_size(&in_shape[2]) as i32,
-                            get_static_or_max_size(&in_shape[3]) as i32,
-                        )
-                    };
-                    let (target_h, target_w, out_c): (i32, i32, i32) = if input_layout == "nhwc" {
-                        (
-                            get_static_or_max_size(&out_shape[1]) as i32,
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
-                        )
-                    } else {
-                        (
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
-                            get_static_or_max_size(&out_shape[1]) as i32,
-                        )
-                    };
+                    let (input_h, input_w): (i32, i32) =
+                        if input_layout == MLInputOperandLayout::Nhwc {
+                            (
+                                get_static_or_max_size(&in_shape[1]) as i32,
+                                get_static_or_max_size(&in_shape[2]) as i32,
+                            )
+                        } else {
+                            (
+                                get_static_or_max_size(&in_shape[2]) as i32,
+                                get_static_or_max_size(&in_shape[3]) as i32,
+                            )
+                        };
+                    let (target_h, target_w, out_c): (i32, i32, i32) =
+                        if input_layout == MLInputOperandLayout::Nhwc {
+                            (
+                                get_static_or_max_size(&out_shape[1]) as i32,
+                                get_static_or_max_size(&out_shape[2]) as i32,
+                                get_static_or_max_size(&out_shape[3]) as i32,
+                            )
+                        } else {
+                            (
+                                get_static_or_max_size(&out_shape[2]) as i32,
+                                get_static_or_max_size(&out_shape[3]) as i32,
+                                get_static_or_max_size(&out_shape[1]) as i32,
+                            )
+                        };
                     let out_batch = get_static_or_max_size(&in_shape[0]) as i32;
                     if target_h <= 0 || target_w <= 0 {
                         deconv_output
@@ -7693,7 +7684,7 @@ impl TrtxConverter {
             spatial_adjusted
         };
 
-        let output = if input_layout == "nhwc" {
+        let output = if input_layout == MLInputOperandLayout::Nhwc {
             let mut shuffle =
                 network
                     .add_shuffle(&conv_output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod executors;
 pub mod graph;
 pub mod graphviz;
 pub mod loader;
+pub mod operator_enums;
 pub mod operator_options;
 pub mod operators;
 pub mod protos;

--- a/src/operator_enums.rs
+++ b/src/operator_enums.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MlOperandDataType {
+    #[default]
+    Float32,
+    Float16,
+    Int32,
+    Uint32,
+    Int64,
+    Uint64,
+    Int8,
+    Uint8,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLLstmWeightLayout {
+    #[default]
+    Iofg,
+    Ifgo,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLRoundingType {
+    #[default]
+    Floor,
+    Ceil,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLInterpolationMode {
+    #[default]
+    NearestNeighbor,
+    Linear,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLRecurrentNetworkDirection {
+    #[default]
+    Forward,
+    Backward,
+    Both,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLConv2dFilterOperandLayout {
+    #[default]
+    Oihw,
+    Hwio,
+    Ohwi,
+    Ihwo,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLConvTranspose2dFilterOperandLayout {
+    #[default]
+    Iohw,
+    Hwoi,
+    Ohwi,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLRecurrentNetworkActivation {
+    #[default]
+    Relu,
+    Sigmoid,
+    Tanh,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLGruWeightLayout {
+    #[default]
+    Zrn,
+    Rzn,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLInputOperandLayout {
+    #[default]
+    Nchw,
+    Nhwc,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MLPaddingMode {
+    #[default]
+    Constant,
+    Edge,
+    Reflection,
+}

--- a/src/operator_enums.rs
+++ b/src/operator_enums.rs
@@ -99,3 +99,94 @@ pub enum MLPaddingMode {
     Edge,
     Reflection,
 }
+
+// ---------------------------------------------------------------------------
+// Stable WebNN JSON / IDL string forms (kebab-case / lowercase) for converters
+// ---------------------------------------------------------------------------
+
+impl MLRoundingType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Floor => "floor",
+            Self::Ceil => "ceil",
+        }
+    }
+}
+
+impl MLInterpolationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NearestNeighbor => "nearest-neighbor",
+            Self::Linear => "linear",
+        }
+    }
+}
+
+impl MLRecurrentNetworkDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Forward => "forward",
+            Self::Backward => "backward",
+            Self::Both => "both",
+        }
+    }
+}
+
+impl MLConv2dFilterOperandLayout {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Oihw => "oihw",
+            Self::Hwio => "hwio",
+            Self::Ohwi => "ohwi",
+            Self::Ihwo => "ihwo",
+        }
+    }
+}
+
+impl MLConvTranspose2dFilterOperandLayout {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Iohw => "iohw",
+            Self::Hwoi => "hwoi",
+            Self::Ohwi => "ohwi",
+        }
+    }
+}
+
+impl MLRecurrentNetworkActivation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Relu => "relu",
+            Self::Sigmoid => "sigmoid",
+            Self::Tanh => "tanh",
+        }
+    }
+}
+
+impl MLGruWeightLayout {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Zrn => "zrn",
+            Self::Rzn => "rzn",
+        }
+    }
+}
+
+impl MLInputOperandLayout {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Nchw => "nchw",
+            Self::Nhwc => "nhwc",
+        }
+    }
+}
+
+impl MLPaddingMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Constant => "constant",
+            Self::Edge => "edge",
+            Self::Reflection => "reflection",
+        }
+    }
+}

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -24,9 +24,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::operator_enums::{
-    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLInputOperandLayout,
-    MLInterpolationMode, MLLstmWeightLayout, MLPaddingMode, MLRecurrentNetworkActivation,
-    MLRecurrentNetworkDirection, MLRoundingType,
+    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLGruWeightLayout,
+    MLInputOperandLayout, MLInterpolationMode, MLLstmWeightLayout, MLPaddingMode,
+    MLRecurrentNetworkActivation, MLRecurrentNetworkDirection, MLRoundingType,
 };
 
 /// Operand reference (graph operand index). Used in option structs for MLOperand fields.
@@ -530,7 +530,7 @@ pub struct MLGruCellOptions {
     #[serde(default)]
     pub reset_after: bool,
     #[serde(default)]
-    pub layout: MLInputOperandLayout,
+    pub layout: MLGruWeightLayout,
     pub activations: Option<Vec<String>>,
 }
 

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -23,6 +23,12 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::operator_enums::{
+    MLConv2dFilterOperandLayout, MLConvTranspose2dFilterOperandLayout, MLInputOperandLayout,
+    MLInterpolationMode, MLLstmWeightLayout, MLPaddingMode, MLRecurrentNetworkActivation,
+    MLRecurrentNetworkDirection, MLRoundingType,
+};
+
 /// Operand reference (graph operand index). Used in option structs for MLOperand fields.
 pub type OperandIndex = u32;
 
@@ -319,9 +325,9 @@ pub struct MLConv2dOptions {
     #[serde(default = "default_conv_groups")]
     pub groups: u32,
     #[serde(default)]
-    pub input_layout: String, // "nchw" | "nhwc"
+    pub input_layout: MLInputOperandLayout, // "nchw" | "nhwc"
     #[serde(default)]
-    pub filter_layout: String, // "oihw" | "hwio" | "ohwi" | "ihwo"
+    pub filter_layout: MLConv2dFilterOperandLayout, // "oihw" | "hwio" | "ohwi" | "ihwo"
     pub bias: Option<OperandIndex>,
 }
 
@@ -333,8 +339,8 @@ impl Default for MLConv2dOptions {
             strides: Vec::new(),
             dilations: Vec::new(),
             groups: default_conv_groups(),
-            input_layout: String::new(),
-            filter_layout: String::new(),
+            input_layout: Default::default(),
+            filter_layout: Default::default(),
             bias: None,
         }
     }
@@ -358,9 +364,9 @@ pub struct MLConvTranspose2dOptions {
     #[serde(default = "default_conv_groups")]
     pub groups: u32,
     #[serde(default)]
-    pub input_layout: String,
+    pub input_layout: MLInputOperandLayout,
     #[serde(default)]
-    pub filter_layout: String, // "iohw" | "hwoi" | "ohwi"
+    pub filter_layout: MLConvTranspose2dFilterOperandLayout, // "iohw" | "hwoi" | "ohwi"
     pub bias: Option<OperandIndex>,
 }
 
@@ -374,8 +380,8 @@ impl Default for MLConvTranspose2dOptions {
             output_padding: Vec::new(),
             output_sizes: None,
             groups: default_conv_groups(),
-            input_layout: String::new(),
-            filter_layout: String::new(),
+            input_layout: Default::default(),
+            filter_layout: Default::default(),
             bias: None,
         }
     }
@@ -524,7 +530,7 @@ pub struct MLGruCellOptions {
     #[serde(default)]
     pub reset_after: bool,
     #[serde(default)]
-    pub layout: String,
+    pub layout: MLInputOperandLayout,
     pub activations: Option<Vec<String>>,
 }
 
@@ -697,10 +703,10 @@ pub struct MLLstmOptions {
     #[serde(default)]
     pub return_sequence: bool,
     #[serde(default)]
-    pub direction: String,
+    pub direction: MLRecurrentNetworkDirection,
     #[serde(default)]
-    pub layout: String, // "iofg" | "ifgo"
-    pub activations: Option<Vec<String>>,
+    pub layout: MLLstmWeightLayout, // "iofg" | "ifgo"
+    pub activations: Option<Vec<MLRecurrentNetworkActivation>>,
 }
 
 /// MLLstmCellOptions. lstmCell.
@@ -730,7 +736,7 @@ pub struct MLPadOptions {
     pub label: String,
     // TODO MTAX mode is an enum of type MLPaddingMode
     #[serde(default)]
-    pub mode: String, // "constant" | "edge" | "reflection"
+    pub mode: MLPaddingMode, // "constant" | "edge" | "reflection"
     pub value: Option<serde_json::Value>, // MLNumber
 }
 
@@ -750,12 +756,10 @@ pub struct MLPool2dOptions {
     pub strides: Vec<u32>,
     #[serde(default)]
     pub dilations: Vec<u32>,
-    // TODO MTAX layout is enum MLInputOperandLayout
     #[serde(default)]
-    pub layout: String,
-    // TODO MTAX enum MLRoundingType
+    pub layout: MLInputOperandLayout,
     #[serde(default)]
-    pub output_shape_rounding: String,
+    pub output_shape_rounding: MLRoundingType,
     pub output_sizes: Option<Vec<u32>>,
 }
 
@@ -781,9 +785,8 @@ pub struct MLReduceOptions {
 pub struct MLResample2dOptions {
     #[serde(default)]
     pub label: String,
-    // TODO MTAX enum MLInterpolationMode
     #[serde(default)]
-    pub mode: String, // "nearest-neighbor" | "linear"
+    pub mode: MLInterpolationMode, // "nearest-neighbor" | "linear"
     #[serde(default)]
     pub scales: Vec<f32>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- [ ] Describe the user-visible and code-level changes.

Some refactoring that caught my attention during WebNN backend. Would do first commit (adding the enums first) and then incrementally do the second AI commit after we have again stable test coverage.

The enums are coming from the enums generated by `web_sys` from WebNN IDL. There is also the option to have them still as strings as `web_sys` generated them:

```rust
#![allow(unused_imports)]
#![allow(clippy::all)]
use wasm_bindgen::prelude::*;
#[cfg(web_sys_unstable_apis)]
#[wasm_bindgen]
#[doc = "The `MlOperandDataType` enum."]
#[doc = ""]
#[doc = "*This API requires the following crate features to be activated: `MlOperandDataType`*"]
#[doc = ""]
#[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
#[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum MlOperandDataType {
    Float32 = "float32",
    Float16 = "float16",
    Int32 = "int32",
    Uint32 = "uint32",
    Int64 = "int64",
    Uint64 = "uint64",
    Int8 = "int8",
    Uint8 = "uint8",
}
```
I copied without the strings, as serde kebab-case will do them for us

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

