### PR TITLE
Fix failing rustnnpt tests for the trtx backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ objc = { version = "0.2", optional = true }
 ort = { version = "2.0.0-rc.11", optional = true, features = ["ndarray", "half", "load-dynamic"] }
 tokenizers = { version = "0.22", optional = true }
 half = "2.4"
-trtx = { version = "0.3.1", optional = true }
+trtx = { version = "0.4.0", optional = true }
 regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }

--- a/docs/converters/TRTX_DEVELOPMENT_GUIDE.md
+++ b/docs/converters/TRTX_DEVELOPMENT_GUIDE.md
@@ -154,21 +154,11 @@ final_output_buffer.copy_to_host(output_bytes)?;
 
 ### 5. Weights Lifetime Management
 
-**Critical Requirement:** Constant weights passed to TensorRT must remain valid until engine serialization completes.
+**Context:** Some TensorRT APIs require weight bytes to stay valid until the engine is serialized.
 
-**Implementation:**
-```rust
-pub struct TrtxConverter {
-    temp_weights: Vec<Vec<u8>>,  // Keeps weights alive
-}
+**Current implementation:** `TrtxConverter` is a unit struct (no fields). The converter adds constants through trtx network helpers such as `add_constant`, `add_small_constant_copied`, and related layers; those APIs copy or retain data as required by the bindings. The converter does not keep an auxiliary host-side buffer for weight bytes.
 
-fn add_constant(&mut self, data: &[u8]) -> trtx::Weights {
-    let weight_data = data.to_vec();
-    self.temp_weights.push(weight_data);
-    let stable_ptr = self.temp_weights.last().unwrap().as_ptr();
-    trtx::Weights::new(stable_ptr, data.len(), data_type)
-}
-```
+**If you see invalid-weights-pointer errors:** Prefer APIs that copy host bytes into the network, and avoid handing TensorRT pointers to stack temporaries unless the API documents an immediate copy.
 
 ---
 
@@ -350,9 +340,8 @@ Segmentation fault
 ```
 
 **Solution:**
-- Store weights in `TrtxConverter::temp_weights`
-- Use stable pointers from stored `Vec<u8>`
-- Don't pass temporary stack arrays
+- Use `add_small_constant_copied` / `add_constant` (or equivalent) so weights are owned or copied by the network build path
+- Do not pass pointers to short-lived stack buffers into APIs that retain raw pointers without copying
 
 ---
 

--- a/docs/converters/trtx-implementation-status.md
+++ b/docs/converters/trtx-implementation-status.md
@@ -516,7 +516,7 @@ Added the final 8 operations, achieving **100% WebNN specification coverage (105
   3. Compare: `IElementWiseLayer` with `kEQUAL`
   4. Cast Bool to Float32: `IElementWiseLayer` multiply by 1.0
 - **Output:** Float32 (0.0 = false, 1.0 = true)
-- **Weights Management:** Infinity constant stored in `temp_weights` for lifetime
+- **Weights Management:** Infinity is supplied via a constant layer; weight bytes are handled by the trtx/TensorRT build APIs.
 
 **roundEven:**
 - **TensorRT's Default:** TensorRT's `kROUND` already uses IEEE 754 round-to-nearest-even (banker's rounding)
@@ -767,20 +767,9 @@ This marks the **first complete implementation of all non-RNN WebNN operations i
 
 ## Implementation Notes
 
-### Weight Lifetime Management
+### Weight lifetime
 
-TrtxConverter uses a `Vec<Vec<u8>>` temporary weight storage to ensure constant weight data remains valid throughout TensorRT engine building and serialization. This is critical for operations like GEMM that create scalar constants dynamically.
-
-```rust
-fn build_network(
-    graph: &GraphInfo,
-    network: &mut trtx::NetworkDefinition,
-) -> Result<Vec<Vec<u8>>, GraphError> {
-    let mut temp_weights: Vec<Vec<u8>> = Vec::new();
-    // ... operations store weights in temp_weights ...
-    Ok(temp_weights) // Keep alive until engine serialization
-}
-```
+`TrtxConverter` does not keep a `Vec<Vec<u8>>` for weights. Network construction uses trtx methods such as `add_constant` and `add_small_constant_copied`, which copy or retain bytes as the bindings require. `build_network` takes the graph and `NetworkDefinition` and returns `Result<(), GraphError>`.
 
 ### TensorRT Layer API Usage
 

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -5,6 +5,7 @@ use crate::graph::GraphInfo;
 
 mod coreml_mlprogram;
 pub mod onnx;
+mod pool2d_shared;
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 mod trtx;
 mod weight_file_builder;

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -7065,7 +7065,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     });
                 }
 
-                if let Some(new_shape_value) = serde_json::to_value(new_shape).ok() {
+                if let Ok(new_shape_value) = serde_json::to_value(new_shape) {
                     // WebNN expand with newShape can be either:
                     // 1. ONNX Expand (broadcasting-compatible shapes)
                     // 2. ONNX Reshape (arbitrary shape changes)

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -1186,111 +1186,6 @@ impl OnnxConverter {
         }
     }
 
-    fn infer_pool_ceil_mode_from_output_sizes(op: &Operation, graph: &GraphInfo) -> Option<i64> {
-        let opts = match &op {
-            Operation::AveragePool2d { options, .. }
-            | Operation::MaxPool2d { options, .. }
-            | Operation::L2Pool2d { options, .. }
-            | Operation::GlobalAveragePool { options, .. }
-            | Operation::GlobalMaxPool { options, .. } => options.as_ref()?,
-            _ => return None,
-        };
-
-        let target: Vec<i64> = opts
-            .output_sizes
-            .as_ref()?
-            .iter()
-            .map(|&u| u as i64)
-            .collect();
-        if target.len() != 2 {
-            return None;
-        }
-
-        let input_id = *op.input_operands().first()?;
-        let input_shape = &graph.operand(input_id)?.descriptor.shape;
-        if input_shape.len() != 4 {
-            return None;
-        }
-        let layout = opts.layout.to_ascii_lowercase();
-        let (input_h, input_w) = if layout == "nhwc" {
-            (
-                get_static_or_max_size(&input_shape[1]) as i64,
-                get_static_or_max_size(&input_shape[2]) as i64,
-            )
-        } else {
-            (
-                get_static_or_max_size(&input_shape[2]) as i64,
-                get_static_or_max_size(&input_shape[3]) as i64,
-            )
-        };
-
-        let kernel: Vec<i64> = opts
-            .window_dimensions
-            .as_ref()
-            .map(|v| v.iter().map(|&u| u as i64).collect())
-            .or_else(|| {
-                if layout == "nhwc" {
-                    Some(vec![
-                        get_static_or_max_size(&input_shape[1]) as i64,
-                        get_static_or_max_size(&input_shape[2]) as i64,
-                    ])
-                } else {
-                    Some(vec![
-                        get_static_or_max_size(&input_shape[2]) as i64,
-                        get_static_or_max_size(&input_shape[3]) as i64,
-                    ])
-                }
-            })?;
-        if kernel.len() != 2 {
-            return None;
-        }
-        let strides: Vec<i64> = if opts.strides.is_empty() {
-            vec![1, 1]
-        } else {
-            opts.strides.iter().map(|&u| u as i64).collect()
-        };
-        let dilations: Vec<i64> = if opts.dilations.is_empty() {
-            vec![1, 1]
-        } else {
-            opts.dilations.iter().map(|&u| u as i64).collect()
-        };
-        let pads: Vec<i64> = if opts.padding.len() == 4 {
-            vec![
-                opts.padding[0] as i64,
-                opts.padding[2] as i64,
-                opts.padding[1] as i64,
-                opts.padding[3] as i64,
-            ]
-        } else if opts.padding.is_empty() {
-            vec![0, 0, 0, 0]
-        } else {
-            opts.padding.iter().map(|&u| u as i64).collect()
-        };
-        if strides.len() != 2 || dilations.len() != 2 || pads.len() != 4 {
-            return None;
-        }
-
-        let eff_h = dilations[0] * (kernel[0] - 1) + 1;
-        let eff_w = dilations[1] * (kernel[1] - 1) + 1;
-        let numer_h = input_h + pads[0] + pads[2] - eff_h;
-        let numer_w = input_w + pads[1] + pads[3] - eff_w;
-        if numer_h < 0 || numer_w < 0 {
-            return None;
-        }
-        let floor_h = (numer_h / strides[0]) + 1;
-        let floor_w = (numer_w / strides[1]) + 1;
-        let ceil_h = ((numer_h + strides[0] - 1) / strides[0]) + 1;
-        let ceil_w = ((numer_w + strides[1] - 1) / strides[1]) + 1;
-
-        if target[0] == floor_h && target[1] == floor_w {
-            Some(0)
-        } else if target[0] == ceil_h && target[1] == ceil_w {
-            Some(1)
-        } else {
-            None
-        }
-    }
-
     fn create_pool2d_attributes_with_graph(
         op: &Operation,
         graph: &GraphInfo,
@@ -1404,7 +1299,7 @@ impl OnnxConverter {
             Self::add_ints_attribute(&mut attributes, "pads", pads);
         }
         let ceil_mode = if opts.output_sizes.is_some() {
-            Self::infer_pool_ceil_mode_from_output_sizes(op, graph)
+            super::pool2d_shared::infer_pool2d_ceil_mode_from_output_sizes(op, graph)
         } else if opts.output_shape_rounding.eq_ignore_ascii_case("ceil") {
             Some(1)
         } else {

--- a/src/converters/pool2d_shared.rs
+++ b/src/converters/pool2d_shared.rs
@@ -1,6 +1,6 @@
 //! Shared pool2d helpers for ONNX, TensorRT, and shape inference.
 
-use crate::graph::{get_static_or_max_size, GraphInfo};
+use crate::graph::{GraphInfo, get_static_or_max_size};
 use crate::operators::Operation;
 
 /// Map WebNN [`output_sizes`](crate::operator_options::MLPool2dOptions::output_sizes) to ONNX `ceil_mode`

--- a/src/converters/pool2d_shared.rs
+++ b/src/converters/pool2d_shared.rs
@@ -1,0 +1,116 @@
+//! Shared pool2d helpers for ONNX, TensorRT, and shape inference.
+
+use crate::graph::{get_static_or_max_size, GraphInfo};
+use crate::operators::Operation;
+
+/// Map WebNN [`output_sizes`](crate::operator_options::MLPool2dOptions::output_sizes) to ONNX `ceil_mode`
+/// / TensorRT round-up: `0` = floor spatial shape, `1` = ceil spatial shape.
+///
+/// Returns [`None`] when `output_sizes` is absent, not length-2, or does not match either implicit shape.
+pub(crate) fn infer_pool2d_ceil_mode_from_output_sizes(
+    op: &Operation,
+    graph: &GraphInfo,
+) -> Option<i64> {
+    let opts = match &op {
+        Operation::AveragePool2d { options, .. }
+        | Operation::MaxPool2d { options, .. }
+        | Operation::L2Pool2d { options, .. }
+        | Operation::GlobalAveragePool { options, .. }
+        | Operation::GlobalMaxPool { options, .. } => options.as_ref()?,
+        _ => return None,
+    };
+
+    let target: Vec<i64> = opts
+        .output_sizes
+        .as_ref()?
+        .iter()
+        .map(|&u| u as i64)
+        .collect();
+    if target.len() != 2 {
+        return None;
+    }
+
+    let input_id = *op.input_operands().first()?;
+    let input_shape = &graph.operand(input_id)?.descriptor.shape;
+    if input_shape.len() != 4 {
+        return None;
+    }
+    let layout = opts.layout.to_ascii_lowercase();
+    let (input_h, input_w) = if layout == "nhwc" {
+        (
+            get_static_or_max_size(&input_shape[1]) as i64,
+            get_static_or_max_size(&input_shape[2]) as i64,
+        )
+    } else {
+        (
+            get_static_or_max_size(&input_shape[2]) as i64,
+            get_static_or_max_size(&input_shape[3]) as i64,
+        )
+    };
+
+    let kernel: Vec<i64> = opts
+        .window_dimensions
+        .as_ref()
+        .map(|v| v.iter().map(|&u| u as i64).collect())
+        .or_else(|| {
+            if layout == "nhwc" {
+                Some(vec![
+                    get_static_or_max_size(&input_shape[1]) as i64,
+                    get_static_or_max_size(&input_shape[2]) as i64,
+                ])
+            } else {
+                Some(vec![
+                    get_static_or_max_size(&input_shape[2]) as i64,
+                    get_static_or_max_size(&input_shape[3]) as i64,
+                ])
+            }
+        })?;
+    if kernel.len() != 2 {
+        return None;
+    }
+    let strides: Vec<i64> = if opts.strides.is_empty() {
+        vec![1, 1]
+    } else {
+        opts.strides.iter().map(|&u| u as i64).collect()
+    };
+    let dilations: Vec<i64> = if opts.dilations.is_empty() {
+        vec![1, 1]
+    } else {
+        opts.dilations.iter().map(|&u| u as i64).collect()
+    };
+    let pads: Vec<i64> = if opts.padding.len() == 4 {
+        vec![
+            opts.padding[0] as i64,
+            opts.padding[2] as i64,
+            opts.padding[1] as i64,
+            opts.padding[3] as i64,
+        ]
+    } else if opts.padding.is_empty() {
+        vec![0, 0, 0, 0]
+    } else {
+        opts.padding.iter().map(|&u| u as i64).collect()
+    };
+    if strides.len() != 2 || dilations.len() != 2 || pads.len() != 4 {
+        return None;
+    }
+
+    let eff_h = dilations[0] * (kernel[0] - 1) + 1;
+    let eff_w = dilations[1] * (kernel[1] - 1) + 1;
+    let numer_h = input_h + pads[0] + pads[2] - eff_h;
+    let numer_w = input_w + pads[1] + pads[3] - eff_w;
+    if numer_h < 0 || numer_w < 0 {
+        return None;
+    }
+    let floor_h = (numer_h / strides[0]) + 1;
+    let floor_w = (numer_w / strides[1]) + 1;
+    let ceil_h = ((numer_h + strides[0] - 1) / strides[0]) + 1;
+    let ceil_w = ((numer_w + strides[1] - 1) / strides[1]) + 1;
+
+    if target[0] == floor_h && target[1] == floor_w {
+        Some(0)
+    } else if target[0] == ceil_h && target[1] == ceil_w {
+        Some(1)
+    } else {
+        None
+    }
+}

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -6743,8 +6743,23 @@ impl TrtxConverter {
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let filter_id = operation.input_operands()[1];
-        let bias_id = operation.input_operands().get(2).copied();
+        let (input_id, filter_id, conv_opts) = match operation {
+            Operation::Conv2d {
+                input,
+                filter,
+                options,
+                ..
+            } => (*input, *filter, options.as_ref()),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_conv2d_op: expected Conv2d operation".to_string(),
+                });
+            }
+        };
+        // WebNN: bias is MLConv2dOptions.bias. [`Operation::input_operands`] is only [input, filter];
+        // a legacy third JSON input is merged into options.bias when the graph is parsed.
+        let bias_id = conv_opts.and_then(|o| o.bias);
 
         // Filter operand and shape (needed for both constant and tensor-weight paths)
         let filter_operand =
@@ -6762,8 +6777,6 @@ impl TrtxConverter {
             });
         }
         let fs = filter_operand.descriptor.static_or_max_shape();
-        let attrs = operation.attributes();
-        let conv_opts = attrs.as_conv2d();
         let filter_layout = conv_opts
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
@@ -6900,7 +6913,6 @@ impl TrtxConverter {
             .map(|o| o.input_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("nchw");
-        let input_id = operation.input_operands()[0];
         let input_dtype = graph
             .operand(input_id)
             .map(|o| o.descriptor.data_type)
@@ -7214,8 +7226,23 @@ impl TrtxConverter {
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let filter_id = operation.input_operands()[1];
-        let bias_id = operation.input_operands().get(2).copied();
+        let (input_id, filter_id, deconv_opts) = match operation {
+            Operation::ConvTranspose2d {
+                input,
+                filter,
+                options,
+                ..
+            } => (*input, *filter, options.as_ref()),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_conv_transpose2d_op: expected ConvTranspose2d operation"
+                        .to_string(),
+                });
+            }
+        };
+        // Same as conv2d: bias from MLConvTranspose2dOptions.bias (optional third JSON input merged at parse time).
+        let bias_id = deconv_opts.and_then(|o| o.bias);
 
         let filter_operand =
             graph
@@ -7235,8 +7262,6 @@ impl TrtxConverter {
             });
         }
         let fs = filter_operand.descriptor.static_or_max_shape();
-        let attrs = operation.attributes();
-        let deconv_opts = attrs.as_conv_transpose2d();
         let filter_layout = deconv_opts
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
@@ -7373,7 +7398,6 @@ impl TrtxConverter {
             .map(|o| o.input_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("nchw");
-        let input_id = operation.input_operands()[0];
         let input_dtype = graph
             .operand(input_id)
             .map(|o| o.descriptor.data_type)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -29,7 +29,7 @@ use super::{ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
-use crate::operator_options::MLDimension;
+use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
 use crate::shape_inference::infer_arg_reduce_shape;
 use trtx::{
@@ -607,9 +607,11 @@ impl TrtxConverter {
 
             // Pooling operations
             "averagePool2d" => {
-                Self::add_pooling_op(network, tensor_map, operation, PoolingType::kAVERAGE)?
+                Self::add_pooling_op(graph, network, tensor_map, operation, PoolingType::kAVERAGE)?
             }
-            "maxPool2d" => Self::add_pooling_op(network, tensor_map, operation, PoolingType::kMAX)?,
+            "maxPool2d" => {
+                Self::add_pooling_op(graph, network, tensor_map, operation, PoolingType::kMAX)?
+            }
             "globalAveragePool" => {
                 Self::add_global_pooling_op(network, tensor_map, operation, PoolingType::kAVERAGE)?
             }
@@ -737,7 +739,7 @@ impl TrtxConverter {
             "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation)?,
             "roundEven" => Self::add_round_even_op(network, tensor_map, operation)?,
             "gatherElements" => Self::add_gather_elements_op(network, tensor_map, operation)?,
-            "l2Pool2d" => Self::add_l2_pool2d_op(network, tensor_map, operation)?,
+            "l2Pool2d" => Self::add_l2_pool2d_op(graph, network, tensor_map, operation)?,
             "reverse" => Self::add_reverse_op(graph, network, tensor_map, operation)?,
             "cumulativeSum" => Self::add_cumulative_sum_op(graph, network, tensor_map, operation)?,
             "triangular" => Self::add_triangular_op(graph, network, tensor_map, operation)?,
@@ -7875,40 +7877,116 @@ impl TrtxConverter {
         Ok(())
     }
 
+    /// Pool kernel `[H, W]` from [`MLPool2dOptions`] and input tensor descriptor.
+    /// When `window_dimensions` is omitted, WebNN uses the full spatial extent (matches ONNX
+    /// `create_pool2d_attributes_with_graph`).
+    fn pool2d_window_from_graph_input(
+        graph: &GraphInfo,
+        input_id: u32,
+        op: &Operation,
+        opts: &MLPool2dOptions,
+    ) -> Result<[i64; 2], GraphError> {
+        let has_explicit_window = opts
+            .window_dimensions
+            .as_ref()
+            .is_some_and(|w| w.len() >= 2);
+        if let Some(wd) = opts.window_dimensions.as_ref()
+            && wd.len() >= 2
+        {
+            return Ok([wd[0] as i64, wd[1] as i64]);
+        }
+
+        let in_operand = graph.operand(input_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pool2d input operand {} not found", input_id),
+        })?;
+
+        let layout = opts.layout.to_ascii_lowercase();
+        let layout = if layout.is_empty() {
+            "nchw"
+        } else {
+            layout.as_str()
+        };
+
+        let shape = &in_operand.descriptor.shape;
+        if shape.len() != 4 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "Pool2d default window requires 4D input, got {}D",
+                    shape.len()
+                ),
+            });
+        }
+
+        let mut h = if layout == "nhwc" {
+            get_static_or_max_size(&shape[1]) as i64
+        } else {
+            get_static_or_max_size(&shape[2]) as i64
+        };
+        let mut w = if layout == "nhwc" {
+            get_static_or_max_size(&shape[2]) as i64
+        } else {
+            get_static_or_max_size(&shape[3]) as i64
+        };
+
+        // Align with ONNX converter: averagePool2d with dilations and no explicit window uses
+        // full input spatial extent as the kernel.
+        if matches!(op, Operation::AveragePool2d { .. })
+            && !opts.dilations.is_empty()
+            && !has_explicit_window
+            && let Some(out_id) = op.output_operand()
+            && let Some(out_operand) = graph.operand(out_id)
+            && out_operand.descriptor.shape.len() == 4
+        {
+            let (in_h, in_w) = if layout == "nhwc" {
+                (
+                    get_static_or_max_size(&shape[1]),
+                    get_static_or_max_size(&shape[2]),
+                )
+            } else {
+                (
+                    get_static_or_max_size(&shape[2]),
+                    get_static_or_max_size(&shape[3]),
+                )
+            };
+            h = in_h as i64;
+            w = in_w as i64;
+        }
+
+        Ok([h, w])
+    }
+
     /// Add pooling operation
     fn add_pooling_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
+        let (input_id, opts_ref) = match operation {
+            Operation::AveragePool2d { input, options, .. }
+            | Operation::MaxPool2d { input, options, .. } => (*input, options.as_ref()),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_pooling_op: expected AveragePool2d or MaxPool2d".to_string(),
+                });
+            }
+        };
+
+        let default_pool = MLPool2dOptions::default();
+        let opts = opts_ref.unwrap_or(&default_pool);
+
         let input = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&input_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let attrs = operation.attributes();
-        let pool_opts = attrs
-            .as_pool2d()
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Pool2d operation missing options".to_string(),
-            })?;
-        let window_size = pool_opts
-            .window_dimensions
-            .as_ref()
-            .filter(|w| !w.is_empty())
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Missing windowDimensions attribute".to_string(),
-            })?;
-
-        let window: [i64; 2] = [
-            window_size.get(0).copied().unwrap_or(2) as i64,
-            window_size.get(1).copied().unwrap_or(2) as i64,
-        ];
+        let window = Self::pool2d_window_from_graph_input(graph, input_id, operation, opts)?;
 
         let layer = network
             .add_pooling(input, pool_type, &window)
@@ -8489,15 +8567,26 @@ impl TrtxConverter {
 
     /// Add l2Pool2d operation (L2 pooling: square → avgPool → sqrt)
     fn add_l2_pool2d_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
+        let (input_id, opts_ref) = match operation {
+            Operation::L2Pool2d { input, options, .. } => (*input, options.as_ref()),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_l2_pool2d_op: expected L2Pool2d".to_string(),
+                });
+            }
+        };
+
         let input_tensor = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&input_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", input_id),
             })?;
 
         // Step 1: Square the input (x^2)
@@ -8516,20 +8605,10 @@ impl TrtxConverter {
                     reason: format!("Failed to get squared output: {}", e),
                 })?;
 
-        // Step 2: Apply average pooling (use same parameters as maxPool2d/averagePool2d)
-        let window_size = operation
-            .attributes()
-            .get("windowDimensions")
-            .and_then(|v| v.as_array().cloned())
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Missing windowDimensions for l2Pool2d".to_string(),
-            })?;
-
-        let window: [i64; 2] = [
-            window_size[0].as_i64().unwrap_or(1),
-            window_size[1].as_i64().unwrap_or(1),
-        ];
+        // Step 2: Apply average pooling (same window resolution as averagePool2d / ONNX)
+        let default_pool = MLPool2dOptions::default();
+        let opts = opts_ref.unwrap_or(&default_pool);
+        let window = Self::pool2d_window_from_graph_input(graph, input_id, operation, opts)?;
 
         let pool_layer = network
             .add_pooling(&squared, PoolingType::kAVERAGE, &window)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -848,12 +848,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
-                let t0 = id0
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get identity output: {}", e),
-                    })?;
+                let t0 =
+                    id0.get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get identity output: {}", e),
+                        })?;
 
                 let id1 =
                     network
@@ -862,12 +862,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
-                let t1 = id1
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get identity output: {}", e),
-                    })?;
+                let t1 =
+                    id1.get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get identity output: {}", e),
+                        })?;
 
                 return Ok((t0, t1));
             }
@@ -1409,13 +1409,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract 1 for elu: {}", e),
             })?;
-        let exp_minus_1 =
-            exp_minus_1_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get exp-1 output: {}", e),
-                })?;
+        let exp_minus_1 = exp_minus_1_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get exp-1 output: {}", e),
+            }
+        })?;
 
         let zero_const = network
             .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
@@ -1471,13 +1470,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to multiply by alpha for elu: {}", e),
             })?;
-        let scaled_neg =
-            scaled_neg_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get scaled neg output: {}", e),
-                })?;
+        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get scaled neg output: {}", e),
+            }
+        })?;
 
         let (bc_relu, bc_scaled) =
             Self::ensure_broadcast_compatible(network, &relu_output, &scaled_neg, "elu_add")?;
@@ -1631,13 +1629,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale neg part for leaky relu: {}", e),
             })?;
-        let scaled_neg =
-            scaled_neg_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get scaled neg output: {}", e),
-                })?;
+        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get scaled neg output: {}", e),
+            }
+        })?;
 
         // relu(x) + alpha * min(0, x)
         let final_layer = network
@@ -1736,13 +1733,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale negative part: {}", e),
             })?;
-        let scaled_neg =
-            scaled_neg_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get scaled negative: {}", e),
-                })?;
+        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get scaled negative: {}", e),
+            }
+        })?;
 
         // Final: relu + slope * neg_part
         let final_layer = network
@@ -1914,13 +1910,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear+beta: {}", e),
             })?;
-        let linear_out =
-            linear_plus_beta
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSigmoid: linear_out: {}", e),
-                })?;
+        let linear_out = linear_plus_beta.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSigmoid: linear_out: {}", e),
+            }
+        })?;
 
         // clamp(linear, 0, 1) = max(0, min(1, linear))
         let min1 = network
@@ -2078,12 +2073,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: max(0, ...): {}", e),
             })?;
-        let inner_out = inner
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: inner output: {}", e),
-            })?;
+        let inner_out =
+            inner
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: inner output: {}", e),
+                })?;
         let x_times_inner = network
             .add_elementwise(input, &inner_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
@@ -2253,12 +2249,13 @@ impl TrtxConverter {
 
         // Constant stored flat: 1D int8. Try 1D -> Reshape(4D) -> DQ so DQ sees Shuffle output not Constant.
         let stored_flat = constants_stored_flat.contains(&input_id);
-        let _input_dims = input
-            .dimensions(&*network)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Cast: failed to get input dimensions: {}", e),
-            })?;
+        let _input_dims =
+            input
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Cast: failed to get input dimensions: {}", e),
+                })?;
         if use_dq_for_float32 {
             // int8/uint8 -> float32: only supported when input is a constant (stored flat). Tensor inputs not supported by TRT-RTX.
             if !stored_flat {
@@ -2295,8 +2292,7 @@ impl TrtxConverter {
                     }
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
-                let scale_tensor =
-                    add_dq_scale_constant(network, "int8->float32 cast")?;
+                let scale_tensor = add_dq_scale_constant(network, "int8->float32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -2304,13 +2300,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_f32");
-                let output =
-                    dq_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get dequantize output: {}", e),
-                        })?;
+                let output = dq_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get dequantize output: {}", e),
+                    }
+                })?;
                 let _ = output.set_name(network, "cast_flat_dq_f32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
@@ -2353,8 +2348,7 @@ impl TrtxConverter {
                     }
                 })?;
                 let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
-                let scale_tensor =
-                    add_dq_scale_constant(network, "int8->int32 cast")?;
+                let scale_tensor = add_dq_scale_constant(network, "int8->int32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -2362,13 +2356,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add dequantize for int8->int32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_int32");
-                let dq_out =
-                    dq_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get dequantize output: {}", e),
-                        })?;
+                let dq_out = dq_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get dequantize output: {}", e),
+                    }
+                })?;
                 let _ = dq_out.set_name(network, "cast_flat_dq_int32");
                 let mut cast_layer =
                     network
@@ -2615,12 +2608,12 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(network, &new_shape).map_err(|e| {
-                GraphError::ConversionFailed {
+            shuffle
+                .set_reshape_dimensions(network, &new_shape)
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
-                }
-            })?;
+                })?;
             let reshaped0 =
                 shuffle
                     .get_output(&*network, 0)
@@ -2646,12 +2639,12 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(network, &new_shape).map_err(|e| {
-                GraphError::ConversionFailed {
+            shuffle
+                .set_reshape_dimensions(network, &new_shape)
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
-                }
-            })?;
+                })?;
             let reshaped1 =
                 shuffle
                     .get_output(&*network, 0)
@@ -2739,12 +2732,12 @@ impl TrtxConverter {
                             op_name, e
                         ),
                     })?;
-            shuffle
-                .set_first_transpose(network, &perm)
-                .map_err(|e| GraphError::ConversionFailed {
+            shuffle.set_first_transpose(network, &perm).map_err(|e| {
+                GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set transpose for {}: {}", op_name, e),
-                })?;
+                }
+            })?;
             return shuffle
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -2773,12 +2766,10 @@ impl TrtxConverter {
             })?;
         shuffle
             .set_reshape_dimensions(network, &target_shape)
-            .map_err(|e| {
-            GraphError::ConversionFailed {
+            .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape for {}: {}", op_name, e),
-            }
-        })?;
+            })?;
         let mut result =
             shuffle
                 .get_output(&*network, 0)
@@ -2798,18 +2789,22 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add second shuffle for {}: {}", op_name, e),
                     })?;
-            shuffle2
-                .set_first_transpose(network, &perm)
-                .map_err(|e| GraphError::ConversionFailed {
+            shuffle2.set_first_transpose(network, &perm).map_err(|e| {
+                GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set second transpose for {}: {}", op_name, e),
-                })?;
-            result = shuffle2
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get second shuffle output for {}: {}", op_name, e),
-                })?;
+                }
+            })?;
+            result =
+                shuffle2
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Failed to get second shuffle output for {}: {}",
+                            op_name, e
+                        ),
+                    })?;
         }
         Ok(result)
     }
@@ -3072,12 +3067,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add mean reduce for instance norm: {}", e),
             })?;
 
-        let mean = mean_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get mean output: {}", e),
-            })?;
+        let mean =
+            mean_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mean output: {}", e),
+                })?;
 
         // x - mean
         let sub_layer = network
@@ -3133,12 +3129,13 @@ impl TrtxConverter {
                 })?;
 
         // variance + epsilon per WebNN spec (epsilon cast to input's dataType)
-        let var_dims = variance
-            .dimensions(&*network)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("InstanceNorm: failed to get variance dimensions: {}", e),
-            })?;
+        let var_dims =
+            variance
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("InstanceNorm: failed to get variance dimensions: {}", e),
+                })?;
         let input_operand = graph
             .operand(operation.input_operands()[0])
             .ok_or_else(|| GraphError::ConversionFailed {
@@ -3282,13 +3279,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set scale reshape: {}", e),
                 })?;
-            let scale_bc =
-                scale_shuffle
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
-                    })?;
+            let scale_bc = scale_shuffle.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
+                }
+            })?;
 
             let mul_layer = network
                 .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
@@ -3330,13 +3326,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set bias reshape: {}", e),
                 })?;
-            let bias_bc =
-                bias_shuffle
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
-                    })?;
+            let bias_bc = bias_shuffle.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
+                }
+            })?;
 
             let add_layer = network
                 .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
@@ -3386,6 +3381,21 @@ impl TrtxConverter {
                 reason: format!("Failed to get input shape: {}", e),
             })?;
 
+        // WebNN: scale and bias live in MLLayerNormalizationOptions, not in input_operands (only the input tensor is listed).
+        let (scale_operand_id, bias_operand_id, epsilon, axes_from_options) = match operation {
+            Operation::LayerNormalization { options, .. } => match options.as_ref() {
+                Some(o) => (o.scale, o.bias, o.epsilon as f32, o.axes.clone()),
+                None => (None, None, 1e-5_f32, None),
+            },
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_layer_normalization_op: expected LayerNormalization operation"
+                        .to_string(),
+                });
+            }
+        };
+
         // TensorRT Reduce requires at least 1 dimension. For 0D scalar: mean=x, variance=0, output = 0*scale + bias = bias or 0.
         if input_dims.is_empty() {
             let input_operand = graph
@@ -3417,9 +3427,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: zero const output: {}", e),
                     })?;
-            // Optional operands are [scale?, bias?]; bias is last when present. So len>=2 => add last (bias when only bias, or bias when scale+bias).
-            if operation.input_operands().len() >= 2 {
-                let bias_id = operation.input_operands()[operation.input_operands().len() - 1];
+            if let Some(bias_id) = bias_operand_id {
                 let bias =
                     tensor_map
                         .get(&bias_id)
@@ -3437,12 +3445,10 @@ impl TrtxConverter {
                         })?;
                 bias_shuffle
                     .set_reshape_dimensions(network, &[1i64])
-                    .map_err(|e| {
-                    GraphError::ConversionFailed {
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),
-                    }
-                })?;
+                    })?;
                 let bias_bc = bias_shuffle.get_output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
@@ -3455,13 +3461,12 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to add bias: {}", e),
                     })?;
-                result =
-                    add_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("LayerNorm 0D: bias add output: {}", e),
-                        })?;
+                result = add_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm 0D: bias add output: {}", e),
+                    }
+                })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -3470,10 +3475,7 @@ impl TrtxConverter {
 
         // Get epsilon and axes from typed options. Spec: when axes not present, axes = [1..rank) if rank > 1 else [].
         // Option<axes>: None = key omitted => default; Some(v) = use v (Some([]) = explicit no reduction).
-        let attrs = operation.attributes();
-        let opts = attrs.as_layer_normalization();
-        let _epsilon = opts.map(|o| o.epsilon as f32).unwrap_or(1e-5);
-        let axes: Vec<u32> = opts.and_then(|o| o.axes.clone()).unwrap_or_else(|| {
+        let axes: Vec<u32> = axes_from_options.unwrap_or_else(|| {
             if input_dims.len() > 1 {
                 (1..input_dims.len()).map(|i| i as u32).collect()
             } else {
@@ -3522,9 +3524,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: zero const output: {}", e),
                     })?;
-            // Optional operands are [scale?, bias?]; bias is last when present.
-            if operation.input_operands().len() >= 2 {
-                let bias_id = operation.input_operands()[operation.input_operands().len() - 1];
+            if let Some(bias_id) = bias_operand_id {
                 let bias =
                     tensor_map
                         .get(&bias_id)
@@ -3573,12 +3573,12 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    bias_const
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
+                    bias_const.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: bias const output: {}", e),
-                        })?
+                        }
+                    })?
                 } else {
                     // Bias is an input (e.g. from test harness). Broadcast scalar to result shape via ensure_broadcast_compatible with ones.
                     let ones_bytes: Vec<u8> = match input_operand.descriptor.data_type {
@@ -3616,13 +3616,12 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: failed to add bias: {}", e),
                     })?;
-                result =
-                    add_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("LayerNorm axes=[]: bias add output: {}", e),
-                        })?;
+                result = add_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm axes=[]: bias add output: {}", e),
+                    }
+                })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -3648,12 +3647,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add mean reduce for layer norm: {}", e),
             })?;
 
-        let mean = mean_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get mean output: {}", e),
-            })?;
+        let mean =
+            mean_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mean output: {}", e),
+                })?;
 
         // x - mean
         let sub_layer = network
@@ -3709,12 +3709,13 @@ impl TrtxConverter {
                 })?;
 
         // variance + epsilon per WebNN spec (then sqrt)
-        let var_dims = variance
-            .dimensions(&*network)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
-            })?;
+        let var_dims =
+            variance
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
+                })?;
         let var_shape: Vec<i64> = var_dims.clone();
         let num_var_el: usize = var_dims.iter().map(|&d| d as usize).product();
         let input_operand = graph
@@ -3729,13 +3730,13 @@ impl TrtxConverter {
         let (epsilon_bytes, epsilon_dtype) = match input_operand.descriptor.data_type {
             DataType::Float16 => (
                 (0..num_var_el)
-                    .flat_map(|_| f16::from_f32(_epsilon).to_bits().to_le_bytes())
+                    .flat_map(|_| f16::from_f32(epsilon).to_bits().to_le_bytes())
                     .collect::<Vec<_>>(),
                 TrtDataType::kHALF,
             ),
             _ => (
                 (0..num_var_el)
-                    .flat_map(|_| _epsilon.to_le_bytes())
+                    .flat_map(|_| epsilon.to_le_bytes())
                     .collect::<Vec<_>>(),
                 TrtDataType::kFLOAT,
             ),
@@ -3830,12 +3831,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm {}: identity: {}", op_name, e),
                         })?;
-                return id_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
+                return id_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm {}: identity output: {}", op_name, e),
-                    });
+                    }
+                });
             }
             let (new_shape, transpose_perm): (Vec<i32>, Option<Vec<i32>>) =
                 if tensor_dims.len() == axes.len() {
@@ -3891,12 +3892,10 @@ impl TrtxConverter {
             let new_shape_i64: Vec<i64> = new_shape.iter().map(|&d| d as i64).collect();
             shuffle
                 .set_reshape_dimensions(network, &new_shape_i64)
-                .map_err(|e| {
-                GraphError::ConversionFailed {
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm {}: set reshape: {}", op_name, e),
-                }
-            })?;
+                })?;
             shuffle
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3905,65 +3904,37 @@ impl TrtxConverter {
                 })
         };
 
-        // Optional operands are [scale?, bias?] in that order. When len() == 2, the single optional may be scale or bias; use name to distinguish.
-        if operation.input_operands().len() > 1 {
-            let opt_id_1 = operation.input_operands()[1];
-            let opt_1 = tensor_map
-                .get(&opt_id_1)
+        if let Some(scale_id) = scale_operand_id {
+            let scale = tensor_map
+                .get(&scale_id)
                 .ok_or_else(|| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("LayerNorm optional operand {} not found", opt_id_1),
+                    reason: format!("LayerNorm scale operand {} not found", scale_id),
                 })?;
-            let name_1 = graph
-                .operand(opt_id_1)
-                .and_then(|o| o.name.as_deref())
-                .unwrap_or("");
-            let is_bias_1 = name_1.to_lowercase().contains("bias");
-            let opt_1_bc = reshape_scale_bias_to_result_rank(
-                network,
-                opt_1,
-                &result,
-                if is_bias_1 { "bias" } else { "scale" },
-                &axes,
-            )?;
-            if is_bias_1 {
-                let add_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kSUM)
+            let scale_bc =
+                reshape_scale_bias_to_result_rank(network, scale, &result, "scale", &axes)?;
+
+            let mul_layer = network
+                .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add scale: {}", e),
+                })?;
+            result =
+                mul_layer
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Failed to add bias: {}", e),
+                        reason: format!("Failed to get mul output: {}", e),
                     })?;
-                result =
-                    add_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get add output: {}", e),
-                        })?;
-            } else {
-                let mul_layer = network
-                    .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kPROD)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add scale: {}", e),
-                    })?;
-                result =
-                    mul_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get mul output: {}", e),
-                        })?;
-            }
         }
 
-        // Second optional (when len() == 3) is always bias
-        if operation.input_operands().len() > 2 {
+        if let Some(bias_id) = bias_operand_id {
             let bias = tensor_map
-                .get(&operation.input_operands()[2])
+                .get(&bias_id)
                 .ok_or_else(|| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Bias operand {} not found", operation.input_operands()[2]),
+                    reason: format!("LayerNorm bias operand {} not found", bias_id),
                 })?;
             let bias_bc = reshape_scale_bias_to_result_rank(network, bias, &result, "bias", &axes)?;
 
@@ -4912,13 +4883,6 @@ impl TrtxConverter {
             }
         };
 
-        if new_shape.is_empty() {
-            return Err(GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Expand newShape must be non-empty".to_string(),
-            });
-        }
-
         let num_elements: usize = new_shape
             .iter()
             .map(|d: &i32| (*d).max(0) as usize)
@@ -5044,16 +5008,12 @@ impl TrtxConverter {
             concat_layer.set_axis(network, axis as i32);
 
             // Get the output tensor
-            let output_tensor =
-                concat_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "Failed to get concat output for tile axis {}: {}",
-                            axis, e
-                        ),
-                    })?;
+            let output_tensor = concat_layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get concat output for tile axis {}: {}", axis, e),
+                }
+            })?;
 
             // Use a temporary ID for intermediate results
             // We use a large number to avoid collisions with actual operand IDs
@@ -5703,12 +5663,10 @@ impl TrtxConverter {
                     })?;
             shuffle_in
                 .set_reshape_dimensions(network, &[n, 1])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ArgMax: set [N,1] reshape: {}", e),
-                }
-            })?;
+                })?;
             let rank2 =
                 shuffle_in
                     .get_output(&*network, 0)
@@ -5717,24 +5675,14 @@ impl TrtxConverter {
                         reason: format!("ArgMax: rank-2 TopK input: {}", e),
                     })?;
             network
-                .add_topk(
-                    &rank2,
-                    TopKOperation::kMAX,
-                    1,
-                    Axes::from_bits(1u32),
-                ) // kMAX along axis 0 of [N,1]
+                .add_topk(&rank2, TopKOperation::kMAX, 1, Axes::from_bits(1u32)) // kMAX along axis 0 of [N,1]
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add topK layer: {}", e),
                 })?
         } else {
             network
-                .add_topk(
-                    input,
-                    TopKOperation::kMAX,
-                    1,
-                    Axes::from_bits(1u32 << axis),
-                ) // kMAX, k=1, axes bitmask
+                .add_topk(input, TopKOperation::kMAX, 1, Axes::from_bits(1u32 << axis)) // kMAX, k=1, axes bitmask
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add topK layer: {}", e),
@@ -5832,12 +5780,10 @@ impl TrtxConverter {
                     })?;
             shuffle_in
                 .set_reshape_dimensions(network, &[n, 1])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("ArgMin: set [N,1] reshape: {}", e),
-                }
-            })?;
+                })?;
             let rank2 =
                 shuffle_in
                     .get_output(&*network, 0)
@@ -5846,29 +5792,17 @@ impl TrtxConverter {
                         reason: format!("ArgMin: rank-2 TopK input: {}", e),
                     })?;
             network
-                .add_topk(
-                    &rank2,
-                    TopKOperation::kMIN,
-                    1,
-                    Axes::from_bits(1u32),
-                ) // kMIN along axis 0 of [N,1]
+                .add_topk(&rank2, TopKOperation::kMIN, 1, Axes::from_bits(1u32)) // kMIN along axis 0 of [N,1]
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add topK layer: {}", e),
                 })?
         } else {
             network
-                .add_topk(
-                    input,
-                    TopKOperation::kMIN,
-                    1,
-                    Axes::from_bits(1u32 << axis),
-                )
-                .map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add topK layer: {}", e),
-                    }
+                .add_topk(input, TopKOperation::kMIN, 1, Axes::from_bits(1u32 << axis))
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add topK layer: {}", e),
                 })?
         };
 
@@ -6313,13 +6247,12 @@ impl TrtxConverter {
                     reason: format!("Failed to create beta constant: {}", e),
                 })?;
 
-            let beta_tensor =
-                beta_constant
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get beta constant output: {}", e),
-                    })?;
+            let beta_tensor = beta_constant.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get beta constant output: {}", e),
+                }
+            })?;
 
             // Add: (alpha * x) + beta
             let add_layer = network
@@ -6773,13 +6706,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add scaled C to result: {}", e),
                     })?;
 
-                result =
-                    add_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get final GEMM output: {}", e),
-                        })?;
+                result = add_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get final GEMM output: {}", e),
+                    }
+                })?;
             } else {
                 // beta == 1.0: add C directly
                 let add_layer = network
@@ -6789,13 +6721,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add C to result: {}", e),
                     })?;
 
-                result =
-                    add_layer
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get final GEMM output: {}", e),
-                        })?;
+                result = add_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get final GEMM output: {}", e),
+                    }
+                })?;
             }
         }
 
@@ -6918,8 +6849,7 @@ impl TrtxConverter {
             let conv_weights_owned = if kernel_promoted.is_some() || bias_promoted.is_some() {
                 let conv_kernel_const_shape: Vec<i64> =
                     vec![o as i64, in_ch as i64, h as i64, w as i64];
-                let kernel_values =
-                    kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
+                let kernel_values = kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
                 let bias_values = match (bias_promoted, bias_raw) {
                     (Some(b), _) => Some(b),
                     (None, Some(br)) => Some(br.to_vec()),
@@ -6983,33 +6913,30 @@ impl TrtxConverter {
             })?;
 
         // NHWC input: TensorRT conv expects NCHW. Insert shuffle to transpose NHWC->NCHW before conv.
-        let nhwc_shuffle_output = if input_layout == "nhwc" {
-            let mut shuffle =
-                network
-                    .add_shuffle(input)
+        let nhwc_shuffle_output =
+            if input_layout == "nhwc" {
+                let mut shuffle =
+                    network
+                        .add_shuffle(input)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
+                        })?;
+                shuffle
+                    .set_first_transpose(network, &[0, 3, 1, 2])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
+                        reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
                     })?;
-            shuffle
-                .set_first_transpose(network, &[0, 3, 1, 2])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
-                }
-            })?;
-            Some(
-                shuffle
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
+                Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC shuffle output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let pre_conv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
         // TensorRT conv kernel is always Float; cast Half input to Float so types match.
@@ -7077,12 +7004,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add padding layer: {}", e),
                     })?;
 
-                padding_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
+                padding_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get padding layer output: {}", e),
-                    })?
+                    }
+                })?
             } else {
                 // No padding needed, use conv_input_source directly
                 let id_layer = network.add_identity(&conv_input_source).map_err(|e| {
@@ -7259,12 +7186,10 @@ impl TrtxConverter {
                     })?;
             shuffle
                 .set_first_transpose(network, &[0, 2, 3, 1])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d set_first_transpose NCHW->NHWC: {}", e),
-                }
-            })?;
+                })?;
             shuffle
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -7398,8 +7323,7 @@ impl TrtxConverter {
             let deconv_weights_owned = if kernel_promoted.is_some() || bias_promoted.is_some() {
                 let deconv_kernel_const_shape: Vec<i64> =
                     vec![in_ch as i64, out_ch as i64, h as i64, w as i64];
-                let kernel_values =
-                    kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
+                let kernel_values = kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
                 let bias_values = match (bias_promoted, bias_raw) {
                     (Some(b), _) => Some(b),
                     (None, Some(br)) => Some(br.to_vec()),
@@ -7461,33 +7385,30 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let nhwc_shuffle_output = if input_layout == "nhwc" {
-            let mut shuffle =
-                network
-                    .add_shuffle(input)
+        let nhwc_shuffle_output =
+            if input_layout == "nhwc" {
+                let mut shuffle =
+                    network
+                        .add_shuffle(input)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
+                        })?;
+                shuffle
+                    .set_first_transpose(network, &[0, 3, 1, 2])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
+                        reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
                     })?;
-            shuffle
-                .set_first_transpose(network, &[0, 3, 1, 2])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
-                }
-            })?;
-            Some(
-                shuffle
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
+                Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC shuffle output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let pre_deconv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
         let half_cast_output: Option<trtx::Tensor<'a>> =
@@ -7759,10 +7680,7 @@ impl TrtxConverter {
         // When padding could not fully absorb outputPadding, add IPaddingLayer for remainder.
         let deconv_output = if padding_remainder[0] != 0 || padding_remainder[1] != 0 {
             let pre_pad: Vec<i64> = vec![0, 0];
-            let post_pad: Vec<i64> = vec![
-                padding_remainder[0] as i64,
-                padding_remainder[1] as i64,
-            ];
+            let post_pad: Vec<i64> = vec![padding_remainder[0] as i64, padding_remainder[1] as i64];
             let pad_layer = network
                 .add_padding(&deconv_output, &pre_pad, &post_pad)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -7913,12 +7831,10 @@ impl TrtxConverter {
                     })?;
             shuffle
                 .set_first_transpose(network, &[0, 2, 3, 1])
-                .map_err(|e| {
-                GraphError::ConversionFailed {
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d set_first_transpose NCHW->NHWC: {}", e),
-                }
-            })?;
+                })?;
             shuffle
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -8943,10 +8859,11 @@ impl GraphConverter for TrtxConverter {
             reason: format!("Failed to create TensorRT logger: {}", e),
         })?;
 
-        let mut builder = trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Failed to create TensorRT builder: {}", e),
-        })?;
+        let mut builder =
+            trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to create TensorRT builder: {}", e),
+            })?;
 
         let mut network = builder
             .create_network(trtx::builder::network_flags::EXPLICIT_BATCH)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -164,6 +164,50 @@ impl TrtxConverter {
         Ok(dst)
     }
 
+    /// `IShuffleLayer::setFirstTranspose`: output axis `i` reads input axis `order[i]`.
+    /// WebNN conv2d filter rank-4 layout to TensorRT kernel **OIHW**.
+    fn conv_dynamic_filter_first_transpose(filter_layout: &str) -> Result<[i32; 4], GraphError> {
+        let order = match filter_layout {
+            "oihw" => [0, 1, 2, 3],
+            "hwio" => [3, 2, 0, 1],
+            "ohwi" => [0, 3, 1, 2],
+            "ihwo" => [3, 0, 1, 2],
+            "hwoi" => [2, 3, 0, 1],
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "Unsupported filter_layout for dynamic conv2d kernel: {}",
+                        filter_layout
+                    ),
+                });
+            }
+        };
+        Ok(order)
+    }
+
+    /// WebNN convTranspose2d filter to TensorRT deconv kernel **IOHW** (matches `deconv_filter_to_iohw`).
+    fn deconv_dynamic_filter_first_transpose(filter_layout: &str) -> Result<[i32; 4], GraphError> {
+        let order = match filter_layout {
+            "iohw" => [0, 1, 2, 3],
+            "oihw" => [1, 0, 2, 3],
+            "hwio" => [2, 3, 0, 1],
+            "ohwi" => [3, 0, 1, 2],
+            "ihwo" => [0, 3, 1, 2],
+            "hwoi" => [3, 2, 0, 1],
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "Unsupported filter_layout for dynamic convTranspose2d kernel: {}",
+                        filter_layout
+                    ),
+                });
+            }
+        };
+        Ok(order)
+    }
+
     /// Transpose 4D deconv filter (f32) from given layout to IOHW for TensorRT (C,K,R,S = input channels, output maps, H, W).
     /// Layouts: iohw [I,O,H,W], oihw [O,I,H,W], hwio [H,W,I,O], ohwi [O,H,W,I], ihwo [I,H,W,O], hwoi [H,W,O,I].
     fn deconv_filter_to_iohw(
@@ -5614,6 +5658,185 @@ impl TrtxConverter {
         Ok(())
     }
 
+    /// Shared argMin/argMax via TopK: indices tensor reshaped to WebNN output, still INT32 (caller casts).
+    ///
+    /// TensorRT `ITopKLayer` for rank &gt;= 5 only allows reduction on one of the **last four**
+    /// dimensions. When WebNN `axis` lies outside that set, swap that axis with the last axis,
+    /// run TopK on the last axis, then apply the same transpose to the index tensor (swap is self-inverse).
+    fn add_arg_reduce_common<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        input_id: u32,
+        input: &trtx::Tensor<'a>,
+        axis: u32,
+        keep_dims: bool,
+        topk_op: TopKOperation,
+        label: &'static str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let input_shape = graph
+            .operand(input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{} input operand {} not in graph", label, input_id),
+            })?
+            .descriptor
+            .static_or_max_shape();
+        let rank = input_shape.len();
+        if rank > 8 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "{}: TensorRT shuffle transpose uses at most 8 axes, got rank {}",
+                    label, rank
+                ),
+            });
+        }
+        let axis_u = axis as usize;
+        if axis_u >= rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: axis {} out of range for rank {}", label, axis, rank),
+            });
+        }
+
+        let target_shape_u32 = infer_arg_reduce_shape(&input_shape, axis, keep_dims)?;
+        let target_shape_i64: Vec<i64> = target_shape_u32.iter().map(|&d| d as i64).collect();
+
+        let indices_pre_reshape = if rank == 1 {
+            let n = input_shape[0] as i64;
+            let mut shuffle_in =
+                network
+                    .add_shuffle(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: unsqueeze 1D input for TopK: {}", label, e),
+                    })?;
+            shuffle_in
+                .set_reshape_dimensions(network, &[n, 1])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: set [N,1] reshape: {}", label, e),
+                })?;
+            let rank2 =
+                shuffle_in
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: rank-2 TopK input: {}", label, e),
+                    })?;
+            let layer = network
+                .add_topk(&rank2, topk_op, 1, Axes::from_bits(1u32))
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK layer: {}", label, e),
+                })?;
+            layer
+                .get_output(&*network, 1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK indices output: {}", label, e),
+                })?
+        } else if rank >= 5 && axis_u < rank - 4 {
+            let last = rank - 1;
+            let mut perm: Vec<i32> = (0..rank as i32).collect();
+            perm[axis_u] = last as i32;
+            perm[last] = axis as i32;
+
+            let mut shuffle_pre =
+                network
+                    .add_shuffle(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: pre-transpose shuffle for TopK: {}", label, e),
+                    })?;
+            shuffle_pre
+                .set_first_transpose(network, &perm)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: set pre-transpose: {}", label, e),
+                })?;
+            let shuffled =
+                shuffle_pre
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: pre-shuffle output: {}", label, e),
+                    })?;
+
+            let layer = network
+                .add_topk(
+                    &shuffled,
+                    topk_op,
+                    1,
+                    Axes::from_bits(1u32 << (last as u32)),
+                )
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK layer: {}", label, e),
+                })?;
+            let idx =
+                layer
+                    .get_output(&*network, 1)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: topK indices output: {}", label, e),
+                    })?;
+
+            let mut shuffle_post =
+                network
+                    .add_shuffle(&idx)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{}: post-transpose shuffle: {}", label, e),
+                    })?;
+            shuffle_post
+                .set_first_transpose(network, &perm)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: set post-transpose: {}", label, e),
+                })?;
+            shuffle_post
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: post-shuffle output: {}", label, e),
+                })?
+        } else {
+            let layer = network
+                .add_topk(input, topk_op, 1, Axes::from_bits(1u32 << axis))
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK layer: {}", label, e),
+                })?;
+            layer
+                .get_output(&*network, 1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK indices output: {}", label, e),
+                })?
+        };
+
+        let mut shuffle_layer =
+            network
+                .add_shuffle(&indices_pre_reshape)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: shuffle for output shape: {}", label, e),
+                })?;
+        shuffle_layer
+            .set_reshape_dimensions(network, &target_shape_i64)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: set reshape dimensions: {}", label, e),
+            })?;
+        shuffle_layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: shuffle output: {}", label, e),
+            })
+    }
+
     /// Add argMax operation (find indices of maximum values)
     fn add_arg_max_op<'a>(
         graph: &GraphInfo,
@@ -5642,88 +5865,17 @@ impl TrtxConverter {
             }
         };
 
-        let input_shape = graph
-            .operand(input_id)
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("ArgMax input operand {} not in graph", input_id),
-            })?
-            .descriptor
-            .static_or_max_shape();
-        let target_shape_u32 = infer_arg_reduce_shape(&input_shape, axis, keep_dims)?;
-        let target_shape_i64: Vec<i64> = target_shape_u32.iter().map(|&d| d as i64).collect();
+        let shaped_output = Self::add_arg_reduce_common(
+            graph,
+            network,
+            input_id,
+            input,
+            axis,
+            keep_dims,
+            TopKOperation::kMAX,
+            "ArgMax",
+        )?;
 
-        // TensorRT TopK requires at least 2 input dimensions. For 1D [N], use [N, 1] and reduce axis 0.
-        let layer = if input_shape.len() == 1 {
-            let n = input_shape[0] as i64;
-            let mut shuffle_in =
-                network
-                    .add_shuffle(input)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("ArgMax: unsqueeze 1D input for TopK: {}", e),
-                    })?;
-            shuffle_in
-                .set_reshape_dimensions(network, &[n, 1])
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMax: set [N,1] reshape: {}", e),
-                })?;
-            let rank2 =
-                shuffle_in
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("ArgMax: rank-2 TopK input: {}", e),
-                    })?;
-            network
-                .add_topk(&rank2, TopKOperation::kMAX, 1, Axes::from_bits(1u32)) // kMAX along axis 0 of [N,1]
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add topK layer: {}", e),
-                })?
-        } else {
-            network
-                .add_topk(input, TopKOperation::kMAX, 1, Axes::from_bits(1u32 << axis)) // kMAX, k=1, axes bitmask
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add topK layer: {}", e),
-                })?
-        };
-
-        // TopK returns two outputs: values and indices
-        // We want indices (output 1)
-        let indices_output =
-            layer
-                .get_output(&*network, 1)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get topK indices output: {}", e),
-                })?;
-
-        // TopK keeps the reduced axis as size k (=1). Reshape to WebNN argMax output rank.
-        let mut shuffle_layer =
-            network
-                .add_shuffle(&indices_output)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMax: shuffle for output shape: {}", e),
-                })?;
-        shuffle_layer
-            .set_reshape_dimensions(network, &target_shape_i64)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("ArgMax: set reshape dimensions: {}", e),
-            })?;
-        let shaped_output =
-            shuffle_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMax: shuffle output: {}", e),
-                })?;
-
-        // Cast INT32 indices to Float32 for WebNN compatibility
         let final_output = Self::cast_int32_to_float32(network, &shaped_output)?;
 
         let output_ids = operation.output_operands_slice();
@@ -5760,86 +5912,17 @@ impl TrtxConverter {
             }
         };
 
-        let input_shape = graph
-            .operand(input_id)
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("ArgMin input operand {} not in graph", input_id),
-            })?
-            .descriptor
-            .static_or_max_shape();
-        let target_shape_u32 = infer_arg_reduce_shape(&input_shape, axis, keep_dims)?;
-        let target_shape_i64: Vec<i64> = target_shape_u32.iter().map(|&d| d as i64).collect();
+        let shaped_output = Self::add_arg_reduce_common(
+            graph,
+            network,
+            input_id,
+            input,
+            axis,
+            keep_dims,
+            TopKOperation::kMIN,
+            "ArgMin",
+        )?;
 
-        let layer = if input_shape.len() == 1 {
-            let n = input_shape[0] as i64;
-            let mut shuffle_in =
-                network
-                    .add_shuffle(input)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("ArgMin: unsqueeze 1D input for TopK: {}", e),
-                    })?;
-            shuffle_in
-                .set_reshape_dimensions(network, &[n, 1])
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMin: set [N,1] reshape: {}", e),
-                })?;
-            let rank2 =
-                shuffle_in
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("ArgMin: rank-2 TopK input: {}", e),
-                    })?;
-            network
-                .add_topk(&rank2, TopKOperation::kMIN, 1, Axes::from_bits(1u32)) // kMIN along axis 0 of [N,1]
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add topK layer: {}", e),
-                })?
-        } else {
-            network
-                .add_topk(input, TopKOperation::kMIN, 1, Axes::from_bits(1u32 << axis))
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to add topK layer: {}", e),
-                })?
-        };
-
-        // TopK returns two outputs: values and indices
-        // We want indices (output 1)
-        let indices_output =
-            layer
-                .get_output(&*network, 1)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get topK indices output: {}", e),
-                })?;
-
-        let mut shuffle_layer =
-            network
-                .add_shuffle(&indices_output)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMin: shuffle for output shape: {}", e),
-                })?;
-        shuffle_layer
-            .set_reshape_dimensions(network, &target_shape_i64)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("ArgMin: set reshape dimensions: {}", e),
-            })?;
-        let shaped_output =
-            shuffle_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ArgMin: shuffle output: {}", e),
-                })?;
-
-        // Cast INT32 indices to Float32 for WebNN compatibility
         let final_output = Self::cast_int32_to_float32(network, &shaped_output)?;
 
         let output_ids = operation.output_operands_slice();
@@ -6891,14 +6974,7 @@ impl TrtxConverter {
                 (Some(filter_data), bias_raw, None)
             }
         } else {
-            // Non-constant filter: use tensor inputs (setInput(1)=kernel, setInput(2)=bias). TensorRT expects OIHW for kernel.
-            if filter_layout != "oihw" {
-                return Err(GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: "conv2d with non-constant filter requires filter_layout \"oihw\""
-                        .to_string(),
-                });
-            }
+            // Non-constant filter: TensorRT kernel tensor is OIHW; shuffle from WebNN layout when needed.
             if let Some(id) = bias_id {
                 if graph.constant_operand_ids_to_handles.contains_key(&id) {
                     return Err(GraphError::ConversionFailed {
@@ -7122,6 +7198,36 @@ impl TrtxConverter {
                     };
                 let bias_tensor_to_use = bias_tensor_for_conv.as_ref().or(bias_tensor_raw);
 
+                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> =
+                    if filter_layout != "oihw" {
+                        let perm = Self::conv_dynamic_filter_first_transpose(filter_layout)?;
+                        let mut shuffle = network
+                            .add_shuffle(filter_tensor_to_use)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("Conv2d dynamic filter layout shuffle: {}", e),
+                            })?;
+                        shuffle
+                            .set_first_transpose(network, &perm)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("Conv2d dynamic filter set_first_transpose: {}", e),
+                            })?;
+                        Some(
+                            shuffle
+                                .get_output(&*network, 0)
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("Conv2d dynamic filter shuffle output: {}", e),
+                                })?,
+                        )
+                    } else {
+                        None
+                    };
+                let filter_for_set_input = filter_layout_shuffle_out
+                    .as_ref()
+                    .unwrap_or(filter_tensor_to_use);
+
                 let conv_weights = trtx::ConvWeights {
                     kernel_weights: &[],
                     kernel_dtype: TrtDataType::kFLOAT,
@@ -7135,7 +7241,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add convolution (tensor weights): {}", e),
                     })?;
                 layer
-                    .set_input(network, 1, filter_tensor_to_use)
+                    .set_input(network, 1, filter_for_set_input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d set_input(1) filter: {}", e),
@@ -7377,14 +7483,6 @@ impl TrtxConverter {
                 (Some(filter_data), bias_raw, None)
             }
         } else {
-            if filter_layout != "iohw" {
-                return Err(GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason:
-                        "convTranspose2d with non-constant filter requires filter_layout \"iohw\""
-                            .to_string(),
-                });
-            }
             if let Some(id) = bias_id {
                 if graph.constant_operand_ids_to_handles.contains_key(&id) {
                     return Err(GraphError::ConversionFailed {
@@ -7594,6 +7692,45 @@ impl TrtxConverter {
                 };
                 let bias_tensor_to_use = bias_tensor_for_conv.as_ref().or(bias_tensor_raw);
 
+                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> =
+                    if filter_layout != "iohw" {
+                        let perm = Self::deconv_dynamic_filter_first_transpose(filter_layout)?;
+                        let mut shuffle = network
+                            .add_shuffle(filter_tensor_to_use)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!(
+                                    "convTranspose2d dynamic filter layout shuffle: {}",
+                                    e
+                                ),
+                            })?;
+                        shuffle
+                            .set_first_transpose(network, &perm)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!(
+                                    "convTranspose2d dynamic filter set_first_transpose: {}",
+                                    e
+                                ),
+                            })?;
+                        Some(
+                            shuffle
+                                .get_output(&*network, 0)
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!(
+                                        "convTranspose2d dynamic filter shuffle output: {}",
+                                        e
+                                    ),
+                                })?,
+                        )
+                    } else {
+                        None
+                    };
+                let filter_for_set_input = filter_layout_shuffle_out
+                    .as_ref()
+                    .unwrap_or(filter_tensor_to_use);
+
                 let deconv_weights = trtx::ConvWeights {
                     kernel_weights: &[],
                     kernel_dtype: TrtDataType::kFLOAT,
@@ -7612,7 +7749,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add deconvolution (tensor weights): {}", e),
                     })?;
                 layer
-                    .set_input(network, 1, filter_tensor_to_use)
+                    .set_input(network, 1, filter_for_set_input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d set_input(1) filter: {}", e),
@@ -7725,14 +7862,45 @@ impl TrtxConverter {
 
         // When outputSizes (or output_shape) is specified, the graph output has explicit spatial
         // dimensions. Resize deconv output to match: slice if larger, pad if smaller.
+        // Prefer options.output_sizes when present so spatial targets are correct even if the
+        // output operand descriptor lacks static dims (get_static_or_max_size would yield 0).
         let output_id = operation.output_operands_slice()[0];
-        let spatial_adjusted = match (graph.operand(input_id), graph.operand(output_id)) {
-            (Some(input_operand), Some(output_operand)) => {
+        let spatial_adjusted = match graph.operand(input_id) {
+            Some(input_operand) => {
                 let in_shape = &input_operand.descriptor.shape;
-                let out_shape = &output_operand.descriptor.shape;
-                if in_shape.len() != 4 || out_shape.len() != 4 {
+                if in_shape.len() != 4 {
                     deconv_output
                 } else {
+                    let targets: Option<(i32, i32, i32)> =
+                        if let Some(sizes) = deconv_opts.and_then(|o| o.output_sizes.as_ref())
+                            && sizes.len() >= 2
+                        {
+                            Some((sizes[0] as i32, sizes[1] as i32, num_output_maps))
+                        } else if let Some(output_operand) = graph.operand(output_id) {
+                            let out_shape = &output_operand.descriptor.shape;
+                            if out_shape.len() != 4 {
+                                None
+                            } else if input_layout == "nhwc" {
+                                Some((
+                                    get_static_or_max_size(&out_shape[1]) as i32,
+                                    get_static_or_max_size(&out_shape[2]) as i32,
+                                    get_static_or_max_size(&out_shape[3]) as i32,
+                                ))
+                            } else {
+                                Some((
+                                    get_static_or_max_size(&out_shape[2]) as i32,
+                                    get_static_or_max_size(&out_shape[3]) as i32,
+                                    get_static_or_max_size(&out_shape[1]) as i32,
+                                ))
+                            }
+                        } else {
+                            None
+                        };
+
+                    match targets {
+                        Some((target_h, target_w, out_c))
+                            if target_h > 0 && target_w > 0 =>
+                        {
                     let (input_h, input_w): (i32, i32) = if input_layout == "nhwc" {
                         (
                             get_static_or_max_size(&in_shape[1]) as i32,
@@ -7744,23 +7912,7 @@ impl TrtxConverter {
                             get_static_or_max_size(&in_shape[3]) as i32,
                         )
                     };
-                    let (target_h, target_w, out_c): (i32, i32, i32) = if input_layout == "nhwc" {
-                        (
-                            get_static_or_max_size(&out_shape[1]) as i32,
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
-                        )
-                    } else {
-                        (
-                            get_static_or_max_size(&out_shape[2]) as i32,
-                            get_static_or_max_size(&out_shape[3]) as i32,
-                            get_static_or_max_size(&out_shape[1]) as i32,
-                        )
-                    };
                     let out_batch = get_static_or_max_size(&in_shape[0]) as i32;
-                    if target_h <= 0 || target_w <= 0 {
-                        deconv_output
-                    } else {
                         let effective_kernel_h = (kernel_size[0] - 1) * dilations[0] + 1;
                         let effective_kernel_w = (kernel_size[1] - 1) * dilations[1] + 1;
                         // Output = (Input - 1) * Stride + (Filter - 1) * Dilation + 1 - PrePadding - PostPadding + outputPadding.
@@ -7825,9 +7977,11 @@ impl TrtxConverter {
                             current
                         }
                     }
+                        _ => deconv_output,
+                    }
                 }
             }
-            _ => deconv_output,
+            None => deconv_output,
         };
 
         let conv_output = if input_dtype == DataType::Float16 {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1168,37 +1168,57 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add logical operation (cast Float32 to BOOL, perform operation, cast back to Float32)
+    /// Add logical operation: broadcast on float/half tensors, cast to BOOL, elementwise kAND/kOR/kXOR, Float32 output.
+    ///
+    /// TensorRT elementwise `kAND` / `kOR` / `kXOR` require BOOL inputs, so we cast after broadcast.
+    /// [`ensure_broadcast_compatible`] may use `IResizeLayer`, which does not accept BOOL—so broadcast must
+    /// run on Float/Half (original path). UInt8/Int8 are **`Cast` to Float32 first** so they never pass
+    /// through `Identity` as internal UINT8/INT8 (strongly-typed TRT rejects that).
     fn add_logical_binary_op<'a>(
-        _graph: &GraphInfo,
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
+        let id0 = operation.input_operands()[0];
+        let id1 = operation.input_operands()[1];
         let input0 = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&id0)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", id0),
             })?;
 
         let input1 = tensor_map
-            .get(&operation.input_operands()[1])
+            .get(&id1)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[1]),
+                reason: format!("Input operand {} not found", id1),
             })?;
 
-        // Ensure broadcast compatibility BEFORE casting to BOOL
-        let (bc_input0, bc_input1) =
-            Self::ensure_broadcast_compatible(network, input0, input1, operation.op_type())?;
+        let promoted0 = match graph.operand(id0).map(|o| o.descriptor.data_type) {
+            Some(DataType::Uint8) | Some(DataType::Int8) => {
+                Some(Self::cast_to_float32(network, input0)?)
+            }
+            _ => None,
+        };
+        let promoted1 = match graph.operand(id1).map(|o| o.descriptor.data_type) {
+            Some(DataType::Uint8) | Some(DataType::Int8) => {
+                Some(Self::cast_to_float32(network, input1)?)
+            }
+            _ => None,
+        };
 
-        // Cast Float32 inputs to BOOL
+        let t0: &trtx::Tensor<'a> = promoted0.as_ref().unwrap_or(input0);
+        let t1: &trtx::Tensor<'a> = promoted1.as_ref().unwrap_or(input1);
+
+        let (bc_input0, bc_input1) =
+            Self::ensure_broadcast_compatible(network, t0, t1, operation.op_type())?;
+
         let bool_input0 = Self::cast_to_bool(network, &bc_input0)?;
         let bool_input1 = Self::cast_to_bool(network, &bc_input1)?;
 
-        // Perform logical operation on BOOL
         let layer = network
             .add_elementwise(&bool_input0, &bool_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
@@ -9083,8 +9103,22 @@ impl TrtxConverter {
             }
         }
 
-        // Convert mask to bytes
-        let mask_bytes: Vec<u8> = mask_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+        let input_dtype = input_operand.descriptor.data_type;
+        // Elementwise PROD requires matching types; mask must match input (e.g. Half for float16).
+        let (mask_bytes, mask_trt_ty) = match input_dtype {
+            DataType::Float16 => {
+                let mut bytes = Vec::with_capacity(total_elements * 2);
+                for &f in &mask_data {
+                    let v = if f == 1.0 { 1.0f32 } else { 0.0f32 };
+                    bytes.extend_from_slice(&f16::from_f32(v).to_bits().to_le_bytes());
+                }
+                (bytes, TrtDataType::kHALF)
+            }
+            _ => {
+                let mask_bytes: Vec<u8> = mask_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+                (mask_bytes, TrtDataType::kFLOAT)
+            }
+        };
 
         // Create constant layer with the mask
         let dims: Vec<i64> = shape
@@ -9092,7 +9126,7 @@ impl TrtxConverter {
             .map(|s| get_static_or_max_size(s) as i64)
             .collect();
         let mask_layer = network
-            .add_constant_owned(&dims, mask_bytes, trtx::DataType::kFLOAT)
+            .add_constant_owned(&dims, mask_bytes, mask_trt_ty)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add constant mask for triangular: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -31,10 +31,11 @@ use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
-use trtx::network::Layer;
+use crate::shape_inference::infer_arg_reduce_shape;
 use trtx::{
-    ActivationType, DataType as TrtDataType, ElementWiseOperation, PoolingType, ReduceOperation,
-    ResizeMode, ScatterMode, UnaryOperation,
+    ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
+    OwnedConvWeights, OwnedWeights, PoolingType, ReduceOperation, ResizeMode, ScatterMode,
+    TopKOperation, UnaryOperation,
 };
 
 /// TensorRT native converter
@@ -44,6 +45,11 @@ impl TrtxConverter {
     /// Create a new TrtxConverter
     pub fn new() -> Self {
         TrtxConverter
+    }
+
+    #[inline]
+    fn trtx_dims_i64(dims: &[i32]) -> Vec<i64> {
+        dims.iter().map(|&d| d as i64).collect()
     }
 
     /// Map WebNN DataType to TensorRT DataType enum.
@@ -222,10 +228,10 @@ impl TrtxConverter {
     }
 
     /// Cast Float32 tensor to BOOL (0.0 → false, non-zero → true)
-    fn cast_to_bool(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_bool<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kBOOL).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -233,7 +239,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -241,10 +247,10 @@ impl TrtxConverter {
     }
 
     /// Cast BOOL tensor to Float32 (false → 0.0, true → 1.0)
-    fn cast_to_float32(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_float32<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kFLOAT).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -252,7 +258,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -260,10 +266,10 @@ impl TrtxConverter {
     }
 
     /// Cast tensor to Float16 (e.g. after float32 reduction to avoid float16 overflow).
-    fn cast_to_float16(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_to_float16<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kHALF).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -271,7 +277,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -279,10 +285,10 @@ impl TrtxConverter {
     }
 
     /// Cast INT32 tensor to Float32
-    fn cast_int32_to_float32(
-        network: &mut trtx::NetworkDefinition,
-        input: &trtx::Tensor,
-    ) -> Result<trtx::Tensor, GraphError> {
+    fn cast_int32_to_float32<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
         let layer = network.add_cast(input, TrtDataType::kFLOAT).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -290,21 +296,21 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
             })
     }
 
-    /// Build TensorRT network from WebNN graph
-    /// Returns temporary weight storage that must be kept alive until engine is serialized
-    fn build_network(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-    ) -> Result<Vec<Vec<u8>>, GraphError> {
-        let mut tensor_map: HashMap<u32, trtx::Tensor> = HashMap::new();
-        let mut temp_weights: Vec<Vec<u8>> = Vec::new(); // Storage for temporary constants
+    /// Build TensorRT network from WebNN graph.
+    /// `temp_weights` must be supplied by the caller and kept alive until engine serialization completes.
+    fn build_network<'a>(
+        graph: &'a GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        temp_weights: &mut Vec<Vec<u8>>,
+    ) -> Result<(), GraphError> {
+        let mut tensor_map: HashMap<u32, trtx::Tensor<'a>> = HashMap::new();
         let promoted_constants: HashSet<u32> = HashSet::new();
         let constants_stored_flat: HashSet<u32> = HashSet::new();
 
@@ -312,15 +318,15 @@ impl TrtxConverter {
         for (operand_id, operand) in graph.operands.iter().enumerate() {
             if operand.kind == OperandKind::Input {
                 let dtype = Self::webnn_to_trt_dtype(operand.descriptor.data_type)?;
-                let dims: Vec<i32> = operand
+                let dims: Vec<i64> = operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let name = operand.name.as_deref().unwrap_or("input");
 
-                let mut tensor = network.add_input(name, dtype, &dims).map_err(|e| {
+                let tensor = network.add_input(name, dtype, &dims).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add input {}: {}", name, e),
@@ -328,7 +334,7 @@ impl TrtxConverter {
                 })?;
 
                 tensor
-                    .set_name(name)
+                    .set_name(network, name)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to set input name: {}", e),
@@ -388,44 +394,36 @@ impl TrtxConverter {
                 // TensorRT add_constant does not support kINT64; convert Int64 constants to Int32.
                 let promote_int64 = operand.descriptor.data_type == DataType::Int64;
 
-                let (trt_dtype, data_to_use, add_dims): (TrtDataType, &[u8], Vec<i32>) =
-                    if use_int8_constant {
-                        // Pass raw bytes; type kINT8 (Uint8 same bits for 0/1, no conversion)
-                        (TrtDataType::kINT8, data, dims.clone())
-                    } else if promote_int64 {
-                        let int32_bytes: Vec<u8> = data
-                            .chunks_exact(8)
-                            .flat_map(|chunk| {
-                                (i64::from_le_bytes(chunk.try_into().unwrap()) as i32).to_le_bytes()
-                            })
-                            .collect();
-                        temp_weights.push(int32_bytes);
-                        (
-                            TrtDataType::kINT32,
-                            temp_weights.last().unwrap().as_slice(),
-                            dims.clone(),
-                        )
-                    } else {
-                        (
-                            Self::webnn_to_trt_dtype(operand.descriptor.data_type)?,
-                            data,
-                            dims.clone(),
-                        )
-                    };
+                let add_dims: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+                let layer = if use_int8_constant {
+                    network.add_small_constant_copied(&add_dims, data, TrtDataType::kINT8)
+                } else if promote_int64 {
+                    let int32_bytes: Vec<u8> = data
+                        .chunks_exact(8)
+                        .flat_map(|chunk| {
+                            (i64::from_le_bytes(chunk.try_into().unwrap()) as i32).to_le_bytes()
+                        })
+                        .collect();
+                    network.add_small_constant_copied(&add_dims, &int32_bytes, TrtDataType::kINT32)
+                } else {
+                    network.add_constant(
+                        &add_dims,
+                        data,
+                        Self::webnn_to_trt_dtype(operand.descriptor.data_type)?,
+                    )
+                }
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add constant (operand {}): {}", operand_id, e),
+                })?;
 
-                let layer = network
-                    .add_constant(&add_dims, data_to_use, trt_dtype)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add constant (operand {}): {}", operand_id, e),
-                    })?;
-
-                let tensor = layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get constant layer output: {}", e),
-                    })?;
+                let tensor =
+                    layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get constant layer output: {}", e),
+                        })?;
 
                 tensor_map.insert(operand_id as u32, tensor);
             }
@@ -437,7 +435,7 @@ impl TrtxConverter {
                 graph,
                 network,
                 &mut tensor_map,
-                &mut temp_weights,
+                temp_weights,
                 &promoted_constants,
                 &constants_stored_flat,
                 operation,
@@ -456,30 +454,21 @@ impl TrtxConverter {
 
                 // Set the output tensor name if available
                 if let Some(name) = &operand.name {
-                    let _ = tensor.set_name(name); // Ignore error if name setting fails
+                    let _ = tensor.set_name(network, name); // Ignore error if name setting fails
                 }
 
-                network
-                    .mark_output(tensor)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "Failed to mark output {}: {}",
-                            operand.name.as_deref().unwrap_or("unnamed"),
-                            e
-                        ),
-                    })?;
+                network.mark_output(tensor);
             }
         }
 
-        Ok(temp_weights)
+        Ok(())
     }
 
     /// Add a single operation to the network
-    fn add_operation(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_operation<'a>(
+        graph: &'a GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         temp_weights: &mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
@@ -611,9 +600,9 @@ impl TrtxConverter {
             "gemm" => Self::add_gemm_op(graph, network, tensor_map, temp_weights, operation)?,
 
             // Convolution operations
-            "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, temp_weights, operation)?,
+            "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, operation)?,
             "convTranspose2d" => {
-                Self::add_conv_transpose2d_op(graph, network, tensor_map, temp_weights, operation)?
+                Self::add_conv_transpose2d_op(graph, network, tensor_map, operation)?
             }
 
             // Pooling operations
@@ -734,8 +723,8 @@ impl TrtxConverter {
             "gatherND" => Self::add_gather_nd_op(network, tensor_map, operation)?,
             "scatterElements" => Self::add_scatter_elements_op(network, tensor_map, operation)?,
             "scatterND" => Self::add_scatter_nd_op(network, tensor_map, operation)?,
-            "argMax" => Self::add_arg_max_op(network, tensor_map, operation)?,
-            "argMin" => Self::add_arg_min_op(network, tensor_map, operation)?,
+            "argMax" => Self::add_arg_max_op(graph, network, tensor_map, operation)?,
+            "argMin" => Self::add_arg_min_op(graph, network, tensor_map, operation)?,
 
             // Other operations
             "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation, temp_weights)?,
@@ -745,17 +734,13 @@ impl TrtxConverter {
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
             "concat" => Self::add_concat_op(network, tensor_map, operation)?,
             "isNaN" => Self::add_is_nan_op(network, tensor_map, operation)?,
-            "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation, temp_weights)?,
+            "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation)?,
             "roundEven" => Self::add_round_even_op(network, tensor_map, operation)?,
             "gatherElements" => Self::add_gather_elements_op(network, tensor_map, operation)?,
             "l2Pool2d" => Self::add_l2_pool2d_op(network, tensor_map, operation)?,
             "reverse" => Self::add_reverse_op(graph, network, tensor_map, operation)?,
-            "cumulativeSum" => {
-                Self::add_cumulative_sum_op(graph, network, tensor_map, operation, temp_weights)?
-            }
-            "triangular" => {
-                Self::add_triangular_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "cumulativeSum" => Self::add_cumulative_sum_op(graph, network, tensor_map, operation)?,
+            "triangular" => Self::add_triangular_op(graph, network, tensor_map, operation)?,
             "transpose" => Self::add_transpose_op(graph, network, tensor_map, operation)?,
             "reshape" => Self::add_reshape_op(graph, network, tensor_map, operation)?,
             "resample2d" => Self::add_resample2d_op(network, tensor_map, operation)?,
@@ -775,15 +760,15 @@ impl TrtxConverter {
 
     /// Helper to ensure two tensors have compatible shapes for elementwise operations
     /// Returns potentially reshaped tensors that are guaranteed to be broadcast-compatible
-    fn ensure_broadcast_compatible(
-        network: &mut trtx::NetworkDefinition,
-        tensor0: &trtx::Tensor,
-        tensor1: &trtx::Tensor,
+    fn ensure_broadcast_compatible<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor0: &trtx::Tensor<'a>,
+        tensor1: &trtx::Tensor<'a>,
         op_name: &str,
-    ) -> Result<(trtx::Tensor, trtx::Tensor), GraphError> {
+    ) -> Result<(trtx::Tensor<'a>, trtx::Tensor<'a>), GraphError> {
         // Get dimensions of both tensors
         let dims0 = tensor0
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!(
@@ -793,7 +778,7 @@ impl TrtxConverter {
             })?;
 
         let dims1 = tensor1
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!(
@@ -812,7 +797,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor0: {}", e),
                 })?;
             let t0 = id0
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -825,7 +810,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor1: {}", e),
                 })?;
             let t1 = id1
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -864,7 +849,7 @@ impl TrtxConverter {
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
                 let t0 = id0
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -878,7 +863,7 @@ impl TrtxConverter {
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
                 let t1 = id1
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -903,15 +888,10 @@ impl TrtxConverter {
                             reason: format!("Failed to add resize layer for tensor0: {}", e),
                         })?;
 
-                resize_layer.set_output_dimensions(&dims1).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to set output dimensions: {}", e),
-                    }
-                })?;
+                resize_layer.set_output_dimensions(network, &dims1);
 
                 resize_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -924,10 +904,11 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
-                id.get_output(0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get identity output: {}", e),
-                })?
+                id.get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?
             };
 
             let t1 = if dims1
@@ -944,15 +925,10 @@ impl TrtxConverter {
                             reason: format!("Failed to add resize layer for tensor1: {}", e),
                         })?;
 
-                resize_layer.set_output_dimensions(&dims0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to set output dimensions: {}", e),
-                    }
-                })?;
+                resize_layer.set_output_dimensions(network, &dims0);
 
                 resize_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -965,10 +941,11 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
-                id.get_output(0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get identity output: {}", e),
-                })?
+                id.get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?
             };
 
             return Ok((t0, t1));
@@ -982,22 +959,24 @@ impl TrtxConverter {
             (tensor1, tensor0, false)
         };
 
-        let reshape_dims = to_reshape
-            .dimensions()
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get reshape dims: {}", e),
-            })?;
-        let target_dims = to_keep
-            .dimensions()
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get target dims: {}", e),
-            })?;
+        let reshape_dims =
+            to_reshape
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get reshape dims: {}", e),
+                })?;
+        let target_dims =
+            to_keep
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get target dims: {}", e),
+                })?;
 
         // Pad smaller tensor with leading 1s
         let rank_diff = target_dims.len() - reshape_dims.len();
-        let mut new_shape: Vec<i32> = vec![1; rank_diff];
+        let mut new_shape: Vec<i64> = vec![1i64; rank_diff];
         new_shape.extend_from_slice(&reshape_dims);
 
         let mut shuffle_layer =
@@ -1009,18 +988,19 @@ impl TrtxConverter {
                 })?;
 
         shuffle_layer
-            .set_reshape_dimensions(&new_shape)
+            .set_reshape_dimensions(network, &new_shape)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape dimensions: {}", e),
             })?;
 
-        let reshaped = shuffle_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get reshape output: {}", e),
-            })?;
+        let reshaped =
+            shuffle_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get reshape output: {}", e),
+                })?;
 
         // Clone the other tensor with identity
         let id_keep = network
@@ -1030,7 +1010,7 @@ impl TrtxConverter {
                 reason: format!("Failed to clone kept tensor: {}", e),
             })?;
         let kept = id_keep
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -1045,10 +1025,10 @@ impl TrtxConverter {
     }
 
     /// Add elementwise operation
-    fn add_elementwise_op(
+    fn add_elementwise_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1079,7 +1059,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1092,10 +1072,10 @@ impl TrtxConverter {
     }
 
     /// Add comparison operation (outputs BOOL, cast to Float32)
-    fn add_comparison_op(
+    fn add_comparison_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1125,12 +1105,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add comparison operation: {}", e),
             })?;
 
-        let bool_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let bool_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -1142,10 +1123,10 @@ impl TrtxConverter {
     }
 
     /// Add logical operation (cast Float32 to BOOL, perform operation, cast back to Float32)
-    fn add_logical_binary_op(
+    fn add_logical_binary_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         op_code: ElementWiseOperation,
     ) -> Result<(), GraphError> {
@@ -1179,12 +1160,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add logical operation: {}", e),
             })?;
 
-        let bool_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let bool_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         // Cast BOOL output back to Float32
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -1198,12 +1180,12 @@ impl TrtxConverter {
     /// Add logical NOT operation. TensorRT Unary(kNOT) requires Bool input.
     /// Quantized constants (kINT8) may only feed DQ/plugin; for UInt8/Int8 constant, add a kBOOL
     /// constant (0 -> false, non-zero -> true) and feed it directly to kNOT so no extra Cast is needed.
-    fn add_logical_not_op(
+    fn add_logical_not_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
         let input = tensor_map
@@ -1226,11 +1208,11 @@ impl TrtxConverter {
             match operand.descriptor.data_type {
                 DataType::Uint8 | DataType::Int8 => {
                     let data = Self::get_constant_data(graph, input_id)?;
-                    let shape: Vec<i32> = operand
+                    let shape: Vec<i64> = operand
                         .descriptor
                         .shape
                         .iter()
-                        .map(|d| get_static_or_max_size(d) as i32)
+                        .map(|d| get_static_or_max_size(d) as i64)
                         .collect();
                     let n: usize = operand
                         .descriptor
@@ -1243,20 +1225,18 @@ impl TrtxConverter {
                         .take(n)
                         .map(|&b| if b == 0 { 0u8 } else { 1u8 })
                         .collect();
-                    temp_weights.push(bool_bytes);
-                    let ref_bytes = temp_weights.last().unwrap().as_slice();
                     let const_layer = network
-                        .add_constant(&shape, ref_bytes, TrtDataType::kBOOL)
+                        .add_small_constant_copied(&shape, &bool_bytes, TrtDataType::kBOOL)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: failed to add BOOL constant: {}", e),
                         })?;
-                    const_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
+                    const_layer.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: BOOL constant output: {}", e),
-                        })?
+                        }
+                    })?
                 }
                 _ => Self::cast_to_bool(network, input)?,
             }
@@ -1271,12 +1251,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add logical NOT: {}", e),
             })?;
 
-        let not_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let not_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output = Self::cast_to_float32(network, &not_output)?;
 
@@ -1287,9 +1268,9 @@ impl TrtxConverter {
     }
 
     /// Add activation operation
-    fn add_activation_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_activation_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         activation_type: ActivationType,
     ) -> Result<(), GraphError> {
@@ -1309,7 +1290,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1324,12 +1305,12 @@ impl TrtxConverter {
     /// Add ELU activation: ELU(x) = x if x > 0, else alpha * (exp(x) - 1)
     /// TensorRT kELU uses alpha=1; for custom alpha we decompose as:
     /// relu(x) + alpha * min(0, exp(x) - 1)
-    fn add_elu_op(
+    fn add_elu_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1360,7 +1341,7 @@ impl TrtxConverter {
         }
 
         let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
         let (trt_dtype, one_bytes, zero_bytes, alpha_bytes) = match input_dtype {
             DataType::Float16 => {
                 let one: Vec<u8> = f16::from_f32(1.0).to_bits().to_le_bytes().to_vec();
@@ -1383,12 +1364,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for elu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let relu_output =
+            relu_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         let exp_layer = network
             .add_unary(input, UnaryOperation::kEXP)
@@ -1396,30 +1378,27 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add exp for elu: {}", e),
             })?;
-        let exp_output = exp_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get exp output: {}", e),
-            })?;
+        let exp_output =
+            exp_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get exp output: {}", e),
+                })?;
 
-        temp_weights.push(one_bytes);
         let one_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create one constant for elu: {}", e),
             })?;
-        let one_tensor = one_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get one constant output: {}", e),
-            })?;
+        let one_tensor =
+            one_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get one constant output: {}", e),
+                })?;
 
         let (bc_exp, bc_one) =
             Self::ensure_broadcast_compatible(network, &exp_output, &one_tensor, "elu_exp_sub")?;
@@ -1432,29 +1411,25 @@ impl TrtxConverter {
             })?;
         let exp_minus_1 =
             exp_minus_1_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get exp-1 output: {}", e),
                 })?;
 
-        temp_weights.push(zero_bytes);
         let zero_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create zero constant for elu: {}", e),
             })?;
-        let zero_tensor = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get zero constant output: {}", e),
-            })?;
+        let zero_tensor =
+            zero_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get zero constant output: {}", e),
+                })?;
 
         let (bc_em1, bc_zero) =
             Self::ensure_broadcast_compatible(network, &exp_minus_1, &zero_tensor, "elu_min")?;
@@ -1465,30 +1440,27 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min for elu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get neg part output: {}", e),
-            })?;
+        let neg_part =
+            neg_part_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get neg part output: {}", e),
+                })?;
 
-        temp_weights.push(alpha_bytes);
         let alpha_const = network
-            .add_constant(
-                &broadcast_shape,
-                temp_weights.last().unwrap(),
-                trt_dtype.clone(),
-            )
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create alpha constant for elu: {}", e),
             })?;
-        let alpha_tensor = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get alpha constant output: {}", e),
-            })?;
+        let alpha_tensor =
+            alpha_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get alpha constant output: {}", e),
+                })?;
 
         let (bc_neg, bc_alpha) =
             Self::ensure_broadcast_compatible(network, &neg_part, &alpha_tensor, "elu_scale")?;
@@ -1501,7 +1473,7 @@ impl TrtxConverter {
             })?;
         let scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled neg output: {}", e),
@@ -1516,12 +1488,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elu parts: {}", e),
             })?;
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get elu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get elu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1530,9 +1503,9 @@ impl TrtxConverter {
     }
 
     /// Add unary operation (element-wise mathematical operations)
-    fn add_unary_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_unary_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         unary_op: UnaryOperation,
     ) -> Result<(), GraphError> {
@@ -1553,7 +1526,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1568,12 +1541,12 @@ impl TrtxConverter {
     /// Add leaky ReLU activation
     /// LeakyReLU(x) = max(alpha * x, x) = x if x >= 0, else alpha * x
     /// Implemented as: max(0, x) + alpha * min(0, x) so alpha is respected (including negative).
-    fn add_leaky_relu_op(
+    fn add_leaky_relu_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1598,7 +1571,7 @@ impl TrtxConverter {
                 ),
             })?;
         let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
 
         let (alpha_bytes, alpha_dtype) = match input_operand.descriptor.data_type {
             DataType::Float16 => (
@@ -1607,21 +1580,19 @@ impl TrtxConverter {
             ),
             _ => (alpha.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
         };
-        temp_weights.push(alpha_bytes);
-        let alpha_ref = temp_weights.last().unwrap().as_slice();
-
         let alpha_const = network
-            .add_constant(&broadcast_shape, alpha_ref, alpha_dtype)
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LeakyReLU: failed to add alpha constant: {}", e),
             })?;
-        let alpha_tensor = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("LeakyReLU: alpha const output: {}", e),
-            })?;
+        let alpha_tensor =
+            alpha_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("LeakyReLU: alpha const output: {}", e),
+                })?;
 
         // max(0, x) = relu(x)
         let relu_layer = network
@@ -1630,12 +1601,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for leaky relu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let relu_output =
+            relu_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         // min(0, x) = x - relu(x)
         let neg_part_layer = network
@@ -1644,12 +1616,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get min(0,x) for leaky relu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get neg part output: {}", e),
-            })?;
+        let neg_part =
+            neg_part_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get neg part output: {}", e),
+                })?;
 
         // alpha * min(0, x)
         let scaled_neg_layer = network
@@ -1660,7 +1633,7 @@ impl TrtxConverter {
             })?;
         let scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled neg output: {}", e),
@@ -1674,12 +1647,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add leaky relu parts: {}", e),
             })?;
 
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get leaky relu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get leaky relu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1688,9 +1662,9 @@ impl TrtxConverter {
     }
 
     /// Add PReLU activation
-    fn add_prelu_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_prelu_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -1717,12 +1691,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add relu for prelu: {}", e),
             })?;
-        let relu_output = relu_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get relu output: {}", e),
-            })?;
+        let relu_output =
+            relu_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get relu output: {}", e),
+                })?;
 
         // Negative part: min(0, x)
         let zero_layer = network
@@ -1731,12 +1706,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add second relu: {}", e),
             })?;
-        let zero_output = zero_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get zero output: {}", e),
-            })?;
+        let zero_output =
+            zero_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get zero output: {}", e),
+                })?;
 
         // x - relu(x) = min(0, x)
         let neg_part_layer = network
@@ -1745,12 +1721,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract for prelu: {}", e),
             })?;
-        let neg_part = neg_part_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get negative part: {}", e),
-            })?;
+        let neg_part =
+            neg_part_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get negative part: {}", e),
+                })?;
 
         // slope * min(0, x)
         let scaled_neg_layer = network
@@ -1761,7 +1738,7 @@ impl TrtxConverter {
             })?;
         let scaled_neg =
             scaled_neg_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get scaled negative: {}", e),
@@ -1775,12 +1752,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add prelu parts: {}", e),
             })?;
 
-        let output = final_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get prelu output: {}", e),
-            })?;
+        let output =
+            final_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get prelu output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -1791,12 +1769,12 @@ impl TrtxConverter {
     /// Add hard sigmoid activation
     /// HardSigmoid(x) = clamp(alpha * x + beta, 0, 1)
     /// Uses built-in kHARD_SIGMOID when alpha=0.2 and beta=0.5; otherwise decomposes with elementwise ops.
-    fn add_hard_sigmoid_op(
+    fn add_hard_sigmoid_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1817,12 +1795,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add hard sigmoid: {}", e),
                 })?;
-            let output = layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+            let output =
+                layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get layer output: {}", e),
+                    })?;
             let output_ids = operation.output_operands_slice();
             tensor_map.insert(output_ids[0], output);
             return Ok(());
@@ -1838,12 +1817,12 @@ impl TrtxConverter {
                 ),
             })?;
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to get input dimensions: {}", e),
             })?;
-        let broadcast_shape: Vec<i32> = vec![1; input_dims.len()];
+        let broadcast_shape: Vec<i64> = vec![1i64; input_dims.len()];
         let input_dtype = input_operand.descriptor.data_type;
 
         let (alpha_bytes, beta_bytes, zero_bytes, one_bytes, trt_dtype) = match input_dtype {
@@ -1862,65 +1841,59 @@ impl TrtxConverter {
                 trtx::DataType::kFLOAT,
             ),
         };
-        temp_weights.push(alpha_bytes);
-        temp_weights.push(beta_bytes);
-        temp_weights.push(zero_bytes);
-        temp_weights.push(one_bytes);
-        let idx = temp_weights.len();
-        let alpha_ref = temp_weights[idx - 4].as_slice();
-        let beta_ref = temp_weights[idx - 3].as_slice();
-        let zero_ref = temp_weights[idx - 2].as_slice();
-        let one_ref = temp_weights[idx - 1].as_slice();
-
         let alpha_const = network
-            .add_constant(&broadcast_shape, alpha_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &alpha_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add alpha constant: {}", e),
             })?;
         let beta_const = network
-            .add_constant(&broadcast_shape, beta_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &beta_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add beta constant: {}", e),
             })?;
         let zero_const = network
-            .add_constant(&broadcast_shape, zero_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add zero constant: {}", e),
             })?;
         let one_const = network
-            .add_constant(&broadcast_shape, one_ref, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &one_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: failed to add one constant: {}", e),
             })?;
 
-        let alpha_out = alpha_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: alpha const output: {}", e),
-            })?;
-        let beta_out = beta_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: beta const output: {}", e),
-            })?;
-        let zero_out = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: zero const output: {}", e),
-            })?;
-        let one_out = one_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: one const output: {}", e),
-            })?;
+        let alpha_out =
+            alpha_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: alpha const output: {}", e),
+                })?;
+        let beta_out =
+            beta_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: beta const output: {}", e),
+                })?;
+        let zero_out =
+            zero_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: zero const output: {}", e),
+                })?;
+        let one_out =
+            one_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: one const output: {}", e),
+                })?;
 
         // linear = alpha * x + beta
         let ax = network
@@ -1929,10 +1902,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: alpha*x: {}", e),
             })?;
-        let linear = ax.get_output(0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("HardSigmoid: linear get output: {}", e),
-        })?;
+        let linear = ax
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSigmoid: linear get output: {}", e),
+            })?;
         let linear_plus_beta = network
             .add_elementwise(&linear, &beta_out, ElementWiseOperation::kSUM)
             .map_err(|e| GraphError::ConversionFailed {
@@ -1941,7 +1916,7 @@ impl TrtxConverter {
             })?;
         let linear_out =
             linear_plus_beta
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: linear_out: {}", e),
@@ -1955,7 +1930,7 @@ impl TrtxConverter {
                 reason: format!("HardSigmoid: min(1, linear): {}", e),
             })?;
         let min1_out = min1
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: min1 output: {}", e),
@@ -1966,12 +1941,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: max(0, ...): {}", e),
             })?;
-        let output = output_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: output: {}", e),
-            })?;
+        let output =
+            output_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         tensor_map.insert(output_ids[0], output);
@@ -1980,12 +1956,12 @@ impl TrtxConverter {
 
     /// Add hard swish activation
     /// WebNN: y = x * max(0, min(6, (x + 3))) / 6 (MobileNetV3). Follows spec decomposition.
-    fn add_hard_swish_op(
+    fn add_hard_swish_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2004,12 +1980,12 @@ impl TrtxConverter {
                 ),
             })?;
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to get input dimensions: {}", e),
             })?;
-        let broadcast_shape: Vec<i32> = vec![1; input_dims.len()];
+        let broadcast_shape: Vec<i64> = vec![1i64; input_dims.len()];
         let input_dtype = input_operand.descriptor.data_type;
 
         let three = 3.0f32;
@@ -2029,51 +2005,46 @@ impl TrtxConverter {
                 trtx::DataType::kFLOAT,
             ),
         };
-        temp_weights.push(three_bytes);
-        temp_weights.push(six_bytes);
-        temp_weights.push(zero_bytes);
-        let idx = temp_weights.len();
-        let three_ref = temp_weights[idx - 3].as_slice();
-        let six_ref = temp_weights[idx - 2].as_slice();
-        let zero_ref = temp_weights[idx - 1].as_slice();
-
         let three_const = network
-            .add_constant(&broadcast_shape, three_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &three_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 3 constant: {}", e),
             })?;
         let six_const = network
-            .add_constant(&broadcast_shape, six_ref, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &six_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add 6 constant: {}", e),
             })?;
         let zero_const = network
-            .add_constant(&broadcast_shape, zero_ref, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: failed to add zero constant: {}", e),
             })?;
 
-        let three_out = three_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: 3 const output: {}", e),
-            })?;
-        let six_out = six_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: 6 const output: {}", e),
-            })?;
-        let zero_out = zero_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: zero const output: {}", e),
-            })?;
+        let three_out =
+            three_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: 3 const output: {}", e),
+                })?;
+        let six_out =
+            six_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: 6 const output: {}", e),
+                })?;
+        let zero_out =
+            zero_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: zero const output: {}", e),
+                })?;
 
         // Spec: div(mul(input, max(0, min(6, add(input, 3)))), 6)
         let x_plus_3 = network
@@ -2082,12 +2053,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: add(input, 3): {}", e),
             })?;
-        let x_plus_3_out = x_plus_3
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: x+3 output: {}", e),
-            })?;
+        let x_plus_3_out =
+            x_plus_3
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: x+3 output: {}", e),
+                })?;
         let min6 = network
             .add_elementwise(&six_out, &x_plus_3_out, ElementWiseOperation::kMIN)
             .map_err(|e| GraphError::ConversionFailed {
@@ -2095,7 +2067,7 @@ impl TrtxConverter {
                 reason: format!("HardSwish: min(6, x+3): {}", e),
             })?;
         let min6_out = min6
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: min6 output: {}", e),
@@ -2107,7 +2079,7 @@ impl TrtxConverter {
                 reason: format!("HardSwish: max(0, ...): {}", e),
             })?;
         let inner_out = inner
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: inner output: {}", e),
@@ -2120,7 +2092,7 @@ impl TrtxConverter {
             })?;
         let x_times_inner_out =
             x_times_inner
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: x*inner output: {}", e),
@@ -2131,12 +2103,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: div(..., 6): {}", e),
             })?;
-        let output = output_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSwish: output: {}", e),
-            })?;
+        let output =
+            output_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSwish: output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         tensor_map.insert(output_ids[0], output);
@@ -2145,9 +2118,9 @@ impl TrtxConverter {
 
     /// Add identity operation
     /// Identity just passes through the input unchanged using IIdentityLayer
-    fn add_identity_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_identity_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
@@ -2167,7 +2140,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -2183,11 +2156,11 @@ impl TrtxConverter {
     /// TensorRT does not allow INT8/UINT8 constants to feed a Cast (only DQ or plugin).
     /// Scalar int8/uint8 constants are promoted to int32 when added; Cast then becomes identity.
     /// For non-scalar int8/uint8 -> int32 we emulate via Dequantize(scale=1) -> Cast(INT32).
-    fn add_cast_op(
+    fn add_cast_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -2249,33 +2222,29 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add identity for promoted scalar cast: {}", e),
                     })?;
-            let output =
-                identity_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get identity output: {}", e),
-                    })?;
+            let output = identity_layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get identity output: {}", e),
+                }
+            })?;
             tensor_map.insert(output_id, output);
             return Ok(());
         }
 
         // Helper: DQ(scale=1) with per-tensor (0D) scale. TensorRT only allows scalar or per-channel scale; 4D scale causes "ScaleMode is illegal".
-        let add_dq_scale_constant = |network: &mut trtx::NetworkDefinition,
-                                     temp_weights: &mut Vec<Vec<u8>>,
+        let add_dq_scale_constant = |network: &mut trtx::NetworkDefinition<'a>,
                                      err_prefix: &str|
-         -> Result<trtx::Tensor, GraphError> {
-            let scale_one: Vec<u8> = 1.0f32.to_le_bytes().to_vec();
-            temp_weights.push(scale_one);
-            let scale_ref = temp_weights.last().unwrap();
+         -> Result<trtx::Tensor<'a>, GraphError> {
+            let scale_one = 1.0f32.to_le_bytes();
             let scale_constant = network
-                .add_constant(&[], scale_ref, TrtDataType::kFLOAT)
+                .add_small_constant_copied(&[], scale_one.as_slice(), TrtDataType::kFLOAT)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: {}", err_prefix, e),
                 })?;
             scale_constant
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: get scale output: {}", err_prefix, e),
@@ -2285,7 +2254,7 @@ impl TrtxConverter {
         // Constant stored flat: 1D int8. Try 1D -> Reshape(4D) -> DQ so DQ sees Shuffle output not Constant.
         let stored_flat = constants_stored_flat.contains(&input_id);
         let _input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Cast: failed to get input dimensions: {}", e),
@@ -2299,11 +2268,11 @@ impl TrtxConverter {
                 });
             }
             {
-                let original_shape: Vec<i32> = input_operand
+                let original_shape: Vec<i64> = input_operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let mut shuffle_to_4d =
                     network
@@ -2312,38 +2281,37 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Cast: failed to add reshape shuffle: {}", e),
                         })?;
-                let _ = shuffle_to_4d.set_layer_name("cast_flat_reshape_4d");
+                let _ = shuffle_to_4d.set_name(network, "cast_flat_reshape_4d");
                 shuffle_to_4d
-                    .set_reshape_dimensions(&original_shape)
+                    .set_reshape_dimensions(network, &original_shape)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d =
-                    shuffle_to_4d
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Cast: failed to get reshape output: {}", e),
-                        })?;
-                let _ = reshaped_4d.set_name("cast_flat_reshape_4d");
+                let reshaped_4d = shuffle_to_4d.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Cast: failed to get reshape output: {}", e),
+                    }
+                })?;
+                let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
                 let scale_tensor =
-                    add_dq_scale_constant(network, temp_weights, "int8->float32 cast")?;
+                    add_dq_scale_constant(network, "int8->float32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
                     })?;
-                let _ = dq_layer.set_layer_name("cast_flat_dq_f32");
-                let mut output =
+                let _ = dq_layer.set_name(network, "cast_flat_dq_f32");
+                let output =
                     dq_layer
-                        .get_output(0)
+                        .get_output(&*network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to get dequantize output: {}", e),
                         })?;
-                let _ = output.set_name("cast_flat_dq_f32");
+                let _ = output.set_name(network, "cast_flat_dq_f32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
             }
@@ -2358,11 +2326,11 @@ impl TrtxConverter {
                 });
             }
             {
-                let original_shape: Vec<i32> = input_operand
+                let original_shape: Vec<i64> = input_operand
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i32)
+                    .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
                 let mut shuffle_to_4d =
                     network
@@ -2371,38 +2339,37 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Cast: failed to add reshape shuffle: {}", e),
                         })?;
-                let _ = shuffle_to_4d.set_layer_name("cast_flat_reshape_4d_int32");
+                let _ = shuffle_to_4d.set_name(network, "cast_flat_reshape_4d_int32");
                 shuffle_to_4d
-                    .set_reshape_dimensions(&original_shape)
+                    .set_reshape_dimensions(network, &original_shape)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let mut reshaped_4d =
-                    shuffle_to_4d
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Cast: failed to get reshape output: {}", e),
-                        })?;
-                let _ = reshaped_4d.set_name("cast_flat_reshape_4d");
+                let reshaped_4d = shuffle_to_4d.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Cast: failed to get reshape output: {}", e),
+                    }
+                })?;
+                let _ = reshaped_4d.set_name(network, "cast_flat_reshape_4d");
                 let scale_tensor =
-                    add_dq_scale_constant(network, temp_weights, "int8->int32 cast")?;
+                    add_dq_scale_constant(network, "int8->int32 cast")?;
                 let mut dq_layer = network
                     .add_dequantize(&reshaped_4d, &scale_tensor, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add dequantize for int8->int32 cast: {}", e),
                     })?;
-                let _ = dq_layer.set_layer_name("cast_flat_dq_int32");
-                let mut dq_out =
+                let _ = dq_layer.set_name(network, "cast_flat_dq_int32");
+                let dq_out =
                     dq_layer
-                        .get_output(0)
+                        .get_output(&*network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to get dequantize output: {}", e),
                         })?;
-                let _ = dq_out.set_name("cast_flat_dq_int32");
+                let _ = dq_out.set_name(network, "cast_flat_dq_int32");
                 let mut cast_layer =
                     network
                         .add_cast(&dq_out, TrtDataType::kINT32)
@@ -2410,15 +2377,14 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to add cast to INT32: {}", e),
                         })?;
-                let _ = cast_layer.set_layer_name("cast_flat_cast_int32");
-                let mut output =
-                    cast_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get cast output: {}", e),
-                        })?;
-                let _ = output.set_name("cast_flat_cast_int32");
+                let _ = cast_layer.set_name(network, "cast_flat_cast_int32");
+                let output = cast_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get cast output: {}", e),
+                    }
+                })?;
+                let _ = output.set_name(network, "cast_flat_cast_int32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
             }
@@ -2436,7 +2402,7 @@ impl TrtxConverter {
                 })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -2447,9 +2413,9 @@ impl TrtxConverter {
     }
 
     /// Add quantizeLinear operation (float to quantized integer)
-    fn add_quantize_linear_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_quantize_linear_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -2479,7 +2445,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get quantize output: {}", e),
@@ -2492,9 +2458,9 @@ impl TrtxConverter {
     }
 
     /// Add dequantizeLinear operation (quantized integer to float)
-    fn add_dequantize_linear_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_dequantize_linear_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -2524,7 +2490,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get dequantize output: {}", e),
@@ -2537,9 +2503,9 @@ impl TrtxConverter {
     }
 
     /// Add global pooling operation
-    fn add_global_pooling_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_global_pooling_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
@@ -2552,7 +2518,7 @@ impl TrtxConverter {
 
         // Get input dimensions to determine window size
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dimensions: {}", e),
@@ -2570,7 +2536,7 @@ impl TrtxConverter {
             });
         }
 
-        let window: [i32; 2] = [input_dims[2], input_dims[3]];
+        let window: [i64; 2] = [input_dims[2], input_dims[3]];
 
         let layer = network
             .add_pooling(input, pool_type, &window)
@@ -2580,7 +2546,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -2595,9 +2561,9 @@ impl TrtxConverter {
     /// Add matrix multiply operation.
     /// TensorRT IMatrixMultiplyLayer requires both inputs to have the same number of dimensions;
     /// if ranks differ, unsqueeze the lower-rank input by prepending 1s.
-    fn add_matmul_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_matmul_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -2615,13 +2581,13 @@ impl TrtxConverter {
             })?;
 
         let dims0 = input0
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Matmul: input0 dimensions: {}", e),
             })?;
         let dims1 = input1
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Matmul: input1 dimensions: {}", e),
@@ -2631,11 +2597,16 @@ impl TrtxConverter {
         let rank1 = dims1.len();
 
         let layer = if rank0 == rank1 {
-            network.add_matrix_multiply(input0, 0, input1, 0)
+            network.add_matrix_multiply(
+                input0,
+                MatrixOperation::kNONE,
+                input1,
+                MatrixOperation::kNONE,
+            )
         } else if rank0 < rank1 {
-            let reshape_dims: Vec<i32> = dims0.iter().map(|&d| d as i32).collect();
+            let reshape_dims: Vec<i64> = dims0.iter().copied().collect();
             let rank_diff = rank1 - rank0;
-            let mut new_shape: Vec<i32> = vec![1; rank_diff];
+            let mut new_shape: Vec<i64> = vec![1i64; rank_diff];
             new_shape.extend(reshape_dims);
             let mut shuffle =
                 network
@@ -2644,23 +2615,29 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
+            shuffle.set_reshape_dimensions(network, &new_shape).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
                 }
             })?;
-            let reshaped0 = shuffle
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Matmul: shuffle output: {}", e),
-                })?;
-            network.add_matrix_multiply(&reshaped0, 0, input1, 0)
+            let reshaped0 =
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Matmul: shuffle output: {}", e),
+                    })?;
+            network.add_matrix_multiply(
+                &reshaped0,
+                MatrixOperation::kNONE,
+                input1,
+                MatrixOperation::kNONE,
+            )
         } else {
-            let reshape_dims: Vec<i32> = dims1.iter().map(|&d| d as i32).collect();
+            let reshape_dims: Vec<i64> = dims1.iter().copied().collect();
             let rank_diff = rank0 - rank1;
-            let mut new_shape: Vec<i32> = vec![1; rank_diff];
+            let mut new_shape: Vec<i64> = vec![1i64; rank_diff];
             new_shape.extend(reshape_dims);
             let mut shuffle =
                 network
@@ -2669,19 +2646,25 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: unsqueeze shuffle: {}", e),
                     })?;
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
+            shuffle.set_reshape_dimensions(network, &new_shape).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Matmul: set reshape: {}", e),
                 }
             })?;
-            let reshaped1 = shuffle
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Matmul: shuffle output: {}", e),
-                })?;
-            network.add_matrix_multiply(input0, 0, &reshaped1, 0)
+            let reshaped1 =
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Matmul: shuffle output: {}", e),
+                    })?;
+            network.add_matrix_multiply(
+                input0,
+                MatrixOperation::kNONE,
+                &reshaped1,
+                MatrixOperation::kNONE,
+            )
         }
         .map_err(|e| GraphError::ConversionFailed {
             format: "trtx".to_string(),
@@ -2689,7 +2672,7 @@ impl TrtxConverter {
         })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -2707,21 +2690,21 @@ impl TrtxConverter {
 
     /// Reshape 1D batch-norm stats [C] to same rank as input with shape [1,...,1,C,1,...,1]
     /// so that the channel dimension aligns with the input's axis. TensorRT then broadcasts correctly.
-    fn reshape_batch_norm_stats_for_broadcast(
-        network: &mut trtx::NetworkDefinition,
-        stats: &trtx::Tensor,
-        input: &trtx::Tensor,
+    fn reshape_batch_norm_stats_for_broadcast<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        stats: &trtx::Tensor<'a>,
+        input: &trtx::Tensor<'a>,
         axis: i64,
         op_name: &str,
-    ) -> Result<trtx::Tensor, GraphError> {
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dims for {}: {}", op_name, e),
             })?;
         let stats_dims = stats
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get stats dims for {}: {}", op_name, e),
@@ -2733,7 +2716,7 @@ impl TrtxConverter {
         }
         axis_idx = axis_idx.max(0).min((rank.saturating_sub(1)) as i64);
         // Channel count: stats may be 1D [C], 4D [C,1,1,1], or 4D [1,C,1,1]; use product so we get C in all cases.
-        let c: i32 = stats_dims.iter().product::<i32>().max(1);
+        let c: i64 = stats_dims.iter().product::<i64>().max(1);
         // When stats are 4D [C,1,1,1], use a transpose-only shuffle so TensorRT sees [1,C,1,1].
         // (Transpose+reshape in one shuffle can leave logical shape as [C,1,1,1].)
         let is_4d_channel_first = rank >= 2
@@ -2757,13 +2740,13 @@ impl TrtxConverter {
                         ),
                     })?;
             shuffle
-                .set_first_transpose(&perm)
+                .set_first_transpose(network, &perm)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set transpose for {}: {}", op_name, e),
                 })?;
             return shuffle
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
@@ -2772,13 +2755,13 @@ impl TrtxConverter {
 
         // For 1D [C], reshape to [1,1,...,1,C] then transpose so C moves to axis_idx; avoids TensorRT giving [C,1,1,1].
         let (target_shape, need_second_transpose) = if stats_dims.len() == 1 {
-            let shape_last: Vec<i32> = (0..rank)
-                .map(|i| if i == rank - 1 { c } else { 1 })
+            let shape_last: Vec<i64> = (0..rank)
+                .map(|i| if i == rank - 1 { c } else { 1i64 })
                 .collect();
             (shape_last, true)
         } else {
-            let shape_axis: Vec<i32> = (0..rank)
-                .map(|i| if i as i64 == axis_idx { c } else { 1 })
+            let shape_axis: Vec<i64> = (0..rank)
+                .map(|i| if i as i64 == axis_idx { c } else { 1i64 })
                 .collect();
             (shape_axis, false)
         };
@@ -2788,18 +2771,21 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add shuffle for {}: {}", op_name, e),
             })?;
-        shuffle.set_reshape_dimensions(&target_shape).map_err(|e| {
+        shuffle
+            .set_reshape_dimensions(network, &target_shape)
+            .map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape for {}: {}", op_name, e),
             }
         })?;
-        let mut result = shuffle
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
-            })?;
+        let mut result =
+            shuffle
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
+                })?;
         if need_second_transpose {
             // Move dimension (rank-1) to axis_idx: perm[axis_idx] = rank-1, perm[rank-1] = axis_idx.
             let mut perm: Vec<i32> = (0..rank as i32).collect();
@@ -2813,13 +2799,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add second shuffle for {}: {}", op_name, e),
                     })?;
             shuffle2
-                .set_first_transpose(&perm)
+                .set_first_transpose(network, &perm)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set second transpose for {}: {}", op_name, e),
                 })?;
             result = shuffle2
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get second shuffle output for {}: {}", op_name, e),
@@ -2830,10 +2816,10 @@ impl TrtxConverter {
 
     /// Add batch normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias
-    fn add_batch_normalization_op(
+    fn add_batch_normalization_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         // Input operands: input, mean, variance, scale (optional), bias (optional)
@@ -2884,14 +2870,15 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add sub for batch norm: {}", e),
             })?;
-        let _ = sub_layer.set_layer_name("batch_norm_sub");
+        let _ = sub_layer.set_name(network, "batch_norm_sub");
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let x_minus_mean =
+            sub_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // Step 2: variance + epsilon (using constant)
         // Need to create a constant tensor with epsilon value
@@ -2914,14 +2901,15 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add sqrt for batch norm: {}", e),
                 })?;
-        let _ = sqrt_var_layer.set_layer_name("batch_norm_sqrt_var");
+        let _ = sqrt_var_layer.set_name(network, "batch_norm_sqrt_var");
 
-        let sqrt_var = sqrt_var_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
-            })?;
+        let sqrt_var =
+            sqrt_var_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // Step 4: (x - mean) / sqrt(variance + epsilon)
         let mut div_layer = network
@@ -2930,14 +2918,15 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add div for batch norm: {}", e),
             })?;
-        let _ = div_layer.set_layer_name("batch_norm_div");
+        let _ = div_layer.set_name(network, "batch_norm_div");
 
-        let normalized = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let normalized =
+            div_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Step 5: Apply scale if present (WebNN: scale is in MLBatchNormalizationOptions, not a positional input)
         let scale_id = operation
@@ -2967,14 +2956,15 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add mul for scale: {}", e),
                 })?;
-            let _ = mul_layer.set_layer_name("batch_norm_scale_mul");
+            let _ = mul_layer.set_name(network, "batch_norm_scale_mul");
 
-            result = mul_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mul output: {}", e),
-                })?;
+            result =
+                mul_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get mul output: {}", e),
+                    })?;
         }
 
         // Step 6: Apply bias if present (WebNN: bias is in MLBatchNormalizationOptions, not a positional input)
@@ -3004,14 +2994,15 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add bias: {}", e),
                 })?;
-            let _ = add_layer.set_layer_name("batch_norm_bias_add");
+            let _ = add_layer.set_name(network, "batch_norm_bias_add");
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3023,12 +3014,12 @@ impl TrtxConverter {
     /// Add instance normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias (WebNN spec)
     /// Computed per-instance over spatial dimensions
-    fn add_instance_normalization_op(
+    fn add_instance_normalization_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Instance normalization computes statistics per-instance (N, C) over spatial dims
         // Input operands: input, scale (optional), bias (optional)
@@ -3040,7 +3031,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to get input dimensions: {}", e),
@@ -3070,14 +3061,19 @@ impl TrtxConverter {
         }
 
         let mean_layer = network
-            .add_reduce(input, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                input,
+                ReduceOperation::kAVG.into(),
+                Axes::from_bits(axes_mask),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add mean reduce for instance norm: {}", e),
             })?;
 
         let mean = mean_layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get mean output: {}", e),
@@ -3091,12 +3087,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add sub for instance norm: {}", e),
             })?;
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let x_minus_mean =
+            sub_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // (x - mean)^2
         let square_layer = network
@@ -3106,31 +3103,38 @@ impl TrtxConverter {
                 reason: format!("Failed to add square for instance norm: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get square output: {}", e),
-            })?;
+        let squared =
+            square_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get square output: {}", e),
+                })?;
 
         // variance = mean((x - mean)^2)
         let var_layer = network
-            .add_reduce(&squared, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                &squared,
+                ReduceOperation::kAVG.into(),
+                Axes::from_bits(axes_mask),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add variance reduce for instance norm: {}", e),
             })?;
 
-        let variance = var_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get variance output: {}", e),
-            })?;
+        let variance =
+            var_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get variance output: {}", e),
+                })?;
 
         // variance + epsilon per WebNN spec (epsilon cast to input's dataType)
         let var_dims = variance
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to get variance dimensions: {}", e),
@@ -3161,18 +3165,16 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        temp_weights.push(epsilon_bytes);
-        let epsilon_ref = temp_weights.last().unwrap().as_slice();
-        let var_shape: Vec<i32> = var_dims.iter().map(|&d| d as i32).collect();
+        let var_shape: Vec<i64> = var_dims.iter().map(|&d| d as i64).collect();
         let epsilon_const = network
-            .add_constant(&var_shape, epsilon_ref, trt_dtype)
+            .add_small_constant_copied(&var_shape, &epsilon_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("InstanceNorm: failed to add epsilon constant: {}", e),
             })?;
         let epsilon_out =
             epsilon_const
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: epsilon const output: {}", e),
@@ -3185,7 +3187,7 @@ impl TrtxConverter {
             })?;
         let var_plus_eps_out =
             var_plus_eps
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: var_plus_eps output: {}", e),
@@ -3199,12 +3201,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add sqrt for instance norm: {}", e),
             })?;
 
-        let std_dev = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
-            })?;
+        let std_dev =
+            sqrt_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
@@ -3214,20 +3217,21 @@ impl TrtxConverter {
                 reason: format!("Failed to add div for instance norm: {}", e),
             })?;
 
-        let mut result = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let mut result =
+            div_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Build broadcast shape for scale/bias [C] to match input (TensorRT elementwise needs same rank).
-        let scale_broadcast_shape: Vec<i32> = if layout == "nchw" && !input_dims.is_empty() {
-            let mut s = vec![1i32; input_dims.len()];
+        let scale_broadcast_shape: Vec<i64> = if layout == "nchw" && !input_dims.is_empty() {
+            let mut s = vec![1i64; input_dims.len()];
             s[1] = input_dims[1];
             s
         } else if !input_dims.is_empty() {
-            let mut s = vec![1i32; input_dims.len()];
+            let mut s = vec![1i64; input_dims.len()];
             let last = input_dims.len() - 1;
             s[last] = input_dims[last];
             s
@@ -3270,15 +3274,17 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for scale: {}", e),
                     })?;
+            let scale_broadcast_i64: Vec<i64> =
+                scale_broadcast_shape.iter().map(|&d| d as i64).collect();
             scale_shuffle
-                .set_reshape_dimensions(&scale_broadcast_shape)
+                .set_reshape_dimensions(network, &scale_broadcast_i64)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set scale reshape: {}", e),
                 })?;
             let scale_bc =
                 scale_shuffle
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
@@ -3291,12 +3297,13 @@ impl TrtxConverter {
                     reason: format!("Failed to add mul for scale: {}", e),
                 })?;
 
-            result = mul_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mul output: {}", e),
-                })?;
+            result =
+                mul_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get mul output: {}", e),
+                    })?;
         }
 
         // Apply bias if present (add)
@@ -3315,18 +3322,21 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("InstanceNorm: failed to add shuffle for bias: {}", e),
                     })?;
+            let bias_broadcast_i64: Vec<i64> =
+                scale_broadcast_shape.iter().map(|&d| d as i64).collect();
             bias_shuffle
-                .set_reshape_dimensions(&scale_broadcast_shape)
+                .set_reshape_dimensions(network, &bias_broadcast_i64)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set bias reshape: {}", e),
                 })?;
-            let bias_bc = bias_shuffle
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
-                })?;
+            let bias_bc =
+                bias_shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
+                    })?;
 
             let add_layer = network
                 .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
@@ -3335,12 +3345,13 @@ impl TrtxConverter {
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3352,12 +3363,12 @@ impl TrtxConverter {
     /// Add layer normalization operation
     /// Formula: y = (x - mean) / sqrt(variance + epsilon) * scale + bias
     /// Computed over specified axes (typically last dimensions)
-    fn add_layer_normalization_op(
+    fn add_layer_normalization_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Layer normalization computes statistics over specified axes
         // Input operands: input, scale (optional), bias (optional)
@@ -3369,7 +3380,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input shape: {}", e),
@@ -3393,17 +3404,15 @@ impl TrtxConverter {
                 ),
                 _ => (0.0f32.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
             };
-            temp_weights.push(zero_bytes);
-            let zero_ref = temp_weights.last().unwrap().as_slice();
             let zero_const = network
-                .add_constant(&[1], zero_ref, zero_dtype)
+                .add_small_constant_copied(&[1], &zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm 0D: failed to add zero constant: {}", e),
                 })?;
             let mut result =
                 zero_const
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: zero const output: {}", e),
@@ -3426,31 +3435,33 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm 0D: failed to add bias shuffle: {}", e),
                         })?;
-                bias_shuffle.set_reshape_dimensions(&[1]).map_err(|e| {
+                bias_shuffle
+                    .set_reshape_dimensions(network, &[1i64])
+                    .map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),
                     }
                 })?;
-                let bias_bc =
-                    bias_shuffle
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
-                        })?;
+                let bias_bc = bias_shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
+                    }
+                })?;
                 let add_layer = network
                     .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm 0D: bias add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm 0D: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -3497,18 +3508,16 @@ impl TrtxConverter {
                     TrtDataType::kFLOAT,
                 ),
             };
-            temp_weights.push(zero_bytes);
-            let zero_ref = temp_weights.last().unwrap().as_slice();
-            let shape_i32: Vec<i32> = input_dims.iter().map(|&d| d as i32).collect();
+            let shape_i64: Vec<i64> = input_dims.iter().map(|&d| d as i64).collect();
             let zero_const = network
-                .add_constant(&shape_i32, zero_ref, zero_dtype.clone())
+                .add_small_constant_copied(&shape_i64, &zero_bytes, zero_dtype.clone())
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm axes=[]: failed to add zeros constant: {}", e),
                 })?;
             let mut result =
                 zero_const
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: zero const output: {}", e),
@@ -3555,10 +3564,8 @@ impl TrtxConverter {
                             (0..num_el).flat_map(|_| v.to_le_bytes()).collect()
                         }
                     };
-                    temp_weights.push(bias_broadcast_bytes);
-                    let bias_ref = temp_weights.last().unwrap().as_slice();
                     let bias_const = network
-                        .add_constant(&shape_i32, bias_ref, zero_dtype)
+                        .add_small_constant_copied(&shape_i64, &bias_broadcast_bytes, zero_dtype)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3567,7 +3574,7 @@ impl TrtxConverter {
                             ),
                         })?;
                     bias_const
-                        .get_output(0)
+                        .get_output(&*network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: bias const output: {}", e),
@@ -3580,10 +3587,8 @@ impl TrtxConverter {
                             .collect(),
                         _ => (0..num_el).flat_map(|_| 1.0f32.to_le_bytes()).collect(),
                     };
-                    temp_weights.push(ones_bytes);
-                    let ones_ref = temp_weights.last().unwrap().as_slice();
                     let ones_const = network
-                        .add_constant(&shape_i32, ones_ref, zero_dtype.clone())
+                        .add_small_constant_copied(&shape_i64, &ones_bytes, zero_dtype.clone())
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!(
@@ -3591,13 +3596,12 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    let ones_tensor =
-                        ones_const
-                            .get_output(0)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("LayerNorm axes=[]: ones const output: {}", e),
-                            })?;
+                    let ones_tensor = ones_const.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: ones const output: {}", e),
+                        }
+                    })?;
                     let (bias_bc, _) = Self::ensure_broadcast_compatible(
                         network,
                         bias,
@@ -3612,12 +3616,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm axes=[]: bias add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -3632,14 +3637,19 @@ impl TrtxConverter {
 
         // Compute mean: E[x]
         let mean_layer = network
-            .add_reduce(input, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                input,
+                ReduceOperation::kAVG.into(),
+                Axes::from_bits(axes_mask),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add mean reduce for layer norm: {}", e),
             })?;
 
         let mean = mean_layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get mean output: {}", e),
@@ -3653,12 +3663,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add sub for layer norm: {}", e),
             })?;
 
-        let x_minus_mean = sub_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sub output: {}", e),
-            })?;
+        let x_minus_mean =
+            sub_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sub output: {}", e),
+                })?;
 
         // (x - mean)^2
         let square_layer = network
@@ -3668,36 +3679,43 @@ impl TrtxConverter {
                 reason: format!("Failed to add square for layer norm: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get square output: {}", e),
-            })?;
+        let squared =
+            square_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get square output: {}", e),
+                })?;
 
         // variance = mean((x - mean)^2)
         let var_layer = network
-            .add_reduce(&squared, ReduceOperation::kAVG, axes_mask, true)
+            .add_reduce(
+                &squared,
+                ReduceOperation::kAVG.into(),
+                Axes::from_bits(axes_mask),
+                true,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add variance reduce for layer norm: {}", e),
             })?;
 
-        let variance = var_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get variance output: {}", e),
-            })?;
+        let variance =
+            var_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get variance output: {}", e),
+                })?;
 
         // variance + epsilon per WebNN spec (then sqrt)
         let var_dims = variance
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to get variance dimensions: {}", e),
             })?;
-        let var_shape: Vec<i32> = var_dims.iter().map(|&d| d as i32).collect();
+        let var_shape: Vec<i64> = var_dims.clone();
         let num_var_el: usize = var_dims.iter().map(|&d| d as usize).product();
         let input_operand = graph
             .operand(operation.input_operands()[0])
@@ -3722,17 +3740,15 @@ impl TrtxConverter {
                 TrtDataType::kFLOAT,
             ),
         };
-        temp_weights.push(epsilon_bytes);
-        let epsilon_ref = temp_weights.last().unwrap().as_slice();
         let epsilon_const = network
-            .add_constant(&var_shape, epsilon_ref, epsilon_dtype)
+            .add_small_constant_copied(&var_shape, &epsilon_bytes, epsilon_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("LayerNorm: failed to add epsilon constant: {}", e),
             })?;
         let epsilon_out =
             epsilon_const
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: epsilon const output: {}", e),
@@ -3745,7 +3761,7 @@ impl TrtxConverter {
             })?;
         let variance_eps =
             var_plus_eps
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: variance+eps output: {}", e),
@@ -3759,12 +3775,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add sqrt for layer norm: {}", e),
             })?;
 
-        let std_dev = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sqrt output: {}", e),
-            })?;
+        let std_dev =
+            sqrt_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sqrt output: {}", e),
+                })?;
 
         // (x - mean) / sqrt(variance + epsilon)
         let div_layer = network
@@ -3774,34 +3791,37 @@ impl TrtxConverter {
                 reason: format!("Failed to add div for layer norm: {}", e),
             })?;
 
-        let mut result = div_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get div output: {}", e),
-            })?;
+        let mut result =
+            div_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get div output: {}", e),
+                })?;
 
         // Reshape scale/bias so they broadcast to result. Scale/bias have shape [d_axes[0], d_axes[1], ...]
         // in axis order; result has input shape. Broadcast shape: for each result dim i, use
         // scale_bias dim at that axis position if i is in axes, else 1.
-        let reshape_scale_bias_to_result_rank = |network: &mut trtx::NetworkDefinition,
-                                                 tensor: &trtx::Tensor,
-                                                 result: &trtx::Tensor,
+        let reshape_scale_bias_to_result_rank = |network: &mut trtx::NetworkDefinition<'a>,
+                                                 tensor: &trtx::Tensor<'a>,
+                                                 result: &trtx::Tensor<'a>,
                                                  op_name: &str,
                                                  axes: &[u32]|
-         -> Result<trtx::Tensor, GraphError> {
-            let result_dims = result
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: result dims: {}", op_name, e),
-                })?;
-            let tensor_dims = tensor
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
-                })?;
+         -> Result<trtx::Tensor<'a>, GraphError> {
+            let result_dims =
+                result
+                    .dimensions(&*network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm {}: result dims: {}", op_name, e),
+                    })?;
+            let tensor_dims =
+                tensor
+                    .dimensions(&*network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("LayerNorm {}: tensor dims: {}", op_name, e),
+                    })?;
             if tensor_dims.len() >= result_dims.len() {
                 let id_layer =
                     network
@@ -3811,7 +3831,7 @@ impl TrtxConverter {
                             reason: format!("LayerNorm {}: identity: {}", op_name, e),
                         })?;
                 return id_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm {}: identity output: {}", op_name, e),
@@ -3862,20 +3882,23 @@ impl TrtxConverter {
                     })?;
             if let Some(ref perm) = transpose_perm {
                 shuffle
-                    .set_first_transpose(perm)
+                    .set_first_transpose(network, perm.as_slice())
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm {}: set transpose: {}", op_name, e),
                     })?;
             }
-            shuffle.set_reshape_dimensions(&new_shape).map_err(|e| {
+            let new_shape_i64: Vec<i64> = new_shape.iter().map(|&d| d as i64).collect();
+            shuffle
+                .set_reshape_dimensions(network, &new_shape_i64)
+                .map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm {}: set reshape: {}", op_name, e),
                 }
             })?;
             shuffle
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm {}: shuffle output: {}", op_name, e),
@@ -3910,12 +3933,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add bias: {}", e),
                     })?;
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get add output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get add output: {}", e),
+                        })?;
             } else {
                 let mul_layer = network
                     .add_elementwise(&result, &opt_1_bc, ElementWiseOperation::kPROD)
@@ -3923,12 +3947,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add scale: {}", e),
                     })?;
-                result = mul_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get mul output: {}", e),
-                    })?;
+                result =
+                    mul_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get mul output: {}", e),
+                        })?;
             }
         }
 
@@ -3949,12 +3974,13 @@ impl TrtxConverter {
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result = add_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get add output: {}", e),
-                })?;
+            result =
+                add_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get add output: {}", e),
+                    })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -3969,9 +3995,9 @@ impl TrtxConverter {
 
     /// Add reduction operation (sum, mean, max, min, product).
     /// Axes optional: when missing, default to all axes (0..rank). Empty axes -> identity.
-    fn add_reduce_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         reduce_op: ReduceOperation,
     ) -> Result<(), GraphError> {
@@ -3983,7 +4009,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Reduce: input dimensions: {}", e),
@@ -4004,12 +4030,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Reduce axes=[] identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Reduce axes=[] output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Reduce axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4023,14 +4050,19 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(input, reduce_op, axes_mask, keep_dims)
+            .add_reduce(
+                input,
+                reduce_op.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce operation: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4043,9 +4075,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceL1 operation: sum(abs(x)). Axes optional; empty axes -> output = abs(input).
-    fn add_reduce_l1_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_l1_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4062,15 +4094,16 @@ impl TrtxConverter {
                 reason: format!("Failed to add abs for L1: {}", e),
             })?;
 
-        let abs_output = abs_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get abs output: {}", e),
-            })?;
+        let abs_output =
+            abs_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get abs output: {}", e),
+                })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceL1: input dimensions: {}", e),
@@ -4097,14 +4130,19 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(&abs_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &abs_output,
+                ReduceOperation::kSUM.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for L1: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4118,10 +4156,10 @@ impl TrtxConverter {
 
     /// Add reduceL2 operation: sqrt(sum(x^2)). Axes optional; empty axes -> output = sqrt(x^2) = |x|.
     /// For float16 input, sum of squares can overflow; do reduce in float32 then cast back.
-    fn add_reduce_l2_op(
+    fn add_reduce_l2_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4145,14 +4183,14 @@ impl TrtxConverter {
 
         let square_output =
             square_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
                 })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceL2: input dimensions: {}", e),
@@ -4172,12 +4210,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("ReduceL2 axes=[] sqrt: {}", e),
                 })?;
-            let output = sqrt_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceL2 axes=[] output: {}", e),
-                })?;
+            let output =
+                sqrt_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceL2 axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4193,18 +4232,24 @@ impl TrtxConverter {
         // Always reduce in float32 to avoid overflow (sum of squares can exceed float16 range).
         let to_reduce = Self::cast_to_float32(network, &square_output)?;
         let sum_layer = network
-            .add_reduce(&to_reduce, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &to_reduce,
+                ReduceOperation::kSUM.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for L2: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let sum_output =
+            sum_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         let sqrt_layer = network
             .add_unary(&sum_output, UnaryOperation::kSQRT)
@@ -4213,12 +4258,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add sqrt for L2: {}", e),
             })?;
 
-        let sqrt_output = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let sqrt_output =
+            sqrt_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output = if input_dtype == DataType::Float16 {
             Self::cast_to_float16(network, &sqrt_output)?
@@ -4232,9 +4278,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceLogSum operation: log(sum(x)). Axes optional; empty axes -> output = log(x).
-    fn add_reduce_log_sum_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_log_sum_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4245,7 +4291,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceLogSum: input dimensions: {}", e),
@@ -4265,12 +4311,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("ReduceLogSum axes=[] log: {}", e),
                 })?;
-            let output = log_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceLogSum axes=[] output: {}", e),
-                })?;
+            let output =
+                log_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceLogSum axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4284,18 +4331,24 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let sum_layer = network
-            .add_reduce(input, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                input,
+                ReduceOperation::kSUM.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for LogSum: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let sum_output =
+            sum_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         // Then log
         let log_layer = network
@@ -4305,12 +4358,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add log for LogSum: {}", e),
             })?;
 
-        let output = log_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let output =
+            log_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4319,9 +4373,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceLogSumExp operation: log(sum(exp(x))). Axes optional; empty axes -> output = x.
-    fn add_reduce_log_sum_exp_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_log_sum_exp_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4338,15 +4392,16 @@ impl TrtxConverter {
                 reason: format!("Failed to add exp for LogSumExp: {}", e),
             })?;
 
-        let exp_output = exp_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get exp output: {}", e),
-            })?;
+        let exp_output =
+            exp_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get exp output: {}", e),
+                })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceLogSumExp: input dimensions: {}", e),
@@ -4367,12 +4422,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("ReduceLogSumExp axes=[] identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("ReduceLogSumExp axes=[] output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ReduceLogSumExp axes=[] output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4386,18 +4442,24 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let sum_layer = network
-            .add_reduce(&exp_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &exp_output,
+                ReduceOperation::kSUM.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for LogSumExp: {}", e),
             })?;
 
-        let sum_output = sum_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get sum output: {}", e),
-            })?;
+        let sum_output =
+            sum_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get sum output: {}", e),
+                })?;
 
         // Finally log
         let log_layer = network
@@ -4407,12 +4469,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add log for LogSumExp: {}", e),
             })?;
 
-        let output = log_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
+        let output =
+            log_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4421,9 +4484,9 @@ impl TrtxConverter {
     }
 
     /// Add reduceSumSquare operation: sum(x^2). Axes optional; empty axes -> output = x^2.
-    fn add_reduce_sum_square_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_reduce_sum_square_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4442,14 +4505,14 @@ impl TrtxConverter {
 
         let square_output =
             square_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
                 })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("ReduceSumSquare: input dimensions: {}", e),
@@ -4476,14 +4539,19 @@ impl TrtxConverter {
         let keep_dims = opts.map(|o| o.keep_dimensions).unwrap_or(false);
 
         let layer = network
-            .add_reduce(&square_output, ReduceOperation::kSUM, axes_mask, keep_dims)
+            .add_reduce(
+                &square_output,
+                ReduceOperation::kSUM.into(),
+                Axes::from_bits(axes_mask),
+                keep_dims,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add reduce for SumSquare: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4500,9 +4568,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add slice operation
-    fn add_slice_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_slice_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4544,12 +4612,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Slice no-op identity: {}", e),
                     })?;
-            let output = id_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Slice no-op output: {}", e),
-                })?;
+            let output =
+                id_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice no-op output: {}", e),
+                    })?;
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -4579,15 +4648,19 @@ impl TrtxConverter {
             })
             .collect();
 
+        let starts_i64: Vec<i64> = starts.iter().map(|&x| x as i64).collect();
+        let trt_sizes_i64: Vec<i64> = trt_sizes.iter().map(|&x| x as i64).collect();
+        let strides_i64: Vec<i64> = strides.iter().map(|&x| x as i64).collect();
+
         let layer = network
-            .add_slice(input, &starts, &trt_sizes, &strides)
+            .add_slice(input, &starts_i64, &trt_sizes_i64, &strides_i64)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add slice layer: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4600,9 +4673,9 @@ impl TrtxConverter {
     }
 
     /// Add split operation
-    fn add_split_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_split_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
@@ -4612,7 +4685,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Input operand {} not found", input_id),
             })?
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input shape: {}", e),
@@ -4671,13 +4744,13 @@ impl TrtxConverter {
             });
         }
 
-        let mut offset = 0i32;
+        let mut offset = 0i64;
         for (k, &size_k) in splits.iter().enumerate() {
-            let mut starts = vec![0i32; ndim];
+            let mut starts = vec![0i64; ndim];
             starts[axis as usize] = offset;
             let mut sizes = input_dims.clone();
-            sizes[axis as usize] = size_k;
-            let strides = vec![1i32; ndim];
+            sizes[axis as usize] = size_k as i64;
+            let strides = vec![1i64; ndim];
 
             let output = {
                 let input =
@@ -4694,7 +4767,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add slice layer for split {}: {}", k, e),
                     })?;
                 layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get layer output for split {}: {}", k, e),
@@ -4702,16 +4775,16 @@ impl TrtxConverter {
             };
 
             tensor_map.insert(output_ids[k], output);
-            offset += size_k;
+            offset += size_k as i64;
         }
 
         Ok(())
     }
 
     /// Add squeeze operation (remove dimensions of size 1)
-    fn add_squeeze_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_squeeze_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4739,7 +4812,7 @@ impl TrtxConverter {
         // For now, this creates the layer structure correctly
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4752,9 +4825,9 @@ impl TrtxConverter {
     }
 
     /// Add unsqueeze operation (add dimensions of size 1)
-    fn add_unsqueeze_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_unsqueeze_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -4798,7 +4871,7 @@ impl TrtxConverter {
         // with the expanded shape (inserting 1s at specified axes)
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4812,12 +4885,12 @@ impl TrtxConverter {
 
     /// Add expand operation (broadcast to new shape)
     /// Implemented as input * ones(new_shape) so elementwise broadcast produces the expanded tensor.
-    fn add_expand_op(
+    fn add_expand_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -4875,21 +4948,20 @@ impl TrtxConverter {
                 (data, trtx::DataType::kFLOAT)
             }
         };
-        temp_weights.push(ones_data);
-        let ones_ref = temp_weights.last().unwrap().as_slice();
-
+        let new_shape_i64: Vec<i64> = new_shape.iter().map(|&d| d as i64).collect();
         let ones_const = network
-            .add_constant(&new_shape, ones_ref, trt_dtype)
+            .add_small_constant_copied(&new_shape_i64, &ones_data, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create ones constant for expand: {}", e),
             })?;
-        let ones_tensor = ones_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get ones constant output: {}", e),
-            })?;
+        let ones_tensor =
+            ones_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get ones constant output: {}", e),
+                })?;
 
         let (bc_input, bc_ones) =
             Self::ensure_broadcast_compatible(network, input, &ones_tensor, "expand")?;
@@ -4900,12 +4972,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add multiply for expand: {}", e),
             })?;
-        let output = mul_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get expand output: {}", e),
-            })?;
+        let output =
+            mul_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get expand output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -4914,9 +4987,9 @@ impl TrtxConverter {
     }
 
     /// Add tile operation (repeat tensor along axes)
-    fn add_tile_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_tile_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let repetitions = match operation {
@@ -4956,7 +5029,8 @@ impl TrtxConverter {
                     })?;
 
             // Create a vector of references to the same tensor, repeated 'reps' times
-            let tensors_to_concat: Vec<&trtx::Tensor> = (0..reps).map(|_| current_tensor).collect();
+            let tensors_to_concat: Vec<&trtx::Tensor<'a>> =
+                (0..reps).map(|_| current_tensor).collect();
 
             // Concatenate along this axis
             let mut concat_layer = network.add_concatenation(&tensors_to_concat).map_err(|e| {
@@ -4967,17 +5041,12 @@ impl TrtxConverter {
             })?;
 
             // Set the concatenation axis
-            concat_layer
-                .set_axis(axis as i32)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to set concatenation axis {}: {}", axis, e),
-                })?;
+            concat_layer.set_axis(network, axis as i32);
 
             // Get the output tensor
             let output_tensor =
                 concat_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!(
@@ -5009,13 +5078,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add identity layer: {}", e),
                     }
                 })?;
-                let output_tensor =
-                    identity_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get identity output: {}", e),
-                        })?;
+                let output_tensor = identity_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    }
+                })?;
                 tensor_map.insert(output_id, output_tensor);
             }
         }
@@ -5028,9 +5096,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add greaterOrEqual operation (greater(x, y) OR equal(x, y))
-    fn add_greater_or_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_greater_or_equal_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5060,7 +5128,7 @@ impl TrtxConverter {
 
         let greater_output =
             greater_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get greater output: {}", e),
@@ -5073,12 +5141,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let or_layer = network
             .add_elementwise(&greater_output, &equal_output, ElementWiseOperation::kOR)
@@ -5087,12 +5156,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add OR layer: {}", e),
             })?;
 
-        let bool_output = or_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get OR output: {}", e),
-            })?;
+        let bool_output =
+            or_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get OR output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5104,9 +5174,9 @@ impl TrtxConverter {
     }
 
     /// Add lesserOrEqual operation (lesser(x, y) OR equal(x, y))
-    fn add_lesser_or_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_lesser_or_equal_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5136,7 +5206,7 @@ impl TrtxConverter {
 
         let lesser_output =
             lesser_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get lesser output: {}", e),
@@ -5149,12 +5219,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let or_layer = network
             .add_elementwise(&lesser_output, &equal_output, ElementWiseOperation::kOR)
@@ -5163,12 +5234,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add OR layer: {}", e),
             })?;
 
-        let bool_output = or_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get OR output: {}", e),
-            })?;
+        let bool_output =
+            or_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get OR output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5180,9 +5252,9 @@ impl TrtxConverter {
     }
 
     /// Add notEqual operation (NOT equal(x, y))
-    fn add_not_equal_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_not_equal_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input0 = tensor_map
@@ -5210,12 +5282,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add equal layer: {}", e),
             })?;
 
-        let equal_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get equal output: {}", e),
-            })?;
+        let equal_output =
+            equal_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get equal output: {}", e),
+                })?;
 
         let not_layer = network
             .add_unary(&equal_output, UnaryOperation::kNOT)
@@ -5224,12 +5297,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add NOT layer: {}", e),
             })?;
 
-        let bool_output = not_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get NOT output: {}", e),
-            })?;
+        let bool_output =
+            not_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get NOT output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -5246,12 +5320,12 @@ impl TrtxConverter {
 
     /// Add gather operation (gather elements along an axis using indices).
     /// Clamps indices to [-dim_size, dim_size - 1] to match WebNN/Chromium behavior and avoid TensorRT out-of-bounds.
-    fn add_gather_op(
+    fn add_gather_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -5314,6 +5388,7 @@ impl TrtxConverter {
             .iter()
             .map(|d| get_static_or_max_size(d) as i32)
             .collect();
+        let indices_shape_i64: Vec<i64> = indices_shape.iter().map(|&d| d as i64).collect();
 
         // Clamp indices to [-dim_size, dim_size - 1] (WebNN/conformance behavior).
         // TensorRT elementwise requires same rank; repeat scalar to match indices shape.
@@ -5331,37 +5406,33 @@ impl TrtxConverter {
         let max_data: Vec<u8> = (0..num_elements)
             .flat_map(|_| clamp_max_val.to_le_bytes())
             .collect();
-        temp_weights.push(min_data);
-        temp_weights.push(max_data);
-        let idx = temp_weights.len();
-        let min_ref = temp_weights[idx - 2].as_slice();
-        let max_ref = temp_weights[idx - 1].as_slice();
-
         let min_const = network
-            .add_constant(&indices_shape, min_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&indices_shape_i64, &min_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp min constant: {}", e),
             })?;
         let max_const = network
-            .add_constant(&indices_shape, max_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&indices_shape_i64, &max_data, trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather clamp max constant: {}", e),
             })?;
 
-        let min_const_out = min_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get clamp min output: {}", e),
-            })?;
-        let max_const_out = max_const
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get clamp max output: {}", e),
-            })?;
+        let min_const_out =
+            min_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get clamp min output: {}", e),
+                })?;
+        let max_const_out =
+            max_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get clamp max output: {}", e),
+                })?;
 
         let clamped_upper = network
             .add_elementwise(indices, &max_const_out, ElementWiseOperation::kMIN)
@@ -5371,7 +5442,7 @@ impl TrtxConverter {
             })?;
         let clamped_upper_out =
             clamped_upper
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get gather clamp upper output: {}", e),
@@ -5387,12 +5458,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add gather indices clamp (max): {}", e),
             })?;
-        let clamped_indices = clamped
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get gather clamped indices output: {}", e),
-            })?;
+        let clamped_indices =
+            clamped
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get gather clamped indices output: {}", e),
+                })?;
 
         let layer = network
             .add_gather(input, &clamped_indices, axis)
@@ -5402,7 +5474,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gather output: {}", e),
@@ -5415,9 +5487,9 @@ impl TrtxConverter {
     }
 
     /// Add gatherND operation (N-dimensional gather)
-    fn add_gather_nd_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_gather_nd_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -5447,15 +5519,10 @@ impl TrtxConverter {
                 })?;
 
         // Set gather mode to kND for N-dimensional gather
-        layer
-            .set_gather_mode(trtx::GatherMode::kND)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set gather mode to kND: {}", e),
-            })?;
+        layer.set_gather_mode(network, trtx::GatherMode::kND);
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherND output: {}", e),
@@ -5468,9 +5535,9 @@ impl TrtxConverter {
     }
 
     /// Add scatterElements operation (element-wise scatter)
-    fn add_scatter_elements_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_scatter_elements_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let data = tensor_map
@@ -5516,15 +5583,10 @@ impl TrtxConverter {
             })?;
 
         // Set axis for element-wise scatter
-        layer
-            .set_axis(axis)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set scatter axis: {}", e),
-            })?;
+        layer.set_axis(network, axis);
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterElements output: {}", e),
@@ -5537,9 +5599,9 @@ impl TrtxConverter {
     }
 
     /// Add scatterND operation (N-dimensional scatter)
-    fn add_scatter_nd_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_scatter_nd_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let data = tensor_map
@@ -5578,7 +5640,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterND output: {}", e),
@@ -5591,16 +5653,18 @@ impl TrtxConverter {
     }
 
     /// Add argMax operation (find indices of maximum values)
-    fn add_arg_max_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_arg_max_op<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
+        let input_id = operation.input_operands()[0];
         let input = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&input_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", input_id),
             })?;
 
         let (axis, keep_dims) = match operation {
@@ -5616,45 +5680,101 @@ impl TrtxConverter {
             }
         };
 
-        // TopK operation: 0=kMAX, 1=kMIN
-        let layer = network
-            .add_topk(input, 0, 1, 1u32 << axis) // operation=kMAX, k=1, axes as bitmask
-            .map_err(|e| GraphError::ConversionFailed {
+        let input_shape = graph
+            .operand(input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to add topK layer: {}", e),
+                reason: format!("ArgMax input operand {} not in graph", input_id),
+            })?
+            .descriptor
+            .static_or_max_shape();
+        let target_shape_u32 = infer_arg_reduce_shape(&input_shape, axis, keep_dims)?;
+        let target_shape_i64: Vec<i64> = target_shape_u32.iter().map(|&d| d as i64).collect();
+
+        // TensorRT TopK requires at least 2 input dimensions. For 1D [N], use [N, 1] and reduce axis 0.
+        let layer = if input_shape.len() == 1 {
+            let n = input_shape[0] as i64;
+            let mut shuffle_in =
+                network
+                    .add_shuffle(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ArgMax: unsqueeze 1D input for TopK: {}", e),
+                    })?;
+            shuffle_in
+                .set_reshape_dimensions(network, &[n, 1])
+                .map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMax: set [N,1] reshape: {}", e),
+                }
             })?;
+            let rank2 =
+                shuffle_in
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ArgMax: rank-2 TopK input: {}", e),
+                    })?;
+            network
+                .add_topk(
+                    &rank2,
+                    TopKOperation::kMAX,
+                    1,
+                    Axes::from_bits(1u32),
+                ) // kMAX along axis 0 of [N,1]
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add topK layer: {}", e),
+                })?
+        } else {
+            network
+                .add_topk(
+                    input,
+                    TopKOperation::kMAX,
+                    1,
+                    Axes::from_bits(1u32 << axis),
+                ) // kMAX, k=1, axes bitmask
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add topK layer: {}", e),
+                })?
+        };
 
         // TopK returns two outputs: values and indices
         // We want indices (output 1)
-        let indices_output = layer
-            .get_output(1)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get topK indices output: {}", e),
-            })?;
-
-        let squeezed_output = if !keep_dims {
-            // Squeeze the k dimension (which is 1)
-            let squeeze_layer =
-                network
-                    .add_shuffle(&indices_output)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add squeeze layer: {}", e),
-                    })?;
-
-            squeeze_layer
-                .get_output(0)
+        let indices_output =
+            layer
+                .get_output(&*network, 1)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Failed to get squeeze output: {}", e),
-                })?
-        } else {
-            indices_output
-        };
+                    reason: format!("Failed to get topK indices output: {}", e),
+                })?;
+
+        // TopK keeps the reduced axis as size k (=1). Reshape to WebNN argMax output rank.
+        let mut shuffle_layer =
+            network
+                .add_shuffle(&indices_output)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMax: shuffle for output shape: {}", e),
+                })?;
+        shuffle_layer
+            .set_reshape_dimensions(network, &target_shape_i64)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("ArgMax: set reshape dimensions: {}", e),
+            })?;
+        let shaped_output =
+            shuffle_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMax: shuffle output: {}", e),
+                })?;
 
         // Cast INT32 indices to Float32 for WebNN compatibility
-        let final_output = Self::cast_int32_to_float32(network, &squeezed_output)?;
+        let final_output = Self::cast_int32_to_float32(network, &shaped_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -5663,16 +5783,18 @@ impl TrtxConverter {
     }
 
     /// Add argMin operation (find indices of minimum values)
-    fn add_arg_min_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_arg_min_op<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
+        let input_id = operation.input_operands()[0];
         let input = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&input_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", input_id),
             })?;
 
         let (axis, keep_dims) = match operation {
@@ -5688,45 +5810,101 @@ impl TrtxConverter {
             }
         };
 
-        // TopK operation: 0=kMAX, 1=kMIN
-        let layer = network
-            .add_topk(input, 1, 1, 1u32 << axis) // operation=kMIN, k=1, axes as bitmask
-            .map_err(|e| GraphError::ConversionFailed {
+        let input_shape = graph
+            .operand(input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to add topK layer: {}", e),
+                reason: format!("ArgMin input operand {} not in graph", input_id),
+            })?
+            .descriptor
+            .static_or_max_shape();
+        let target_shape_u32 = infer_arg_reduce_shape(&input_shape, axis, keep_dims)?;
+        let target_shape_i64: Vec<i64> = target_shape_u32.iter().map(|&d| d as i64).collect();
+
+        let layer = if input_shape.len() == 1 {
+            let n = input_shape[0] as i64;
+            let mut shuffle_in =
+                network
+                    .add_shuffle(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ArgMin: unsqueeze 1D input for TopK: {}", e),
+                    })?;
+            shuffle_in
+                .set_reshape_dimensions(network, &[n, 1])
+                .map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMin: set [N,1] reshape: {}", e),
+                }
             })?;
+            let rank2 =
+                shuffle_in
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("ArgMin: rank-2 TopK input: {}", e),
+                    })?;
+            network
+                .add_topk(
+                    &rank2,
+                    TopKOperation::kMIN,
+                    1,
+                    Axes::from_bits(1u32),
+                ) // kMIN along axis 0 of [N,1]
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add topK layer: {}", e),
+                })?
+        } else {
+            network
+                .add_topk(
+                    input,
+                    TopKOperation::kMIN,
+                    1,
+                    Axes::from_bits(1u32 << axis),
+                )
+                .map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to add topK layer: {}", e),
+                    }
+                })?
+        };
 
         // TopK returns two outputs: values and indices
         // We want indices (output 1)
-        let indices_output = layer
-            .get_output(1)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get topK indices output: {}", e),
-            })?;
-
-        let squeezed_output = if !keep_dims {
-            // Squeeze the k dimension (which is 1)
-            let squeeze_layer =
-                network
-                    .add_shuffle(&indices_output)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add squeeze layer: {}", e),
-                    })?;
-
-            squeeze_layer
-                .get_output(0)
+        let indices_output =
+            layer
+                .get_output(&*network, 1)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Failed to get squeeze output: {}", e),
-                })?
-        } else {
-            indices_output
-        };
+                    reason: format!("Failed to get topK indices output: {}", e),
+                })?;
+
+        let mut shuffle_layer =
+            network
+                .add_shuffle(&indices_output)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMin: shuffle for output shape: {}", e),
+                })?;
+        shuffle_layer
+            .set_reshape_dimensions(network, &target_shape_i64)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("ArgMin: set reshape dimensions: {}", e),
+            })?;
+        let shaped_output =
+            shuffle_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("ArgMin: shuffle output: {}", e),
+                })?;
 
         // Cast INT32 indices to Float32 for WebNN compatibility
-        let final_output = Self::cast_int32_to_float32(network, &squeezed_output)?;
+        let final_output = Self::cast_int32_to_float32(network, &shaped_output)?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -5739,12 +5917,12 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add clamp operation (clip values to range [min, max])
-    fn add_clamp_op(
+    fn add_clamp_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -5766,7 +5944,7 @@ impl TrtxConverter {
         let num_dims = input_operand.descriptor.shape.len();
         let input_dtype = input_operand.descriptor.data_type;
         // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
 
         // Get min and max values from attributes (handle "Infinity"/"-Infinity"/"NaN" strings from WPT).
         let parse_clamp_bound_f32 = |v: &serde_json::Value| -> Option<f32> {
@@ -5897,10 +6075,8 @@ impl TrtxConverter {
 
         // Implement clamp as: max(min_value, min(input, max_value))
         // First: min(input, max_value)
-        temp_weights.push(max_bytes);
-        let max_const_data = temp_weights.last().unwrap();
         let max_const = network
-            .add_constant(&broadcast_shape, max_const_data, trt_dtype.clone())
+            .add_small_constant_copied(&broadcast_shape, &max_bytes, trt_dtype.clone())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add max constant: {}", e),
@@ -5908,7 +6084,7 @@ impl TrtxConverter {
 
         let max_const_output =
             max_const
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get max constant output: {}", e),
@@ -5923,17 +6099,15 @@ impl TrtxConverter {
 
         let clamped_upper_output =
             clamped_upper
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get upper clamp output: {}", e),
                 })?;
 
         // Second: max(min_value, clamped_upper)
-        temp_weights.push(min_bytes);
-        let min_const_data = temp_weights.last().unwrap();
         let min_const = network
-            .add_constant(&broadcast_shape, min_const_data, trt_dtype)
+            .add_small_constant_copied(&broadcast_shape, &min_bytes, trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add min constant: {}", e),
@@ -5941,7 +6115,7 @@ impl TrtxConverter {
 
         let min_const_output =
             min_const
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get min constant output: {}", e),
@@ -5959,7 +6133,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get clamp output: {}", e),
@@ -5972,9 +6146,9 @@ impl TrtxConverter {
     }
 
     /// Add where operation (select elements based on condition)
-    fn add_where_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_where_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let condition = tensor_map
@@ -6018,7 +6192,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get select output: {}", e),
@@ -6031,12 +6205,12 @@ impl TrtxConverter {
     }
 
     /// Add linear operation (alpha * x + beta)
-    fn add_linear_op(
+    fn add_linear_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -6057,7 +6231,7 @@ impl TrtxConverter {
             })?;
         let num_dims = input_operand.descriptor.shape.len();
         // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i32> = vec![1; num_dims];
+        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
 
         let attrs = operation.attributes();
         let linear_opts = attrs.as_linear();
@@ -6077,23 +6251,19 @@ impl TrtxConverter {
                 ),
                 _ => (alpha.to_le_bytes().to_vec(), trtx::DataType::kFLOAT),
             };
-            temp_weights.push(alpha_bytes);
-            let alpha_bytes_ref = temp_weights.last().unwrap();
-
             let alpha_constant = network
-                .add_constant(&broadcast_shape, alpha_bytes_ref, alpha_dtype)
+                .add_small_constant_copied(&broadcast_shape, &alpha_bytes, alpha_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let alpha_tensor =
-                alpha_constant
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get alpha constant output: {}", e),
-                    })?;
+            let alpha_tensor = alpha_constant.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get alpha constant output: {}", e),
+                }
+            })?;
 
             // Multiply: alpha * x
             let mul_layer = network
@@ -6104,7 +6274,7 @@ impl TrtxConverter {
                 })?;
 
             mul_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get multiply output: {}", e),
@@ -6119,7 +6289,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add identity layer: {}", e),
                     })?;
             identity_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -6136,11 +6306,8 @@ impl TrtxConverter {
                 ),
                 _ => (beta.to_le_bytes().to_vec(), trtx::DataType::kFLOAT),
             };
-            temp_weights.push(beta_bytes);
-            let beta_bytes_ref = temp_weights.last().unwrap();
-
             let beta_constant = network
-                .add_constant(&broadcast_shape, beta_bytes_ref, beta_dtype)
+                .add_small_constant_copied(&broadcast_shape, &beta_bytes, beta_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create beta constant: {}", e),
@@ -6148,7 +6315,7 @@ impl TrtxConverter {
 
             let beta_tensor =
                 beta_constant
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get beta constant output: {}", e),
@@ -6163,7 +6330,7 @@ impl TrtxConverter {
                 })?;
 
             add_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get add output: {}", e),
@@ -6179,9 +6346,9 @@ impl TrtxConverter {
     }
 
     /// Add pad operation (pad tensor with constant/edge/reflection values)
-    fn add_pad_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_pad_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -6225,7 +6392,7 @@ impl TrtxConverter {
 
         // Get input dimensions
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dimensions: {}", e),
@@ -6249,7 +6416,7 @@ impl TrtxConverter {
                 original_ndims
             );
             // Calculate 4D shape: pad with 1s on the left
-            let mut shape_4d = vec![1; 4 - original_ndims];
+            let mut shape_4d: Vec<i64> = vec![1i64; 4 - original_ndims];
             shape_4d.extend_from_slice(&input_dims);
             eprintln!("[PAD DEBUG] Shape 4D: {:?}", shape_4d);
 
@@ -6263,14 +6430,14 @@ impl TrtxConverter {
                     })?;
 
             reshape_layer
-                .set_reshape_dimensions(&shape_4d)
+                .set_reshape_dimensions(network, &shape_4d)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set reshape dimensions: {}", e),
                 })?;
 
             reshape_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape output: {}", e),
@@ -6286,7 +6453,7 @@ impl TrtxConverter {
                         reason: format!("Failed to create identity layer: {}", e),
                     })?;
             identity
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -6300,20 +6467,21 @@ impl TrtxConverter {
         let spatial_dims = 2; // H, W dimensions in NCHW
 
         // Right-align: If we have fewer than 2 padding values, pad LEFT with zeros
-        let mut pre_padding_spatial = vec![0; spatial_dims];
-        let mut post_padding_spatial = vec![0; spatial_dims];
+        let mut pre_padding_spatial: Vec<i64> = vec![0; spatial_dims];
+        let mut post_padding_spatial: Vec<i64> = vec![0; spatial_dims];
 
         let len = pre_padding.len().min(spatial_dims);
         let pad_offset = spatial_dims.saturating_sub(pre_padding.len());
-        let pad_offset_end = pad_offset + len;
 
-        pre_padding_spatial[pad_offset..pad_offset_end].copy_from_slice(&pre_padding[..len]);
-        post_padding_spatial[pad_offset..pad_offset_end].copy_from_slice(&post_padding[..len]);
+        for i in 0..len {
+            pre_padding_spatial[pad_offset + i] = pre_padding[i] as i64;
+            post_padding_spatial[pad_offset + i] = post_padding[i] as i64;
+        }
 
         // Check actual dimensions of input_to_pad
         let input_to_pad_dims =
             input_to_pad
-                .dimensions()
+                .dimensions(&*network)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get input_to_pad dimensions: {}", e),
@@ -6346,7 +6514,7 @@ impl TrtxConverter {
 
         let padded_output =
             padding_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get padding output: {}", e),
@@ -6358,7 +6526,7 @@ impl TrtxConverter {
             let mut output_shape = input_dims.clone();
             for (i, (&pre, &post)) in pre_padding.iter().zip(post_padding.iter()).enumerate() {
                 if i < output_shape.len() {
-                    output_shape[i] += pre + post;
+                    output_shape[i] += (pre + post) as i64;
                 }
             }
 
@@ -6371,14 +6539,14 @@ impl TrtxConverter {
                     })?;
 
             reshape_back
-                .set_reshape_dimensions(&output_shape)
+                .set_reshape_dimensions(network, &output_shape)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to set reshape-back dimensions: {}", e),
                 })?;
 
             reshape_back
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape-back output: {}", e),
@@ -6395,11 +6563,11 @@ impl TrtxConverter {
 
     /// Add GEMM (General Matrix Multiply) operation
     /// Computes: C = alpha * A * B + beta * C
-    fn add_gemm_op(
+    fn add_gemm_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
+        _temp_weights: &mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_a = tensor_map
@@ -6425,13 +6593,13 @@ impl TrtxConverter {
 
         // Get actual dimensions for validation
         let _dims_a = input_a
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input A dimensions: {}", e),
             })?;
         let _dims_b = input_b
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input B dimensions: {}", e),
@@ -6453,38 +6621,28 @@ impl TrtxConverter {
         // This would only work if B was already [1280, 1000]!
         //
         // Try swapping operands and transpose flags to match TensorRT's expectations
-        use trtx::MatrixOperation;
-
         // Swap: instead of A @ B^T, try B^T @ A^T (which gives same result transposed)
         // NO wait - let's try: B @ A instead since B^T @ A^T = (A @ B)^T
         //
         // Actually, for WebNN: output = A @ B^T
         // Try: output = (B @ A^T)^T = A @ B^T (mathematically equivalent)
         let (mat_a, mat_b, op_a, op_b) = if b_transpose && !a_transpose {
-            // Original: A @ B^T
-            // Our input_a: [1, 1280], input_b: [1000, 1280]
-            // Try: use B @ A^T and then transpose result
-            // B: [1000, 1280] @ A^T: [1280, 1] = [1000, 1]
-            // Then transpose to [1, 1000]
-            //
-            // But we can't easily transpose the result...
-            // Let's just try the transpose flags as-is first
             (
                 input_a,
                 input_b,
-                MatrixOperation::kNONE as i32,
-                MatrixOperation::kTRANSPOSE as i32,
+                MatrixOperation::kNONE,
+                MatrixOperation::kTRANSPOSE,
             )
         } else {
             let a_op = if a_transpose {
-                MatrixOperation::kTRANSPOSE as i32
+                MatrixOperation::kTRANSPOSE
             } else {
-                MatrixOperation::kNONE as i32
+                MatrixOperation::kNONE
             };
             let b_op = if b_transpose {
-                MatrixOperation::kTRANSPOSE as i32
+                MatrixOperation::kTRANSPOSE
             } else {
-                MatrixOperation::kNONE as i32
+                MatrixOperation::kNONE
             };
             (input_a, input_b, a_op, b_op)
         };
@@ -6497,34 +6655,32 @@ impl TrtxConverter {
                 reason: format!("Failed to add GEMM matrix multiply: {}", e),
             })?;
 
-        let mut result = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get GEMM layer output: {}", e),
-            })?;
+        let mut result =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get GEMM layer output: {}", e),
+                })?;
 
         // If alpha != 1.0, scale the result
         if (alpha - 1.0).abs() > 1e-6 {
             // Get result dimensions to create a constant with matching shape
-            let result_dims = result
-                .dimensions()
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get result dimensions: {}", e),
-                })?;
+            let result_dims =
+                result
+                    .dimensions(&*network)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get result dimensions: {}", e),
+                    })?;
 
             // Create constant filled with alpha value matching result shape
             let num_elements: usize = result_dims.iter().map(|&d| d as usize).product();
             let alpha_data: Vec<f32> = vec![alpha; num_elements];
             let alpha_bytes: Vec<u8> = alpha_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-            // Store weights to keep them alive until engine serialization
-            temp_weights.push(alpha_bytes);
-            let alpha_bytes_ref = temp_weights.last().unwrap().as_slice();
-
             let alpha_layer = network
-                .add_constant(&result_dims, alpha_bytes_ref, TrtDataType::kFLOAT)
+                .add_small_constant_copied(&result_dims, &alpha_bytes, TrtDataType::kFLOAT)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
@@ -6532,7 +6688,7 @@ impl TrtxConverter {
 
             let alpha_tensor =
                 alpha_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get alpha tensor: {}", e),
@@ -6546,12 +6702,13 @@ impl TrtxConverter {
                     reason: format!("Failed to scale by alpha: {}", e),
                 })?;
 
-            result = scale_layer
-                .get_output(0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get scaled output: {}", e),
-                })?;
+            result =
+                scale_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get scaled output: {}", e),
+                    })?;
         }
 
         // If there's a C input and beta != 0, add it
@@ -6566,36 +6723,32 @@ impl TrtxConverter {
             // Scale C by beta if needed, then add to result
             if (beta - 1.0).abs() > 1e-6 {
                 // Get C dimensions to create a constant with matching shape
-                let c_dims = input_c
-                    .dimensions()
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get C dimensions: {}", e),
-                    })?;
+                let c_dims =
+                    input_c
+                        .dimensions(&*network)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get C dimensions: {}", e),
+                        })?;
 
                 // Create constant filled with beta value matching C shape
                 let num_elements: usize = c_dims.iter().map(|&d| d as usize).product();
                 let beta_data: Vec<f32> = vec![beta; num_elements];
                 let beta_bytes: Vec<u8> = beta_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-                // Store weights to keep them alive until engine serialization
-                temp_weights.push(beta_bytes);
-                let beta_bytes_ref = temp_weights.last().unwrap().as_slice();
-
                 let beta_layer = network
-                    .add_constant(&c_dims, beta_bytes_ref, TrtDataType::kFLOAT)
+                    .add_small_constant_copied(&c_dims, &beta_bytes, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to create beta constant: {}", e),
                     })?;
 
-                let beta_tensor =
-                    beta_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get beta tensor: {}", e),
-                        })?;
+                let beta_tensor = beta_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get beta tensor: {}", e),
+                    }
+                })?;
 
                 // Multiply C by beta
                 let scale_c_layer = network
@@ -6605,13 +6758,12 @@ impl TrtxConverter {
                         reason: format!("Failed to scale C by beta: {}", e),
                     })?;
 
-                let scaled_c =
-                    scale_c_layer
-                        .get_output(0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get scaled C: {}", e),
-                        })?;
+                let scaled_c = scale_c_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get scaled C: {}", e),
+                    }
+                })?;
 
                 // Add result + beta*C
                 let add_layer = network
@@ -6621,12 +6773,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add scaled C to result: {}", e),
                     })?;
 
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             } else {
                 // beta == 1.0: add C directly
                 let add_layer = network
@@ -6636,12 +6789,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add C to result: {}", e),
                     })?;
 
-                result = add_layer
-                    .get_output(0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    })?;
+                result =
+                    add_layer
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             }
         }
 
@@ -6652,11 +6806,10 @@ impl TrtxConverter {
     }
 
     /// Add 2D convolution operation
-    fn add_conv2d_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+    fn add_conv2d_op<'a>(
+        graph: &'a GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -6684,7 +6837,7 @@ impl TrtxConverter {
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("oihw");
-        let (o, _i, h, w): (u32, u32, u32, u32) = match filter_layout {
+        let (o, in_ch, h, w): (u32, u32, u32, u32) = match filter_layout {
             "oihw" => (fs[0], fs[1], fs[2], fs[3]),
             "hwio" => (fs[3], fs[2], fs[0], fs[1]),
             "ohwi" => (fs[0], fs[3], fs[1], fs[2]),
@@ -6705,11 +6858,12 @@ impl TrtxConverter {
             .contains_key(&filter_id);
 
         // When filter is non-constant we use ILayer::setInput(1, kernel) / setInput(2, bias); kernel/bias weights must be empty.
-        let (filter_data_to_use, bias_data) = if filter_constant {
+        // Promoted layouts / f16 use `add_convolution_owned_weights` so slices are not tied to `&'a GraphInfo` for the whole op loop.
+        let (filter_data_to_use, bias_data, conv_weights_owned) = if filter_constant {
             let filter_shape_u32 = filter_operand.descriptor.static_or_max_shape();
             let filter_data = Self::get_constant_data(graph, filter_id)?;
-            // Get optional bias - operand 2 if present.
-            let (bias_temp_index, bias_raw): (Option<usize>, Option<&[u8]>) = match bias_id {
+            let mut bias_promoted: Option<Vec<u8>> = None;
+            let bias_raw: Option<&[u8]> = match bias_id {
                 Some(id) => {
                     if !graph.constant_operand_ids_to_handles.contains_key(&id) {
                         return Err(GraphError::ConversionFailed {
@@ -6723,17 +6877,17 @@ impl TrtxConverter {
                         .map(|o| o.descriptor.data_type)
                         .unwrap_or(DataType::Float32);
                     if dtype == DataType::Float16 {
-                        let f32_bias = Self::f16_bytes_to_f32_bytes(raw)?;
-                        temp_weights.push(f32_bias);
-                        (Some(temp_weights.len() - 1), None)
+                        bias_promoted = Some(Self::f16_bytes_to_f32_bytes(raw)?);
+                        None
                     } else {
-                        (None, Some(raw))
+                        Some(raw)
                     }
                 }
-                None => (None, None),
+                None => None,
             };
             let filter_dtype = filter_operand.descriptor.data_type;
-            let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
+            let mut kernel_promoted: Option<Vec<u8>> = None;
+            match (filter_dtype, filter_layout) {
                 (DataType::Float16, _) => {
                     let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
                     let oihw = if filter_layout == "oihw" {
@@ -6741,15 +6895,15 @@ impl TrtxConverter {
                     } else {
                         Self::conv_filter_to_oihw(&f32_bytes, filter_layout, &filter_shape_u32)?
                     };
-                    temp_weights.push(oihw);
-                    Some(temp_weights.len() - 1)
+                    kernel_promoted = Some(oihw);
                 }
-                (DataType::Float32, "oihw") => None,
+                (DataType::Float32, "oihw") => {}
                 (DataType::Float32, _) => {
-                    let oihw =
-                        Self::conv_filter_to_oihw(filter_data, filter_layout, &filter_shape_u32)?;
-                    temp_weights.push(oihw);
-                    Some(temp_weights.len() - 1)
+                    kernel_promoted = Some(Self::conv_filter_to_oihw(
+                        filter_data,
+                        filter_layout,
+                        &filter_shape_u32,
+                    )?);
                 }
                 _ => {
                     return Err(GraphError::ConversionFailed {
@@ -6761,15 +6915,36 @@ impl TrtxConverter {
                     });
                 }
             };
-            let bias_data: Option<&[u8]> = match bias_temp_index {
-                Some(idx) => Some(temp_weights[idx].as_slice()),
-                None => bias_raw,
+            let conv_weights_owned = if kernel_promoted.is_some() || bias_promoted.is_some() {
+                let conv_kernel_const_shape: Vec<i64> =
+                    vec![o as i64, in_ch as i64, h as i64, w as i64];
+                let kernel_values =
+                    kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
+                let bias_values = match (bias_promoted, bias_raw) {
+                    (Some(b), _) => Some(b),
+                    (None, Some(br)) => Some(br.to_vec()),
+                    (None, None) => None,
+                };
+                Some(OwnedConvWeights {
+                    kernel: OwnedWeights {
+                        shape: conv_kernel_const_shape,
+                        data_type: TrtDataType::kFLOAT,
+                        values: kernel_values,
+                    },
+                    bias: bias_values.map(|values| OwnedWeights {
+                        shape: vec![num_output_maps as i64],
+                        data_type: TrtDataType::kFLOAT,
+                        values,
+                    }),
+                })
+            } else {
+                None
             };
-            let filter_data_to_use: &[u8] = match filter_temp_index {
-                Some(idx) => temp_weights[idx].as_slice(),
-                None => filter_data,
-            };
-            (Some(filter_data_to_use), bias_data)
+            if conv_weights_owned.is_some() {
+                (None, None, conv_weights_owned)
+            } else {
+                (Some(filter_data), bias_raw, None)
+            }
         } else {
             // Non-constant filter: use tensor inputs (setInput(1)=kernel, setInput(2)=bias). TensorRT expects OIHW for kernel.
             if filter_layout != "oihw" {
@@ -6787,7 +6962,7 @@ impl TrtxConverter {
                     });
                 }
             }
-            (None, None)
+            (None, None, None)
         };
 
         // Input layout: nchw (default) or nhwc. TensorRT conv is NCHW; we use IShuffleLayer::setFirstTranspose for NHWC.
@@ -6816,7 +6991,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 3, 1, 2]).map_err(|e| {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
@@ -6824,7 +7001,7 @@ impl TrtxConverter {
             })?;
             Some(
                 shuffle
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC shuffle output: {}", e),
@@ -6836,24 +7013,23 @@ impl TrtxConverter {
         let pre_conv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
         // TensorRT conv kernel is always Float; cast Half input to Float so types match.
-        let half_cast_output: Option<trtx::Tensor> = if input_dtype == DataType::Float16 {
-            let cast_layer = network
-                .add_cast(pre_conv_input, TrtDataType::kFLOAT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Conv2d Half->Float cast: {}", e),
-                })?;
-            Some(
-                cast_layer
-                    .get_output(0)
+        let half_cast_output: Option<trtx::Tensor<'a>> =
+            if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pre_conv_input, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("Conv2d Half->Float cast: {}", e),
+                    })?;
+                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("Conv2d cast output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let conv_input_source = half_cast_output.as_ref().unwrap_or(pre_conv_input);
 
         // Stride, padding, dilation, groups from typed options
@@ -6892,15 +7068,17 @@ impl TrtxConverter {
         // Use explicit padding layer if any padding is specified
         let conv_input =
             if pre_padding.iter().any(|&p| p != 0) || post_padding.iter().any(|&p| p != 0) {
+                let pre_pad_i64: Vec<i64> = pre_padding.iter().map(|&p| p as i64).collect();
+                let post_pad_i64: Vec<i64> = post_padding.iter().map(|&p| p as i64).collect();
                 let padding_layer = network
-                    .add_padding(&conv_input_source, &pre_padding, &post_padding)
+                    .add_padding(&conv_input_source, &pre_pad_i64, &post_pad_i64)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add padding layer: {}", e),
                     })?;
 
                 padding_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get padding layer output: {}", e),
@@ -6914,7 +7092,7 @@ impl TrtxConverter {
                     }
                 })?;
                 id_layer
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -6923,13 +7101,19 @@ impl TrtxConverter {
 
         // Add convolution layer with zero padding (padding already applied via padding layer)
         // Constant path always passes f32 data (f16 filter/bias are converted above); dtype must match.
-        let mut layer = match (filter_data_to_use, bias_data) {
-            (Some(fd), b) => {
+        let mut layer = match (conv_weights_owned, filter_data_to_use) {
+            (Some(owned), _) => network
+                .add_convolution_owned_weights(&conv_input, num_output_maps, &kernel_size, owned)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add convolution (owned weights): {}", e),
+                })?,
+            (None, Some(fd)) => {
                 let conv_weights = trtx::ConvWeights {
                     kernel_weights: fd,
                     kernel_dtype: TrtDataType::kFLOAT,
-                    bias_weights: b,
-                    bias_dtype: b.map(|_| TrtDataType::kFLOAT),
+                    bias_weights: bias_data,
+                    bias_dtype: bias_data.map(|_| TrtDataType::kFLOAT),
                 };
                 network
                     .add_convolution(&conv_input, num_output_maps, &kernel_size, &conv_weights)
@@ -6938,7 +7122,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add convolution: {}", e),
                     })?
             }
-            (None, _) => {
+            (None, None) => {
                 let filter_tensor =
                     tensor_map
                         .get(&filter_id)
@@ -6947,7 +7131,7 @@ impl TrtxConverter {
                             reason: format!("Filter operand {} tensor not found", filter_id),
                         })?;
                 // TensorRT conv requires input and kernel same type. We cast activation to Float when input_dtype is Float16; cast filter (and bias) to Float too.
-                let filter_tensor_for_conv: Option<trtx::Tensor> =
+                let filter_tensor_for_conv: Option<trtx::Tensor<'a>> =
                     if filter_operand.descriptor.data_type == DataType::Float16
                         && input_dtype == DataType::Float16
                     {
@@ -6957,7 +7141,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter cast output: {}", e),
@@ -6969,7 +7153,7 @@ impl TrtxConverter {
                 let filter_tensor_to_use = filter_tensor_for_conv.as_ref().unwrap_or(filter_tensor);
 
                 let bias_tensor_raw = bias_id.and_then(|id| tensor_map.get(&id));
-                let bias_tensor_for_conv: Option<trtx::Tensor> =
+                let bias_tensor_for_conv: Option<trtx::Tensor<'a>> =
                     if let (Some(bt), Some(bid)) = (bias_tensor_raw, bias_id) {
                         let bias_dtype = graph
                             .operand(bid)
@@ -6983,7 +7167,7 @@ impl TrtxConverter {
                                         reason: format!("Conv2d bias Half->Float cast: {}", e),
                                     }
                                 })?;
-                            Some(cast_layer.get_output(0).map_err(|e| {
+                            Some(cast_layer.get_output(&*network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!("Conv2d bias cast output: {}", e),
@@ -7009,15 +7193,15 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add convolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(1, filter_tensor_to_use).map_err(|e| {
-                    GraphError::ConversionFailed {
+                layer
+                    .set_input(network, 1, filter_tensor_to_use)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d set_input(1) filter: {}", e),
-                    }
-                })?;
+                    })?;
                 if let Some(bt) = bias_tensor_to_use {
                     layer
-                        .set_input(2, bt)
+                        .set_input(network, 2, bt)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Conv2d set_input(2) bias: {}", e),
@@ -7028,42 +7212,23 @@ impl TrtxConverter {
         };
 
         // Set layer properties (matches C++ API pattern: call setters after creation)
-        layer
-            .set_stride(&strides)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set stride: {}", e),
-            })?;
+        layer.set_stride(network, &[strides[0] as i64, strides[1] as i64]);
 
         // No need to set padding on convolution layer - already handled by explicit padding layer
-        layer
-            .set_padding(&[0, 0])
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set padding: {}", e),
-            })?;
+        layer.set_padding(network, &[0i64, 0]);
 
-        layer
-            .set_dilation(&dilations)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set dilation: {}", e),
-            })?;
+        layer.set_dilation(network, &[dilations[0] as i64, dilations[1] as i64]);
 
-        layer
-            .set_num_groups(groups)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set groups: {}", e),
-            })?;
+        layer.set_num_groups(network, groups as i64);
 
         // Extract output tensor from layer (NCHW, Float)
-        let conv_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get convolution output: {}", e),
-            })?;
+        let conv_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get convolution output: {}", e),
+                })?;
 
         // If input was Half, cast conv output back to Half to match graph output type.
         let conv_output = if input_dtype == DataType::Float16 {
@@ -7074,7 +7239,7 @@ impl TrtxConverter {
                     reason: format!("Conv2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d cast output: {}", e),
@@ -7092,14 +7257,16 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 2, 3, 1]).map_err(|e| {
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d set_first_transpose NCHW->NHWC: {}", e),
                 }
             })?;
             shuffle
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d NHWC output shuffle: {}", e),
@@ -7116,11 +7283,10 @@ impl TrtxConverter {
 
     /// Add convTranspose2d operation (deconvolution/transposed convolution).
     /// Mirrors add_conv2d_op: supports constant or non-constant filter/bias via setInput(1)/setInput(2).
-    fn add_conv_transpose2d_op(
-        graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
-        temp_weights: &mut Vec<Vec<u8>>,
+    fn add_conv_transpose2d_op<'a>(
+        graph: &'a GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let filter_id = operation.input_operands()[1];
@@ -7150,7 +7316,7 @@ impl TrtxConverter {
             .map(|o| o.filter_layout.as_str())
             .filter(|s| !s.is_empty())
             .unwrap_or("iohw");
-        let (_i, o, h, w): (u32, u32, u32, u32) = match filter_layout {
+        let (in_ch, out_ch, h, w): (u32, u32, u32, u32) = match filter_layout {
             "iohw" => (fs[0], fs[1], fs[2], fs[3]),
             "oihw" => (fs[1], fs[0], fs[2], fs[3]),
             "hwio" => (fs[2], fs[3], fs[0], fs[1]),
@@ -7166,17 +7332,18 @@ impl TrtxConverter {
         };
         let groups = deconv_opts.map(|o| o.groups as i32).unwrap_or(1);
         // WebNN filter shape is [inputChannels, outputChannels/groups, H, W]; TensorRT expects total output maps.
-        let num_output_maps = (o as i32) * groups;
+        let num_output_maps = (out_ch as i32) * groups;
         let kernel_size: [i32; 2] = [h as i32, w as i32];
 
         let filter_constant = graph
             .constant_operand_ids_to_handles
             .contains_key(&filter_id);
 
-        let (filter_data_to_use, bias_data) = if filter_constant {
+        let (filter_data_to_use, bias_data, deconv_weights_owned) = if filter_constant {
             let filter_shape_u32 = filter_operand.descriptor.static_or_max_shape();
             let filter_data = Self::get_constant_data(graph, filter_id)?;
-            let (bias_temp_index, bias_raw): (Option<usize>, Option<&[u8]>) = match bias_id {
+            let mut bias_promoted: Option<Vec<u8>> = None;
+            let bias_raw: Option<&[u8]> = match bias_id {
                 Some(id) => {
                     if !graph.constant_operand_ids_to_handles.contains_key(&id) {
                         return Err(GraphError::ConversionFailed {
@@ -7190,17 +7357,17 @@ impl TrtxConverter {
                         .map(|o| o.descriptor.data_type)
                         .unwrap_or(DataType::Float32);
                     if dtype == DataType::Float16 {
-                        let f32_bias = Self::f16_bytes_to_f32_bytes(raw)?;
-                        temp_weights.push(f32_bias);
-                        (Some(temp_weights.len() - 1), None)
+                        bias_promoted = Some(Self::f16_bytes_to_f32_bytes(raw)?);
+                        None
                     } else {
-                        (None, Some(raw))
+                        Some(raw)
                     }
                 }
-                None => (None, None),
+                None => None,
             };
             let filter_dtype = filter_operand.descriptor.data_type;
-            let filter_temp_index: Option<usize> = match (filter_dtype, filter_layout) {
+            let mut kernel_promoted: Option<Vec<u8>> = None;
+            match (filter_dtype, filter_layout) {
                 (DataType::Float16, _) => {
                     let f32_bytes = Self::f16_bytes_to_f32_bytes(filter_data)?;
                     let iohw = if filter_layout == "iohw" {
@@ -7208,15 +7375,15 @@ impl TrtxConverter {
                     } else {
                         Self::deconv_filter_to_iohw(&f32_bytes, filter_layout, &filter_shape_u32)?
                     };
-                    temp_weights.push(iohw);
-                    Some(temp_weights.len() - 1)
+                    kernel_promoted = Some(iohw);
                 }
-                (DataType::Float32, "iohw") => None,
+                (DataType::Float32, "iohw") => {}
                 (DataType::Float32, _) => {
-                    let iohw =
-                        Self::deconv_filter_to_iohw(filter_data, filter_layout, &filter_shape_u32)?;
-                    temp_weights.push(iohw);
-                    Some(temp_weights.len() - 1)
+                    kernel_promoted = Some(Self::deconv_filter_to_iohw(
+                        filter_data,
+                        filter_layout,
+                        &filter_shape_u32,
+                    )?);
                 }
                 _ => {
                     return Err(GraphError::ConversionFailed {
@@ -7228,15 +7395,36 @@ impl TrtxConverter {
                     });
                 }
             };
-            let bias_data: Option<&[u8]> = match bias_temp_index {
-                Some(idx) => Some(temp_weights[idx].as_slice()),
-                None => bias_raw,
+            let deconv_weights_owned = if kernel_promoted.is_some() || bias_promoted.is_some() {
+                let deconv_kernel_const_shape: Vec<i64> =
+                    vec![in_ch as i64, out_ch as i64, h as i64, w as i64];
+                let kernel_values =
+                    kernel_promoted.unwrap_or_else(|| filter_data.to_vec());
+                let bias_values = match (bias_promoted, bias_raw) {
+                    (Some(b), _) => Some(b),
+                    (None, Some(br)) => Some(br.to_vec()),
+                    (None, None) => None,
+                };
+                Some(OwnedConvWeights {
+                    kernel: OwnedWeights {
+                        shape: deconv_kernel_const_shape,
+                        data_type: TrtDataType::kFLOAT,
+                        values: kernel_values,
+                    },
+                    bias: bias_values.map(|values| OwnedWeights {
+                        shape: vec![num_output_maps as i64],
+                        data_type: TrtDataType::kFLOAT,
+                        values,
+                    }),
+                })
+            } else {
+                None
             };
-            let filter_data_to_use: &[u8] = match filter_temp_index {
-                Some(idx) => temp_weights[idx].as_slice(),
-                None => filter_data,
-            };
-            (Some(filter_data_to_use), bias_data)
+            if deconv_weights_owned.is_some() {
+                (None, None, deconv_weights_owned)
+            } else {
+                (Some(filter_data), bias_raw, None)
+            }
         } else {
             if filter_layout != "iohw" {
                 return Err(GraphError::ConversionFailed {
@@ -7254,7 +7442,7 @@ impl TrtxConverter {
                     });
                 }
             }
-            (None, None)
+            (None, None, None)
         };
 
         let input_layout = deconv_opts
@@ -7281,7 +7469,9 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 3, 1, 2]).map_err(|e| {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
@@ -7289,7 +7479,7 @@ impl TrtxConverter {
             })?;
             Some(
                 shuffle
-                    .get_output(0)
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC shuffle output: {}", e),
@@ -7300,24 +7490,23 @@ impl TrtxConverter {
         };
         let pre_deconv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
-        let half_cast_output: Option<trtx::Tensor> = if input_dtype == DataType::Float16 {
-            let cast_layer = network
-                .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("convTranspose2d Half->Float cast: {}", e),
-                })?;
-            Some(
-                cast_layer
-                    .get_output(0)
+        let half_cast_output: Option<trtx::Tensor<'a>> =
+            if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("convTranspose2d Half->Float cast: {}", e),
+                    })?;
+                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("convTranspose2d cast output: {}", e),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let deconv_input_source = half_cast_output.as_ref().unwrap_or(pre_deconv_input);
 
         let strides: [i32; 2] = deconv_opts
@@ -7360,26 +7549,38 @@ impl TrtxConverter {
                 }
             })?;
             id_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d identity output: {}", e),
                 })?
         };
 
-        let mut layer = match (filter_data_to_use, bias_data) {
-            (Some(fd), b) => {
+        let kernel_size_i64: [i64; 2] = [kernel_size[0] as i64, kernel_size[1] as i64];
+        let mut layer = match (deconv_weights_owned, filter_data_to_use) {
+            (Some(owned), _) => network
+                .add_deconvolution_owned_weights(
+                    &deconv_input,
+                    num_output_maps as i64,
+                    &kernel_size_i64,
+                    owned,
+                )
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to add deconvolution (owned weights): {}", e),
+                })?,
+            (None, Some(fd)) => {
                 let deconv_weights = trtx::ConvWeights {
                     kernel_weights: fd,
                     kernel_dtype: TrtDataType::kFLOAT,
-                    bias_weights: b,
-                    bias_dtype: b.map(|_| TrtDataType::kFLOAT),
+                    bias_weights: bias_data,
+                    bias_dtype: bias_data.map(|_| TrtDataType::kFLOAT),
                 };
                 network
                     .add_deconvolution(
                         &deconv_input,
-                        num_output_maps,
-                        &kernel_size,
+                        num_output_maps as i64,
+                        &kernel_size_i64,
                         &deconv_weights,
                     )
                     .map_err(|e| GraphError::ConversionFailed {
@@ -7387,7 +7588,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add deconvolution: {}", e),
                     })?
             }
-            (None, _) => {
+            (None, None) => {
                 let filter_tensor =
                     tensor_map
                         .get(&filter_id)
@@ -7395,7 +7596,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Filter operand {} tensor not found", filter_id),
                         })?;
-                let filter_tensor_for_conv: Option<trtx::Tensor> =
+                let filter_tensor_for_conv: Option<trtx::Tensor<'a>> =
                     if filter_operand.descriptor.data_type == DataType::Float16
                         && input_dtype == DataType::Float16
                     {
@@ -7405,7 +7606,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter cast output: {}", e),
@@ -7417,7 +7618,7 @@ impl TrtxConverter {
                 let filter_tensor_to_use = filter_tensor_for_conv.as_ref().unwrap_or(filter_tensor);
 
                 let bias_tensor_raw = bias_id.and_then(|id| tensor_map.get(&id));
-                let bias_tensor_for_conv: Option<trtx::Tensor> = if let (Some(bt), Some(bid)) =
+                let bias_tensor_for_conv: Option<trtx::Tensor<'a>> = if let (Some(bt), Some(bid)) =
                     (bias_tensor_raw, bias_id)
                 {
                     let bias_dtype = graph
@@ -7432,7 +7633,7 @@ impl TrtxConverter {
                                     reason: format!("convTranspose2d bias Half->Float cast: {}", e),
                                 }
                             })?;
-                        Some(cast_layer.get_output(0).map_err(|e| {
+                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d bias cast output: {}", e),
@@ -7455,23 +7656,23 @@ impl TrtxConverter {
                 let mut layer = network
                     .add_deconvolution(
                         &deconv_input,
-                        num_output_maps,
-                        &kernel_size,
+                        num_output_maps as i64,
+                        &[kernel_size[0] as i64, kernel_size[1] as i64],
                         &deconv_weights,
                     )
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add deconvolution (tensor weights): {}", e),
                     })?;
-                layer.set_input(1, filter_tensor_to_use).map_err(|e| {
-                    GraphError::ConversionFailed {
+                layer
+                    .set_input(network, 1, filter_tensor_to_use)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d set_input(1) filter: {}", e),
-                    }
-                })?;
+                    })?;
                 if let Some(bt) = bias_tensor_to_use {
                     layer
-                        .set_input(2, bt)
+                        .set_input(network, 2, bt)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("convTranspose2d set_input(2) bias: {}", e),
@@ -7482,13 +7683,13 @@ impl TrtxConverter {
         };
 
         layer
-            .set_stride(&strides)
+            .set_stride(network, &[strides[0] as i64, strides[1] as i64])
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("convTranspose2d set_stride: {}", e),
             })?;
         layer
-            .set_dilation(&dilations)
+            .set_dilation(network, &[dilations[0] as i64, dilations[1] as i64])
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("convTranspose2d set_dilation: {}", e),
@@ -7525,39 +7726,43 @@ impl TrtxConverter {
         ];
         // TensorRT Deconvolution: pre/post padding trim the output. DimsHW order is (height, width).
         // See https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-861/operators/docs/Deconvolution.html
-        let pre: [i32; 2] = pre_effective;
-        let post: [i32; 2] = post_effective;
+        let pre: [i64; 2] = [pre_effective[0] as i64, pre_effective[1] as i64];
+        let post: [i64; 2] = [post_effective[0] as i64, post_effective[1] as i64];
         layer
-            .set_pre_padding(&pre)
+            .set_pre_padding(network, &pre)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("convTranspose2d set_pre_padding: {}", e),
             })?;
         layer
-            .set_post_padding(&post)
+            .set_post_padding(network, &post)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("convTranspose2d set_post_padding: {}", e),
             })?;
 
         layer
-            .set_num_groups(groups)
+            .set_num_groups(network, groups as i64)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("convTranspose2d set_num_groups: {}", e),
             })?;
 
-        let deconv_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get deconvolution output: {}", e),
-            })?;
+        let deconv_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get deconvolution output: {}", e),
+                })?;
 
         // When padding could not fully absorb outputPadding, add IPaddingLayer for remainder.
         let deconv_output = if padding_remainder[0] != 0 || padding_remainder[1] != 0 {
-            let pre_pad: Vec<i32> = vec![0, 0];
-            let post_pad: Vec<i32> = vec![padding_remainder[0], padding_remainder[1]];
+            let pre_pad: Vec<i64> = vec![0, 0];
+            let post_pad: Vec<i64> = vec![
+                padding_remainder[0] as i64,
+                padding_remainder[1] as i64,
+            ];
             let pad_layer = network
                 .add_padding(&deconv_output, &pre_pad, &post_pad)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -7565,7 +7770,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d outputPadding remainder: {}", e),
                 })?;
             pad_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d outputPadding remainder output: {}", e),
@@ -7627,16 +7832,21 @@ impl TrtxConverter {
                         let slice_w = current_w.min(target_w);
                         let mut current = deconv_output;
                         if slice_h < current_h || slice_w < current_w {
-                            let start: Vec<i32> = vec![0, 0, 0, 0];
-                            let size: Vec<i32> = vec![out_batch, out_c, slice_h, slice_w];
-                            let stride: Vec<i32> = vec![1, 1, 1, 1];
+                            let start: Vec<i64> = vec![0, 0, 0, 0];
+                            let size: Vec<i64> = vec![
+                                out_batch as i64,
+                                out_c as i64,
+                                slice_h as i64,
+                                slice_w as i64,
+                            ];
+                            let stride: Vec<i64> = vec![1, 1, 1, 1];
                             let slice_layer = network
                                 .add_slice(&current, &start, &size, &stride)
                                 .map_err(|e| GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d outputSizes slice: {}", e),
                             })?;
-                            current = slice_layer.get_output(0).map_err(|e| {
+                            current = slice_layer.get_output(&*network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!(
@@ -7649,8 +7859,8 @@ impl TrtxConverter {
                         let pad_h = target_h - slice_h;
                         let pad_w = target_w - slice_w;
                         if pad_h > 0 || pad_w > 0 {
-                            let pre: Vec<i32> = vec![0, 0];
-                            let post: Vec<i32> = vec![pad_h, pad_w];
+                            let pre: Vec<i64> = vec![0, 0];
+                            let post: Vec<i64> = vec![pad_h as i64, pad_w as i64];
                             let pad_layer =
                                 network.add_padding(&current, &pre, &post).map_err(|e| {
                                     GraphError::ConversionFailed {
@@ -7658,15 +7868,15 @@ impl TrtxConverter {
                                         reason: format!("convTranspose2d outputSizes pad: {}", e),
                                     }
                                 })?;
-                            pad_layer
-                                .get_output(0)
-                                .map_err(|e| GraphError::ConversionFailed {
+                            pad_layer.get_output(&*network, 0).map_err(|e| {
+                                GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!(
                                         "convTranspose2d outputSizes pad output: {}",
                                         e
                                     ),
-                                })?
+                                }
+                            })?
                         } else {
                             current
                         }
@@ -7684,7 +7894,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d cast output: {}", e),
@@ -7701,14 +7911,16 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NCHW->NHWC shuffle: {}", e),
                     })?;
-            shuffle.set_first_transpose(&[0, 2, 3, 1]).map_err(|e| {
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d set_first_transpose NCHW->NHWC: {}", e),
                 }
             })?;
             shuffle
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d NHWC output shuffle: {}", e),
@@ -7724,9 +7936,9 @@ impl TrtxConverter {
     }
 
     /// Add pooling operation
-    fn add_pooling_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_pooling_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
@@ -7753,9 +7965,9 @@ impl TrtxConverter {
                 reason: "Missing windowDimensions attribute".to_string(),
             })?;
 
-        let window: [i32; 2] = [
-            window_size.get(0).copied().unwrap_or(2) as i32,
-            window_size.get(1).copied().unwrap_or(2) as i32,
+        let window: [i64; 2] = [
+            window_size.get(0).copied().unwrap_or(2) as i64,
+            window_size.get(1).copied().unwrap_or(2) as i64,
         ];
 
         let layer = network
@@ -7767,7 +7979,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7780,9 +7992,9 @@ impl TrtxConverter {
     }
 
     /// Add softmax operation
-    fn add_softmax_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_softmax_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -7809,7 +8021,7 @@ impl TrtxConverter {
         let axes = 1u32 << positive_axis;
 
         let layer = network
-            .add_softmax(input, axes)
+            .add_softmax(input, Axes::from_bits(axes))
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add softmax: {}", e),
@@ -7817,7 +8029,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7830,12 +8042,12 @@ impl TrtxConverter {
     }
 
     /// Add concatenation operation
-    fn add_concat_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_concat_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let inputs: Vec<&trtx::Tensor> = operation
+        let inputs: Vec<&trtx::Tensor<'a>> = operation
             .input_operands()
             .iter()
             .map(|&id| {
@@ -7866,7 +8078,7 @@ impl TrtxConverter {
                 .unwrap_or(0),
         };
         let ndim = inputs[0]
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Concat: failed to get input dimensions: {}", e),
@@ -7877,16 +8089,11 @@ impl TrtxConverter {
             axis_i32 += ndim;
         }
         axis_i32 = axis_i32.max(0).min(ndim.saturating_sub(1));
-        layer
-            .set_axis(axis_i32)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set concat axis {}: {}", axis_i32, e),
-            })?;
+        layer.set_axis(network, axis_i32);
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7904,10 +8111,10 @@ impl TrtxConverter {
     }
 
     /// Add transpose operation using shuffle layer
-    fn add_transpose_op(
+    fn add_transpose_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -7918,7 +8125,7 @@ impl TrtxConverter {
             })?;
 
         let input_dims = input
-            .dimensions()
+            .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Transpose: failed to get input dimensions: {}", e),
@@ -7952,14 +8159,14 @@ impl TrtxConverter {
             })?;
 
         layer
-            .set_first_transpose(&perm)
+            .set_first_transpose(network, perm.as_slice())
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set transpose permutation: {}", e),
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -7972,10 +8179,10 @@ impl TrtxConverter {
     }
 
     /// Add reshape operation using shuffle layer
-    fn add_reshape_op(
+    fn add_reshape_op<'a>(
         _graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -8001,9 +8208,9 @@ impl TrtxConverter {
             });
         }
 
-        let dims: Vec<i32> = crate::operator_options::mldimensions_static_or_max(new_shape)
+        let dims: Vec<i64> = crate::operator_options::mldimensions_static_or_max(new_shape)
             .into_iter()
-            .map(|u| u as i32)
+            .map(|u| u as i64)
             .collect();
 
         // Use shuffle layer for reshape
@@ -8016,7 +8223,7 @@ impl TrtxConverter {
 
         // Set the reshape dimensions
         layer
-            .set_reshape_dimensions(&dims)
+            .set_reshape_dimensions(network, &dims)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape dimensions: {}", e),
@@ -8024,7 +8231,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -8037,9 +8244,9 @@ impl TrtxConverter {
     }
 
     /// Add resample2d operation (resize/interpolate 2D tensor)
-    fn add_resample2d_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_resample2d_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input = tensor_map
@@ -8101,26 +8308,16 @@ impl TrtxConverter {
         // WebNN resample2d only specifies [H, W], so we need to preserve N and C
         // For now, we'll assume 4D NCHW input and set full dimensions
         // TODO: Get actual input dimensions to preserve N and C
-        let output_dims = vec![1, 1, sizes[0], sizes[1]]; // Placeholder: [N=1, C=1, H, W]
+        let output_dims: Vec<i64> = vec![1, 1, sizes[0] as i64, sizes[1] as i64]; // Placeholder: [N=1, C=1, H, W]
 
         // Set output dimensions
-        layer
-            .set_output_dimensions(&output_dims)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set resize output dimensions: {}", e),
-            })?;
+        layer.set_output_dimensions(network, &output_dims);
 
         // Set resize mode (uses ResizeMode typedef for InterpolationMode)
-        layer
-            .set_resize_mode(resize_mode)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set resize mode: {}", e),
-            })?;
+        layer.set_resize_mode(network, resize_mode);
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get resize output: {}", e),
@@ -8137,9 +8334,9 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add isNaN operation (check if value is NaN using x != x)
-    fn add_is_nan_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_is_nan_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8158,12 +8355,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create EQUAL layer for isNaN: {}", e),
             })?;
 
-        let equal_output = layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get EQUAL output: {}", e),
-            })?;
+        let equal_output =
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get EQUAL output: {}", e),
+                })?;
 
         // Negate the result (isNaN = NOT(x == x))
         let not_layer = network
@@ -8173,12 +8371,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create NOT layer for isNaN: {}", e),
             })?;
 
-        let bool_output = not_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get isNaN output: {}", e),
-            })?;
+        let bool_output =
+            not_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get isNaN output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -8190,11 +8389,10 @@ impl TrtxConverter {
     }
 
     /// Add isInfinite operation (check if value is infinite)
-    fn add_is_infinite_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_is_infinite_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8212,29 +8410,29 @@ impl TrtxConverter {
                 reason: format!("Failed to create ABS layer for isInfinite: {}", e),
             })?;
 
-        let abs_output = abs_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get ABS output: {}", e),
-            })?;
+        let abs_output =
+            abs_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get ABS output: {}", e),
+                })?;
 
-        // Create constant for infinity
-        temp_weights.push(f32::INFINITY.to_le_bytes().to_vec());
-        let inf_data = temp_weights.last().unwrap();
+        let inf_bytes = f32::INFINITY.to_le_bytes();
         let inf_constant = network
-            .add_constant(&[1], inf_data, TrtDataType::kFLOAT)
+            .add_small_constant_copied(&[1], inf_bytes.as_slice(), TrtDataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create infinity constant: {}", e),
             })?;
 
-        let inf_tensor = inf_constant
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get infinity tensor: {}", e),
-            })?;
+        let inf_tensor =
+            inf_constant
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get infinity tensor: {}", e),
+                })?;
 
         // Compare abs(x) == infinity
         let equal_layer = network
@@ -8244,12 +8442,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create EQUAL layer for isInfinite: {}", e),
             })?;
 
-        let bool_output = equal_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get isInfinite output: {}", e),
-            })?;
+        let bool_output =
+            equal_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get isInfinite output: {}", e),
+                })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -8261,9 +8460,9 @@ impl TrtxConverter {
     }
 
     /// Add roundEven operation (round to nearest even integer, banker's rounding)
-    fn add_round_even_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_round_even_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8282,7 +8481,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get roundEven output: {}", e),
@@ -8295,9 +8494,9 @@ impl TrtxConverter {
     }
 
     /// Add gatherElements operation (gather using index tensor along axis)
-    fn add_gather_elements_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_gather_elements_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let data_tensor = tensor_map
@@ -8333,15 +8532,10 @@ impl TrtxConverter {
             })?;
 
         // Set gather mode to ELEMENT
-        layer
-            .set_gather_mode(trtx::GatherMode::kELEMENT)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set gather mode: {}", e),
-            })?;
+        layer.set_gather_mode(network, trtx::GatherMode::kELEMENT);
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherElements output: {}", e),
@@ -8354,9 +8548,9 @@ impl TrtxConverter {
     }
 
     /// Add l2Pool2d operation (L2 pooling: square → avgPool → sqrt)
-    fn add_l2_pool2d_op(
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+    fn add_l2_pool2d_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8374,12 +8568,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create square layer for l2Pool2d: {}", e),
             })?;
 
-        let squared = square_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get squared output: {}", e),
-            })?;
+        let squared =
+            square_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get squared output: {}", e),
+                })?;
 
         // Step 2: Apply average pooling (use same parameters as maxPool2d/averagePool2d)
         let window_size = operation
@@ -8391,9 +8586,9 @@ impl TrtxConverter {
                 reason: "Missing windowDimensions for l2Pool2d".to_string(),
             })?;
 
-        let window: [i32; 2] = [
-            window_size[0].as_i64().unwrap_or(1) as i32,
-            window_size[1].as_i64().unwrap_or(1) as i32,
+        let window: [i64; 2] = [
+            window_size[0].as_i64().unwrap_or(1),
+            window_size[1].as_i64().unwrap_or(1),
         ];
 
         let pool_layer = network
@@ -8403,12 +8598,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
             })?;
 
-        let pooled = pool_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get pooled output: {}", e),
-            })?;
+        let pooled =
+            pool_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get pooled output: {}", e),
+                })?;
 
         // Step 3: Take square root
         let sqrt_layer = network
@@ -8418,12 +8614,13 @@ impl TrtxConverter {
                 reason: format!("Failed to create sqrt layer for l2Pool2d: {}", e),
             })?;
 
-        let output = sqrt_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get l2Pool2d output: {}", e),
-            })?;
+        let output =
+            sqrt_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get l2Pool2d output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -8433,10 +8630,10 @@ impl TrtxConverter {
 
     /// Add reverse operation (reverse elements along axes) - PLACEHOLDER
     /// Add reverse operation (reverse elements along axes using negative stride slicing)
-    fn add_reverse_op(
+    fn add_reverse_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
@@ -8469,12 +8666,12 @@ impl TrtxConverter {
         //   size = n (number of elements)
         //   stride = -1
         //   end_idx should be = (n-1) + (n-1)*(-1) = (n-1) - (n-1) = 0 ✓
-        let mut starts: Vec<i32> = vec![0; rank];
-        let sizes: Vec<i32> = shape
+        let mut starts: Vec<i64> = vec![0; rank];
+        let sizes: Vec<i64> = shape
             .iter()
-            .map(|s| get_static_or_max_size(s) as i32)
+            .map(|s| get_static_or_max_size(s) as i64)
             .collect();
-        let mut strides: Vec<i32> = vec![1; rank];
+        let mut strides: Vec<i64> = vec![1; rank];
 
         for &axis in &axes_to_reverse {
             if axis >= rank {
@@ -8490,7 +8687,7 @@ impl TrtxConverter {
             // TensorRT will compute: indices = start + i*stride for i in 0..size
             // So: indices = (size-1) + i*(-1) = (size-1) - i
             // For i=0: size-1, i=1: size-2, ..., i=size-1: 0 ✓
-            starts[axis] = (get_static_or_max_size(&shape[axis]) - 1) as i32;
+            starts[axis] = (get_static_or_max_size(&shape[axis]) - 1) as i64;
             strides[axis] = -1;
         }
 
@@ -8502,7 +8699,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get reverse output: {}", e),
@@ -8518,12 +8715,11 @@ impl TrtxConverter {
     /// Add cumulativeSum operation using explicit slice-and-add decomposition
     ///
     /// Uses TensorRT's native ICumulativeLayer for efficient implementation.
-    fn add_cumulative_sum_op(
+    fn add_cumulative_sum_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8553,17 +8749,13 @@ impl TrtxConverter {
             });
         }
 
-        // Create axis constant with proper lifetime management
-        // Store bytes in temp_weights to keep them alive until engine is built
         let axis_value = axis as i32;
-        let axis_bytes: Vec<u8> = axis_value.to_le_bytes().to_vec();
-        temp_weights.push(axis_bytes);
-        let axis_bytes_ref = temp_weights.last().unwrap();
+        let axis_bytes = axis_value.to_le_bytes();
 
         // Create axis constant tensor (true 0D scalar with shape [])
         // TensorRT requires axisDims.nbDims == 0 for cumulative operations
         let axis_constant = network
-            .add_constant(&[], axis_bytes_ref, trtx::DataType::kINT32)
+            .add_small_constant_copied(&[], axis_bytes.as_slice(), trtx::DataType::kINT32)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create axis constant: {}", e),
@@ -8571,7 +8763,7 @@ impl TrtxConverter {
 
         let axis_tensor =
             axis_constant
-                .get_output(0)
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get axis constant output: {}", e),
@@ -8592,7 +8784,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(0)
+            .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cumulative sum output: {}", e),
@@ -8606,12 +8798,11 @@ impl TrtxConverter {
 
     /// Add triangular operation (extract triangular part of matrix) - PLACEHOLDER
     /// Add triangular operation (extract upper/lower triangular part with masking)
-    fn add_triangular_op(
+    fn add_triangular_op<'a>(
         graph: &GraphInfo,
-        network: &mut trtx::NetworkDefinition,
-        tensor_map: &mut HashMap<u32, trtx::Tensor>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_tensor = tensor_map
             .get(&operation.input_operands()[0])
@@ -8672,28 +8863,25 @@ impl TrtxConverter {
         // Convert mask to bytes
         let mask_bytes: Vec<u8> = mask_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
 
-        // Store mask in temp_weights to keep it alive (critical for weight lifetime)
-        temp_weights.push(mask_bytes);
-        let mask_bytes_ref = temp_weights.last().unwrap();
-
         // Create constant layer with the mask
-        let dims: Vec<i32> = shape
+        let dims: Vec<i64> = shape
             .iter()
-            .map(|s| get_static_or_max_size(s) as i32)
+            .map(|s| get_static_or_max_size(s) as i64)
             .collect();
         let mask_layer = network
-            .add_constant(&dims, mask_bytes_ref, trtx::DataType::kFLOAT)
+            .add_constant_owned(&dims, mask_bytes, trtx::DataType::kFLOAT)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add constant mask for triangular: {}", e),
             })?;
 
-        let mask_tensor = mask_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get mask tensor: {}", e),
-            })?;
+        let mask_tensor =
+            mask_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mask tensor: {}", e),
+                })?;
 
         // Multiply input by mask (elementwise)
         let multiply_layer = network
@@ -8703,12 +8891,13 @@ impl TrtxConverter {
                 reason: format!("Failed to add elementwise multiply for triangular: {}", e),
             })?;
 
-        let output = multiply_layer
-            .get_output(0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get triangular output: {}", e),
-            })?;
+        let output =
+            multiply_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get triangular output: {}", e),
+                })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -8754,7 +8943,7 @@ impl GraphConverter for TrtxConverter {
             reason: format!("Failed to create TensorRT logger: {}", e),
         })?;
 
-        let builder = trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
+        let mut builder = trtx::Builder::new(&logger).map_err(|e| GraphError::ConversionFailed {
             format: "trtx".to_string(),
             reason: format!("Failed to create TensorRT builder: {}", e),
         })?;
@@ -8766,9 +8955,9 @@ impl GraphConverter for TrtxConverter {
                 reason: format!("Failed to create TensorRT network: {}", e),
             })?;
 
-        // Build the network from WebNN graph and capture temporary weights
-        // These weights must stay alive until engine serialization completes
-        let _temp_weights = Self::build_network(graph_info, &mut network)?;
+        // Temporary weight buffers referenced by the network; must outlive `build_serialized_network`.
+        let mut temp_weights: Vec<Vec<u8>> = Vec::new();
+        Self::build_network(graph_info, &mut network, &mut temp_weights)?;
 
         // Create builder config
         let mut config = builder
@@ -8779,12 +8968,7 @@ impl GraphConverter for TrtxConverter {
             })?;
 
         // Set workspace size (1 GB)
-        config
-            .set_memory_pool_limit(trtx::builder::MemoryPoolType::Workspace, 1 << 30)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to set workspace size: {}", e),
-            })?;
+        config.set_memory_pool_limit(trtx::builder::MemoryPoolType::kWORKSPACE, 1 << 30);
 
         // Build and serialize the engine
         let engine_data = builder
@@ -8797,7 +8981,7 @@ impl GraphConverter for TrtxConverter {
         Ok(ConvertedGraph {
             format: "trtx",
             content_type: "application/x-tensorrt-engine",
-            data: engine_data,
+            data: engine_data.to_vec(),
             weights_data: None,
         })
     }

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -6191,7 +6191,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let (beginning_padding, ending_padding, opts) = match operation {
+        let (beginning_padding, ending_padding, _opts) = match operation {
             Operation::Pad {
                 beginning_padding,
                 ending_padding,
@@ -8532,7 +8532,8 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let cum_opts = operation.attributes().as_cumulative_sum();
+        let attrs = operation.attributes();
+        let cum_opts = attrs.as_cumulative_sum();
         let axis = match operation {
             Operation::CumulativeSum { axis, .. } => *axis as usize,
             _ => 0,

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -6582,17 +6582,18 @@ impl TrtxConverter {
     /// Add GEMM (General Matrix Multiply) operation
     /// Computes: C = alpha * A * B + beta * C
     fn add_gemm_op<'a>(
-        _graph: &GraphInfo,
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         _temp_weights: &mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
+        let a_id = operation.input_operands()[0];
         let input_a = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&a_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", a_id),
             })?;
 
         let input_b = tensor_map
@@ -6601,6 +6602,11 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Input operand {} not found", operation.input_operands()[1]),
             })?;
+
+        let gemm_dtype = graph
+            .operand(a_id)
+            .map(|o| o.descriptor.data_type)
+            .unwrap_or(DataType::Float32);
 
         let attrs = operation.attributes();
         let opts = attrs.as_gemm();
@@ -6692,13 +6698,28 @@ impl TrtxConverter {
                         reason: format!("Failed to get result dimensions: {}", e),
                     })?;
 
-            // Create constant filled with alpha value matching result shape
+            // Create constant filled with alpha value matching result shape and element type
+            // (TensorRT elementwise PROD requires matching types; matrix multiply output follows A/B).
             let num_elements: usize = result_dims.iter().map(|&d| d as usize).product();
-            let alpha_data: Vec<f32> = vec![alpha; num_elements];
-            let alpha_bytes: Vec<u8> = alpha_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+            let (alpha_bytes, alpha_trt_ty) = match gemm_dtype {
+                DataType::Float16 => {
+                    let bits = f16::from_f32(alpha).to_bits().to_le_bytes();
+                    let mut v = Vec::with_capacity(num_elements * 2);
+                    for _ in 0..num_elements {
+                        v.extend_from_slice(&bits);
+                    }
+                    (v, TrtDataType::kHALF)
+                }
+                _ => {
+                    let alpha_data: Vec<f32> = vec![alpha; num_elements];
+                    let alpha_bytes: Vec<u8> =
+                        alpha_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+                    (alpha_bytes, TrtDataType::kFLOAT)
+                }
+            };
 
             let alpha_layer = network
-                .add_small_constant_copied(&result_dims, &alpha_bytes, TrtDataType::kFLOAT)
+                .add_small_constant_copied(&result_dims, &alpha_bytes, alpha_trt_ty)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to create alpha constant: {}", e),
@@ -6729,13 +6750,14 @@ impl TrtxConverter {
                     })?;
         }
 
-        // If there's a C input and beta != 0, add it
-        if operation.input_operands().len() > 2 && beta.abs() > 1e-6 {
+        // Optional bias matrix C is WebNN `MLGemmOptions.c`; Gemm only lists [A, B] in
+        // `input_operands` (same as ONNX node inputs in converters/onnx.rs).
+        if let Some(c_id) = opts.and_then(|o| o.c).filter(|_| beta.abs() > 1e-6) {
             let input_c = tensor_map
-                .get(&operation.input_operands()[2])
+                .get(&c_id)
                 .ok_or_else(|| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Input operand {} not found", operation.input_operands()[2]),
+                    reason: format!("GEMM options.c operand {} not found", c_id),
                 })?;
 
             // Scale C by beta if needed, then add to result
@@ -6749,13 +6771,27 @@ impl TrtxConverter {
                             reason: format!("Failed to get C dimensions: {}", e),
                         })?;
 
-                // Create constant filled with beta value matching C shape
+                // Create constant filled with beta value matching C shape and GEMM element type
                 let num_elements: usize = c_dims.iter().map(|&d| d as usize).product();
-                let beta_data: Vec<f32> = vec![beta; num_elements];
-                let beta_bytes: Vec<u8> = beta_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+                let (beta_bytes, beta_trt_ty) = match gemm_dtype {
+                    DataType::Float16 => {
+                        let bits = f16::from_f32(beta).to_bits().to_le_bytes();
+                        let mut v = Vec::with_capacity(num_elements * 2);
+                        for _ in 0..num_elements {
+                            v.extend_from_slice(&bits);
+                        }
+                        (v, TrtDataType::kHALF)
+                    }
+                    _ => {
+                        let beta_data: Vec<f32> = vec![beta; num_elements];
+                        let beta_bytes: Vec<u8> =
+                            beta_data.iter().flat_map(|&f| f.to_le_bytes()).collect();
+                        (beta_bytes, TrtDataType::kFLOAT)
+                    }
+                };
 
                 let beta_layer = network
-                    .add_small_constant_copied(&c_dims, &beta_bytes, TrtDataType::kFLOAT)
+                    .add_small_constant_copied(&c_dims, &beta_bytes, beta_trt_ty)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to create beta constant: {}", e),
@@ -6783,9 +6819,19 @@ impl TrtxConverter {
                     }
                 })?;
 
-                // Add result + beta*C
+                // WebNN/ONNX broadcast C to alpha*A*B (e.g. C [5] with output [3,5]). One call
+                // pads rank ([5]->[1,5]); a second call expands 1s to match rows (TRT elementwise).
+                let (r_bc, c_bc) = Self::ensure_broadcast_compatible(
+                    network,
+                    &result,
+                    &scaled_c,
+                    "gemm_options_c",
+                )?;
+                let (r_bc2, c_bc2) =
+                    Self::ensure_broadcast_compatible(network, &r_bc, &c_bc, "gemm_options_c")?;
+
                 let add_layer = network
-                    .add_elementwise(&result, &scaled_c, ElementWiseOperation::kSUM)
+                    .add_elementwise(&r_bc2, &c_bc2, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add scaled C to result: {}", e),
@@ -6798,9 +6844,13 @@ impl TrtxConverter {
                     }
                 })?;
             } else {
-                // beta == 1.0: add C directly
+                let (r_bc, c_bc) =
+                    Self::ensure_broadcast_compatible(network, &result, input_c, "gemm_options_c")?;
+                let (r_bc2, c_bc2) =
+                    Self::ensure_broadcast_compatible(network, &r_bc, &c_bc, "gemm_options_c")?;
+
                 let add_layer = network
-                    .add_elementwise(&result, input_c, ElementWiseOperation::kSUM)
+                    .add_elementwise(&r_bc2, &c_bc2, ElementWiseOperation::kSUM)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add C to result: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -634,16 +634,10 @@ impl TrtxConverter {
             "gelu" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kGELU_ERF)?
             }
-            "leakyRelu" => {
-                Self::add_leaky_relu_op(graph, network, tensor_map, operation)?
-            }
+            "leakyRelu" => Self::add_leaky_relu_op(graph, network, tensor_map, operation)?,
             "prelu" => Self::add_prelu_op(network, tensor_map, operation)?,
-            "hardSigmoid" => {
-                Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?
-            }
-            "hardSwish" => {
-                Self::add_hard_swish_op(graph, network, tensor_map, operation)?
-            }
+            "hardSigmoid" => Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?,
+            "hardSwish" => Self::add_hard_swish_op(graph, network, tensor_map, operation)?,
 
             // Unary mathematical operations (use IUnaryLayer)
             // Exponential and logarithmic
@@ -797,9 +791,7 @@ impl TrtxConverter {
                 operation,
                 ElementWiseOperation::kXOR,
             )?,
-            "logicalNot" => {
-                Self::add_logical_not_op(graph, network, tensor_map, operation)?
-            }
+            "logicalNot" => Self::add_logical_not_op(graph, network, tensor_map, operation)?,
 
             // Indexing/Gathering operations
             "gather" => Self::add_gather_op(graph, network, tensor_map, operation)?,

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -25,22 +25,24 @@ use std::collections::{HashMap, HashSet};
 
 use half::f16;
 
-use super::{pool2d_shared::infer_pool2d_ceil_mode_from_output_sizes, ConvertedGraph, GraphConverter};
+use super::{
+    ConvertedGraph, GraphConverter, pool2d_shared::infer_pool2d_ceil_mode_from_output_sizes,
+};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
 use crate::shape_inference::{
-    infer_arg_reduce_shape, infer_pool2d_shape, infer_where_shape, Conv2dInputLayout, Pool2dOptions,
+    Conv2dInputLayout, Pool2dOptions, infer_arg_reduce_shape, infer_pool2d_shape, infer_where_shape,
 };
+use trtx::network::PoolingLayer;
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
     OwnedConvWeights, OwnedWeights, PaddingMode, PoolingType, ReduceOperation,
     ResizeCoordinateTransformation, ResizeMode, ResizeRoundMode, ScatterMode, TopKOperation,
     UnaryOperation,
 };
-use trtx::network::PoolingLayer;
 
 /// TensorRT native converter
 pub struct TrtxConverter;
@@ -412,19 +414,19 @@ impl TrtxConverter {
                     .collect();
                 let trt_io_name = Self::engine_binding_name(operand_id as u32);
 
-                let tensor = network
-                    .add_input(&trt_io_name, dtype, &dims)
-                    .map_err(|e| GraphError::ConversionFailed {
+                let tensor = network.add_input(&trt_io_name, dtype, &dims).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add input {}: {}", trt_io_name, e),
-                    })?;
+                    }
+                })?;
 
-                tensor
-                    .set_name(network, &trt_io_name)
-                    .map_err(|e| GraphError::ConversionFailed {
+                tensor.set_name(network, &trt_io_name).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to set input name: {}", e),
-                    })?;
+                    }
+                })?;
 
                 tensor_map.insert(operand_id as u32, tensor);
             }
@@ -830,7 +832,9 @@ impl TrtxConverter {
             "isNaN" => Self::add_is_nan_op(network, tensor_map, operation)?,
             "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation)?,
             "roundEven" => Self::add_round_even_op(network, tensor_map, operation)?,
-            "gatherElements" => Self::add_gather_elements_op(graph, network, tensor_map, operation)?,
+            "gatherElements" => {
+                Self::add_gather_elements_op(graph, network, tensor_map, operation)?
+            }
             "l2Pool2d" => Self::add_l2_pool2d_op(graph, network, tensor_map, operation)?,
             "reverse" => Self::add_reverse_op(graph, network, tensor_map, operation)?,
             "cumulativeSum" => Self::add_cumulative_sum_op(graph, network, tensor_map, operation)?,
@@ -1120,10 +1124,12 @@ impl TrtxConverter {
 
     /// Static shape dimensions for TRTX broadcast (all dims must be known).
     fn operand_shape_u32_static(graph: &GraphInfo, id: u32) -> Result<Vec<u32>, GraphError> {
-        let operand = graph.operand(id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("operand {} not in graph", id),
-        })?;
+        let operand = graph
+            .operand(id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("operand {} not in graph", id),
+            })?;
         let mut out = Vec::with_capacity(operand.descriptor.shape.len());
         for d in &operand.descriptor.shape {
             let s = get_static_or_max_size(d);
@@ -1150,14 +1156,18 @@ impl TrtxConverter {
         op_label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         if from_dims == target_dims {
-            let layer = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast identity: {e}"),
-            })?;
-            return layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast identity output: {e}"),
-            });
+            let layer = network
+                .add_identity(tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast identity: {e}"),
+                })?;
+            return layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast identity output: {e}"),
+                });
         }
 
         let mut cur: &trtx::Tensor<'a> = tensor;
@@ -1168,26 +1178,33 @@ impl TrtxConverter {
             let rank_diff = target_dims.len() - dims.len();
             let mut new_shape: Vec<i64> = vec![1i64; rank_diff];
             new_shape.extend_from_slice(&dims);
-            let mut shuffle_layer = network.add_shuffle(cur).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast shuffle: {e}"),
-            })?;
+            let mut shuffle_layer =
+                network
+                    .add_shuffle(cur)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_label} broadcast shuffle: {e}"),
+                    })?;
             shuffle_layer
                 .set_reshape_dimensions(network, &new_shape)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{op_label} broadcast reshape: {e}"),
                 })?;
-            let out = shuffle_layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast shuffle output: {e}"),
+            let out = shuffle_layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast shuffle output: {e}"),
+                }
             })?;
             staged = Some(out);
             dims = new_shape;
-            cur = staged.as_ref().ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast shuffle missing tensor"),
-            })?;
+            cur = staged
+                .as_ref()
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast shuffle missing tensor"),
+                })?;
         }
 
         if dims.len() != target_dims.len() {
@@ -1220,15 +1237,20 @@ impl TrtxConverter {
             };
         }
 
-        let mut resize_layer = network.add_resize(cur).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{op_label} broadcast resize: {e}"),
-        })?;
+        let mut resize_layer =
+            network
+                .add_resize(cur)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast resize: {e}"),
+                })?;
         resize_layer.set_output_dimensions(network, target_dims);
-        resize_layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{op_label} broadcast resize output: {e}"),
-        })
+        resize_layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast resize output: {e}"),
+            })
     }
 
     /// Add elementwise operation
@@ -2652,33 +2674,42 @@ impl TrtxConverter {
         tensor: &trtx::Tensor<'a>,
         label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
-        let dims = tensor.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{label}: dimensions: {e}"),
-        })?;
-        if dims.is_empty() {
-            let mut sh = network.add_shuffle(tensor).map_err(|e| GraphError::ConversionFailed {
+        let dims = tensor
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("{label}: rank-1 shuffle: {e}"),
+                reason: format!("{label}: dimensions: {e}"),
             })?;
-            sh.set_reshape_dimensions(network, &[1i64])
+        if dims.is_empty() {
+            let mut sh = network
+                .add_shuffle(tensor)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("{label}: reshape [1]: {e}"),
+                    reason: format!("{label}: rank-1 shuffle: {e}"),
                 })?;
-            sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{label}: shuffle output: {e}"),
-            })
-        } else {
-            let id = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{label}: identity: {e}"),
+            sh.set_reshape_dimensions(network, &[1i64]).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: reshape [1]: {e}"),
+                }
             })?;
-            id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{label}: identity output: {e}"),
-            })
+            sh.get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: shuffle output: {e}"),
+                })
+        } else {
+            let id = network
+                .add_identity(tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: identity: {e}"),
+                })?;
+            id.get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: identity output: {e}"),
+                })
         }
     }
 
@@ -2689,19 +2720,25 @@ impl TrtxConverter {
         target_rank: usize,
         label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
-        let dims = tensor.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{label}: prepend dimensions: {e}"),
-        })?;
-        if dims.len() == target_rank {
-            let id = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
+        let dims = tensor
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("{label}: prepend identity: {e}"),
+                reason: format!("{label}: prepend dimensions: {e}"),
             })?;
-            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{label}: prepend identity output: {e}"),
-            });
+        if dims.len() == target_rank {
+            let id = network
+                .add_identity(tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: prepend identity: {e}"),
+                })?;
+            return id
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: prepend identity output: {e}"),
+                });
         }
         if dims.len() > target_rank {
             return Err(GraphError::ConversionFailed {
@@ -2715,19 +2752,22 @@ impl TrtxConverter {
         }
         let mut new_shape = vec![1_i64; target_rank - dims.len()];
         new_shape.extend_from_slice(&dims);
-        let mut sh = network.add_shuffle(tensor).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{label}: prepend shuffle: {e}"),
-        })?;
+        let mut sh = network
+            .add_shuffle(tensor)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: prepend shuffle: {e}"),
+            })?;
         sh.set_reshape_dimensions(network, &new_shape)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label}: prepend reshape: {e}"),
             })?;
-        sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{label}: prepend shuffle output: {e}"),
-        })
+        sh.get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: prepend shuffle output: {e}"),
+            })
     }
 
     /// After `IDequantizeLayer` (scale = 1) on **kINT8** weights that hold **WebNN Uint8** bytes, recover
@@ -2739,10 +2779,12 @@ impl TrtxConverter {
         dq_out_ty: TrtDataType,
         label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
-        let dims = dq_out.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("{label} uint8 storage fix dimensions: {e}"),
-        })?;
+        let dims = dq_out
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 storage fix dimensions: {e}"),
+            })?;
         let bshape: Vec<i64> = if dims.is_empty() {
             vec![]
         } else {
@@ -2809,12 +2851,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix +256 out: {e}"),
             })?;
-        let layer = network
-            .add_select(&cond, &shifted, dq_out)
-            .map_err(|e| GraphError::ConversionFailed {
+        let layer = network.add_select(&cond, &shifted, dq_out).map_err(|e| {
+            GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix select: {e}"),
-            })?;
+            }
+        })?;
         layer
             .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
@@ -2868,12 +2910,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} identity DQ: {e}"),
             })?;
-        let dq_out = dq_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{label} identity DQ output: {e}"),
-            })?;
+        let dq_out =
+            dq_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label} identity DQ output: {e}"),
+                })?;
 
         match (webnn_integer_dtype, input_ty) {
             (DataType::Uint8, TrtDataType::kINT8) => {
@@ -2881,10 +2924,12 @@ impl TrtxConverter {
             }
             (DataType::Uint8, TrtDataType::kUINT8) => {
                 let dq_dims =
-                    dq_out.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{label} kUINT8 DQ+128 dimensions: {e}"),
-                    })?;
+                    dq_out
+                        .dimensions(&*network)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("{label} kUINT8 DQ+128 dimensions: {e}"),
+                        })?;
                 let bias_shape: Vec<i64> = if dq_dims.is_empty() {
                     vec![]
                 } else {
@@ -2946,22 +2991,21 @@ impl TrtxConverter {
         int8_uint8_identity_dq_to: Option<TrtDataType>,
         identity_dq_webnn_dtype: Option<DataType>,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
-        let dq_tensor: Option<trtx::Tensor<'a>> =
-            if let Some(dq_ty) = int8_uint8_identity_dq_to {
-                if matches!(
-                    tensor.get_type(&*network),
-                    TrtDataType::kINT8 | TrtDataType::kUINT8
-                ) {
-                    let wd = identity_dq_webnn_dtype.unwrap_or(DataType::Int8);
-                    Some(Self::trtx_int8_uint8_identity_dequantize(
-                        network, tensor, dq_ty, label, wd,
-                    )?)
-                } else {
-                    None
-                }
+        let dq_tensor: Option<trtx::Tensor<'a>> = if let Some(dq_ty) = int8_uint8_identity_dq_to {
+            if matches!(
+                tensor.get_type(&*network),
+                TrtDataType::kINT8 | TrtDataType::kUINT8
+            ) {
+                let wd = identity_dq_webnn_dtype.unwrap_or(DataType::Int8);
+                Some(Self::trtx_int8_uint8_identity_dequantize(
+                    network, tensor, dq_ty, label, wd,
+                )?)
             } else {
                 None
-            };
+            }
+        } else {
+            None
+        };
         let src_for_rank1 = dq_tensor.as_ref().unwrap_or(tensor);
         let mut cur = Self::trtx_qdq_ensure_rank1(network, src_for_rank1, label)?;
 
@@ -2969,12 +3013,7 @@ impl TrtxConverter {
             return Ok(cur);
         }
 
-        cur = Self::trtx_prepend_ones_to_trt_rank(
-            network,
-            &cur,
-            input_shape.len(),
-            label,
-        )?;
+        cur = Self::trtx_prepend_ones_to_trt_rank(network, &cur, input_shape.len(), label)?;
 
         let eff_shape_u32: Vec<u32> = cur
             .dimensions(&*network)
@@ -3059,8 +3098,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("{label}: block tile slice output ax={ax} k={k}: {e}"),
                     })?;
-                let dup_inputs: Vec<&trtx::Tensor<'a>> =
-                    (0..r_us).map(|_| &slice_out).collect();
+                let dup_inputs: Vec<&trtx::Tensor<'a>> = (0..r_us).map(|_| &slice_out).collect();
                 let mut cat = network.add_concatenation(&dup_inputs).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
@@ -3068,13 +3106,12 @@ impl TrtxConverter {
                     }
                 })?;
                 cat.set_axis(network, ax as i32);
-                expanded_parts.push(
-                    cat.get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("{label}: block tile dup out ax={ax} k={k}: {e}"),
-                        })?,
-                );
+                expanded_parts.push(cat.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label}: block tile dup out ax={ax} k={k}: {e}"),
+                    }
+                })?);
             }
             let part_refs: Vec<&trtx::Tensor<'a>> = expanded_parts.iter().collect();
             let mut cat2 = network.add_concatenation(&part_refs).map_err(|e| {
@@ -3100,10 +3137,12 @@ impl TrtxConverter {
         network: &trtx::NetworkDefinition<'a>,
         tensor: &trtx::Tensor<'a>,
     ) -> Result<bool, GraphError> {
-        let dims = tensor.dimensions(network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("tensor dimensions: {e}"),
-        })?;
+        let dims = tensor
+            .dimensions(network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("tensor dimensions: {e}"),
+            })?;
         Ok(dims.is_empty())
     }
 
@@ -3151,23 +3190,24 @@ impl TrtxConverter {
         // `trtx_align_quantize_param_for_elementwise` before any shuffle.
         let zp_q = Self::trtx_qdq_ensure_rank1(network, zero_point, "quantizeLinear zero_point")?;
 
-        let mut cast_if_needed = |t: trtx::Tensor<'a>, lab: &str| -> Result<trtx::Tensor<'a>, GraphError> {
-            if t.get_type(&*network) == compute_fp {
-                Ok(t)
-            } else {
-                network
-                    .add_cast(&t, compute_fp)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("quantizeLinear manual {lab} to compute fp: {e}"),
-                    })?
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("quantizeLinear manual {lab} cast out: {e}"),
-                    })
-            }
-        };
+        let mut cast_if_needed =
+            |t: trtx::Tensor<'a>, lab: &str| -> Result<trtx::Tensor<'a>, GraphError> {
+                if t.get_type(&*network) == compute_fp {
+                    Ok(t)
+                } else {
+                    network
+                        .add_cast(&t, compute_fp)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("quantizeLinear manual {lab} to compute fp: {e}"),
+                        })?
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("quantizeLinear manual {lab} cast out: {e}"),
+                        })
+                }
+            };
         let input_e = cast_if_needed(input_q, "input")?;
         let scale_e = cast_if_needed(scale_q, "scale")?;
         let zp_fp = cast_if_needed(zp_q, "zero_point")?;
@@ -3210,10 +3250,13 @@ impl TrtxConverter {
 
         // qmin/qmax must broadcast with `summed`. A single `[1]` constant is rank-1 and TRT rejects
         // elementwise with e.g. `[3,2]` (`nbDims` mismatch). Use `[1; rank]` so broadcasting applies.
-        let summed_dims = summed.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("quantizeLinear manual summed dimensions: {e}"),
-        })?;
+        let summed_dims =
+            summed
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear manual summed dimensions: {e}"),
+                })?;
         let broadcast_shape: Vec<i64> = vec![1_i64; summed_dims.len()];
 
         let (min_bytes, max_bytes) = match compute_fp {
@@ -3311,17 +3354,21 @@ impl TrtxConverter {
         let sc_id = ins[1];
 
         let output_id = operation.output_operands_slice()[0];
-        let out_operand = graph.operand(output_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("quantizeLinear output operand {output_id} not found"),
-        })?;
+        let out_operand = graph
+            .operand(output_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear output operand {output_id} not found"),
+            })?;
         let out_dtype = out_operand.descriptor.data_type;
         let out_trt = Self::webnn_to_trt_dtype(out_dtype)?;
 
-        let in_operand = graph.operand(ins[0]).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("quantizeLinear input operand {} not found", ins[0]),
-        })?;
+        let in_operand = graph
+            .operand(ins[0])
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear input operand {} not found", ins[0]),
+            })?;
         let fp_trt = Self::webnn_to_trt_dtype(in_operand.descriptor.data_type)?;
         if fp_trt != TrtDataType::kFLOAT && fp_trt != TrtDataType::kHALF {
             return Err(GraphError::ConversionFailed {
@@ -3334,25 +3381,31 @@ impl TrtxConverter {
         }
 
         let in_rank0 = {
-            let t = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Input operand {in_id} not found"),
-            })?;
+            let t = tensor_map
+                .get(&in_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Input operand {in_id} not found"),
+                })?;
             Self::trtx_tensor_dims_empty(&*network, t)?
         };
         let sc_rank0 = {
-            let t = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Scale operand {sc_id} not found"),
-            })?;
+            let t = tensor_map
+                .get(&sc_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Scale operand {sc_id} not found"),
+                })?;
             Self::trtx_tensor_dims_empty(&*network, t)?
         };
         let zp_rank0 = if ins.len() > 2 {
             let zid = ins[2];
-            let zp = tensor_map.get(&zid).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Zero point operand {zid} not found"),
-            })?;
+            let zp = tensor_map
+                .get(&zid)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Zero point operand {zid} not found"),
+                })?;
             Self::trtx_tensor_dims_empty(&*network, zp)?
         } else {
             false
@@ -3377,26 +3430,41 @@ impl TrtxConverter {
             let in_shape = in_operand.descriptor.static_or_max_shape();
             let out = if ins.len() > 2 {
                 let zid = ins[2];
-                let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Input operand {in_id} not found"),
-                })?;
-                let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Scale operand {sc_id} not found"),
-                })?;
-                let zp = tensor_map.get(&zid).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Zero point operand {zid} not found"),
-                })?;
-                let sc_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("quantizeLinear scale operand {sc_id} missing from graph"),
-                })?;
-                let z_operand = graph.operand(zid).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("quantizeLinear zero_point operand {zid} missing from graph"),
-                })?;
+                let input = tensor_map
+                    .get(&in_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Input operand {in_id} not found"),
+                    })?;
+                let scale = tensor_map
+                    .get(&sc_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Scale operand {sc_id} not found"),
+                    })?;
+                let zp = tensor_map
+                    .get(&zid)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Zero point operand {zid} not found"),
+                    })?;
+                let sc_operand =
+                    graph
+                        .operand(sc_id)
+                        .ok_or_else(|| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!(
+                                "quantizeLinear scale operand {sc_id} missing from graph"
+                            ),
+                        })?;
+                let z_operand = graph
+                    .operand(zid)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "quantizeLinear zero_point operand {zid} missing from graph"
+                        ),
+                    })?;
                 let sc_shape = sc_operand.descriptor.static_or_max_shape();
                 let z_shape = z_operand.descriptor.static_or_max_shape();
                 let scale_a = Self::trtx_align_quantize_param_for_elementwise(
@@ -3441,14 +3509,18 @@ impl TrtxConverter {
                         });
                     }
                 };
-                let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Input operand {in_id} not found"),
-                })?;
-                let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Scale operand {sc_id} not found"),
-                })?;
+                let input = tensor_map
+                    .get(&in_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Input operand {in_id} not found"),
+                    })?;
+                let scale = tensor_map
+                    .get(&sc_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Scale operand {sc_id} not found"),
+                    })?;
                 let zp_const = network
                     .add_small_constant_copied(&[1_i64], zp_bytes, zdt)
                     .map_err(|e| GraphError::ConversionFailed {
@@ -3460,10 +3532,15 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("quantizeLinear default zero_point output: {e}"),
                     })?;
-                let sc_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("quantizeLinear scale operand {sc_id} missing from graph"),
-                })?;
+                let sc_operand =
+                    graph
+                        .operand(sc_id)
+                        .ok_or_else(|| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!(
+                                "quantizeLinear scale operand {sc_id} missing from graph"
+                            ),
+                        })?;
                 let sc_shape = sc_operand.descriptor.static_or_max_shape();
                 let scale_a = Self::trtx_align_quantize_param_for_elementwise(
                     network,
@@ -3484,31 +3561,30 @@ impl TrtxConverter {
                     Some(out_dtype),
                 )?;
                 Self::add_quantize_linear_elementwise_manual(
-                    network,
-                    input,
-                    &scale_a,
-                    &zp_a,
-                    fp_trt,
-                    out_trt,
-                    out_dtype,
+                    network, input, &scale_a, &zp_a, fp_trt, out_trt, out_dtype,
                 )?
             };
             // Elementwise path uses `trtx_qdq_ensure_rank1`, so scalar inputs become `[1]`. WebNN
             // output rank must match the float input (e.g. `[]` not `[1]`).
             let out = if in_shape.is_empty() {
-                let mut sh = network.add_shuffle(&out).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("quantizeLinear scalar output shuffle: {e}"),
-                })?;
-                sh.set_reshape_dimensions(network, &[])
-                    .map_err(|e| GraphError::ConversionFailed {
+                let mut sh =
+                    network
+                        .add_shuffle(&out)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("quantizeLinear scalar output shuffle: {e}"),
+                        })?;
+                sh.set_reshape_dimensions(network, &[]).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("quantizeLinear scalar output reshape: {e}"),
-                    })?;
-                sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("quantizeLinear scalar shuffle output: {e}"),
-                })?
+                    }
+                })?;
+                sh.get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear scalar shuffle output: {e}"),
+                    })?
             } else {
                 out
             };
@@ -3516,14 +3592,18 @@ impl TrtxConverter {
             return Ok(());
         }
 
-        let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Input operand {in_id} not found"),
-        })?;
-        let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Scale operand {sc_id} not found"),
-        })?;
+        let input = tensor_map
+            .get(&in_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Input operand {in_id} not found"),
+            })?;
+        let scale = tensor_map
+            .get(&sc_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Scale operand {sc_id} not found"),
+            })?;
 
         let input_q = Self::trtx_qdq_ensure_rank1(network, input, "quantizeLinear input")?;
         let scale_q = Self::trtx_qdq_ensure_rank1(network, scale, "quantizeLinear scale")?;
@@ -3563,10 +3643,12 @@ impl TrtxConverter {
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
-        let out_operand = graph.operand(output_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("dequantizeLinear output operand {output_id} not found"),
-        })?;
+        let out_operand = graph
+            .operand(output_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear output operand {output_id} not found"),
+            })?;
         let out_trt = match out_operand.descriptor.data_type {
             DataType::Float32 => TrtDataType::kFLOAT,
             DataType::Float16 => TrtDataType::kHALF,
@@ -3581,14 +3663,18 @@ impl TrtxConverter {
             }
         };
 
-        let input_operand = graph.operand(in_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("dequantizeLinear input operand {in_id} not found"),
-        })?;
-        let scale_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("dequantizeLinear scale operand {sc_id} not found"),
-        })?;
+        let input_operand = graph
+            .operand(in_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear input operand {in_id} not found"),
+            })?;
+        let scale_operand = graph
+            .operand(sc_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear scale operand {sc_id} not found"),
+            })?;
         let fp_trt = match scale_operand.descriptor.data_type {
             DataType::Float32 => TrtDataType::kFLOAT,
             DataType::Float16 => TrtDataType::kHALF,
@@ -3603,15 +3689,19 @@ impl TrtxConverter {
             }
         };
 
-        let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Input operand {in_id} not found"),
-        })?;
+        let input = tensor_map
+            .get(&in_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Input operand {in_id} not found"),
+            })?;
 
-        let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Scale operand {sc_id} not found"),
-        })?;
+        let scale = tensor_map
+            .get(&sc_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Scale operand {sc_id} not found"),
+            })?;
 
         let input_dims = input
             .dimensions(&*network)
@@ -3655,23 +3745,28 @@ impl TrtxConverter {
                 reason: format!("Failed to add dequantize layer: {}", e),
             })?;
 
-        let mut dq_out = dq_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get dequantize output: {}", e),
-            })?;
+        let mut dq_out =
+            dq_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get dequantize output: {}", e),
+                })?;
 
         if ins.len() > 2 {
             let z_id = ins[2];
-            let zp = tensor_map.get(&z_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Zero point operand {z_id} not found"),
-            })?;
-            let z_operand = graph.operand(z_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("dequantizeLinear zero_point operand {z_id} not in graph"),
-            })?;
+            let zp = tensor_map
+                .get(&z_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Zero point operand {z_id} not found"),
+                })?;
+            let z_operand = graph
+                .operand(z_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point operand {z_id} not in graph"),
+                })?;
             // kINT8/kUINT8 constants must feed Constant -> DQ before other layers (QDQ validator).
             let zp_q = if matches!(
                 zp.get_type(&*network),
@@ -3690,32 +3785,38 @@ impl TrtxConverter {
                 } else {
                     Self::trtx_qdq_ensure_rank1(network, &zp_dq, "dequantizeLinear zero_point")?
                 }
-            } else if scalar_dq && z_operand.descriptor.static_or_max_shape().is_empty()
+            } else if scalar_dq
+                && z_operand.descriptor.static_or_max_shape().is_empty()
                 && Self::trtx_tensor_dims_empty(network, zp)?
             {
-                let id = network.add_identity(zp).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("dequantizeLinear zero_point identity: {e}"),
-                })?;
-                id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("dequantizeLinear zero_point identity output: {e}"),
-                })?
+                let id = network
+                    .add_identity(zp)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("dequantizeLinear zero_point identity: {e}"),
+                    })?;
+                id.get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("dequantizeLinear zero_point identity output: {e}"),
+                    })?
             } else {
                 Self::trtx_qdq_ensure_rank1(network, zp, "dequantizeLinear zero_point")?
             };
-            let zp_fp_layer = network.add_cast(&zp_q, fp_trt).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("dequantizeLinear zero_point cast: {}", e),
-                }
-            })?;
-            let zp_fp = zp_fp_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("dequantizeLinear zero_point cast output: {}", e),
-                })?;
+            let zp_fp_layer =
+                network
+                    .add_cast(&zp_q, fp_trt)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("dequantizeLinear zero_point cast: {}", e),
+                    })?;
+            let zp_fp =
+                zp_fp_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("dequantizeLinear zero_point cast output: {}", e),
+                    })?;
             let zp_times_scale = network
                 .add_elementwise(&zp_fp, scale_for_zp, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -3777,38 +3878,39 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(input)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("globalPool NHWC->NCHW shuffle: {e}"),
-                })?;
-            shuffle
-                .set_first_transpose(network, &[0, 3, 1, 2])
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("globalPool set_first_transpose NHWC: {e}"),
-                })?;
-            Some(
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
+            if layout == "nhwc" {
+                let mut shuffle =
+                    network
+                        .add_shuffle(input)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("globalPool NHWC->NCHW shuffle: {e}"),
+                        })?;
                 shuffle
-                    .get_output(&*network, 0)
+                    .set_first_transpose(network, &[0, 3, 1, 2])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("globalPool set_first_transpose NHWC: {e}"),
+                    })?;
+                Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("globalPool NHWC shuffle output: {e}"),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let pool_in = nhwc_to_nchw.as_ref().unwrap_or(input);
 
-        let input_dims = pool_in
-            .dimensions(&*network)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get input dimensions: {}", e),
-            })?;
+        let input_dims =
+            pool_in
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get input dimensions: {}", e),
+                })?;
 
         if input_dims.len() < 4 {
             return Err(GraphError::ConversionFailed {
@@ -3829,20 +3931,22 @@ impl TrtxConverter {
                 reason: format!("Failed to add global pooling: {}", e),
             })?;
 
-        let pooled_nchw = layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
-
-        let output = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(&pooled_nchw)
+        let pooled_nchw =
+            layer
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("globalPool NCHW->NHWC shuffle: {e}"),
+                    reason: format!("Failed to get layer output: {}", e),
                 })?;
+
+        let output = if layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(&pooled_nchw)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("globalPool NCHW->NHWC shuffle: {e}"),
+                    })?;
             shuffle
                 .set_first_transpose(network, &[0, 2, 3, 1])
                 .map_err(|e| GraphError::ConversionFailed {
@@ -6282,10 +6386,12 @@ impl TrtxConverter {
 
         let input_id = operation.input_operands()[0];
         let input_rank = {
-            let input = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Tile: input operand {} not found", input_id),
-            })?;
+            let input = tensor_map
+                .get(&input_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Tile: input operand {} not found", input_id),
+                })?;
             input
                 .dimensions(&*network)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -6360,23 +6466,30 @@ impl TrtxConverter {
         let output_id = output_ids[0];
 
         if produced_temp {
-            let final_tensor = tensor_map.remove(&current_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Tile: missing intermediate tensor {}", current_id),
-            })?;
+            let final_tensor =
+                tensor_map
+                    .remove(&current_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Tile: missing intermediate tensor {}", current_id),
+                    })?;
             tensor_map.insert(output_id, final_tensor);
         } else {
             // No concat tiling (all reps <= 1, or rank-0 with repetitions []): keep input in map, identity to output.
-            let input_tensor = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Tile: input {} missing for identity", input_id),
-            })?;
-            let identity_layer = network.add_identity(input_tensor).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Tile: identity: {}", e),
-                }
-            })?;
+            let input_tensor =
+                tensor_map
+                    .get(&input_id)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Tile: input {} missing for identity", input_id),
+                    })?;
+            let identity_layer =
+                network
+                    .add_identity(input_tensor)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Tile: identity: {}", e),
+                    })?;
             let output_tensor = identity_layer.get_output(&*network, 0).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
@@ -6871,13 +6984,12 @@ impl TrtxConverter {
         let prefix_count: usize = if r <= 1 {
             1usize
         } else {
-            idx_dims[..r - 1]
-                .iter()
-                .map(|&x| x as usize)
-                .product()
+            idx_dims[..r - 1].iter().map(|&x| x as usize).product()
         };
-        let mut min_data: Vec<u8> = Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
-        let mut max_data: Vec<u8> = Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
+        let mut min_data: Vec<u8> =
+            Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
+        let mut max_data: Vec<u8> =
+            Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
         for _ in 0..prefix_count {
             for j in 0..k {
                 min_data.extend_from_slice(&mins_k[j].to_le_bytes());
@@ -6899,18 +7011,20 @@ impl TrtxConverter {
                 reason: format!("gatherND: clamp max constant: {}", e),
             })?;
 
-        let min_const_out = min_const
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherND: clamp min output: {}", e),
-            })?;
-        let max_const_out = max_const
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherND: clamp max output: {}", e),
-            })?;
+        let min_const_out =
+            min_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherND: clamp min output: {}", e),
+                })?;
+        let max_const_out =
+            max_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherND: clamp max output: {}", e),
+                })?;
 
         let clamped_upper = network
             .add_elementwise(indices, &max_const_out, ElementWiseOperation::kMIN)
@@ -6918,12 +7032,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("gatherND: indices clamp upper: {}", e),
             })?;
-        let clamped_upper_out = clamped_upper
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherND: clamp upper tensor: {}", e),
-            })?;
+        let clamped_upper_out =
+            clamped_upper
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherND: clamp upper tensor: {}", e),
+                })?;
 
         let clamped = network
             .add_elementwise(
@@ -6935,20 +7050,20 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("gatherND: indices clamp lower: {}", e),
             })?;
-        let clamped_indices = clamped
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherND: clamped indices: {}", e),
-            })?;
-
-        let mut layer =
-            network
-                .add_gather(input, &clamped_indices, 0)
+        let clamped_indices =
+            clamped
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Failed to add gatherND layer: {}", e),
+                    reason: format!("gatherND: clamped indices: {}", e),
                 })?;
+
+        let mut layer = network
+            .add_gather(input, &clamped_indices, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to add gatherND layer: {}", e),
+            })?;
 
         layer.set_gather_mode(network, trtx::GatherMode::kND);
 
@@ -7199,13 +7314,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("{}: topK layer: {}", label, e),
                 })?;
-            let idx =
-                layer
-                    .get_output(&*network, 1)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{}: topK indices output: {}", label, e),
-                    })?;
+            let idx = layer
+                .get_output(&*network, 1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{}: topK indices output: {}", label, e),
+                })?;
 
             let mut shuffle_post =
                 network
@@ -7241,13 +7355,12 @@ impl TrtxConverter {
                 })?
         };
 
-        let mut shuffle_layer =
-            network
-                .add_shuffle(&indices_pre_reshape)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{}: shuffle for output shape: {}", label, e),
-                })?;
+        let mut shuffle_layer = network.add_shuffle(&indices_pre_reshape).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{}: shuffle for output shape: {}", label, e),
+            }
+        })?;
         shuffle_layer
             .set_reshape_dimensions(network, &target_shape_i64)
             .map_err(|e| GraphError::ConversionFailed {
@@ -7620,12 +7733,13 @@ impl TrtxConverter {
                 reason: format!("True value operand {} not found", true_id),
             })?;
 
-        let false_value = tensor_map
-            .get(&false_id)
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("False value operand {} not found", false_id),
-            })?;
+        let false_value =
+            tensor_map
+                .get(&false_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("False value operand {} not found", false_id),
+                })?;
 
         let shape_c = Self::operand_shape_u32_static(graph, cond_id)?;
         let shape_t = Self::operand_shape_u32_static(graph, true_id)?;
@@ -7645,12 +7759,27 @@ impl TrtxConverter {
         };
         let cond_f: &trtx::Tensor<'a> = cond_float_promoted.as_ref().unwrap_or(condition);
 
-        let cond_bc =
-            Self::broadcast_trtx_tensor_to_dims(network, cond_f, &cond_in, &target_i64, "where_cond")?;
-        let true_bc =
-            Self::broadcast_trtx_tensor_to_dims(network, true_value, &true_in, &target_i64, "where_true")?;
-        let false_bc =
-            Self::broadcast_trtx_tensor_to_dims(network, false_value, &false_in, &target_i64, "where_false")?;
+        let cond_bc = Self::broadcast_trtx_tensor_to_dims(
+            network,
+            cond_f,
+            &cond_in,
+            &target_i64,
+            "where_cond",
+        )?;
+        let true_bc = Self::broadcast_trtx_tensor_to_dims(
+            network,
+            true_value,
+            &true_in,
+            &target_i64,
+            "where_true",
+        )?;
+        let false_bc = Self::broadcast_trtx_tensor_to_dims(
+            network,
+            false_value,
+            &false_in,
+            &target_i64,
+            "where_false",
+        )?;
 
         let condition_bool = Self::cast_to_bool(network, &cond_bc)?;
 
@@ -7848,23 +7977,26 @@ impl TrtxConverter {
         fill_f32: f32,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         if pre <= 0 && post <= 0 {
-            let id =
-                network
-                    .add_identity(input)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad concat: identity: {}", e),
-                    })?;
-            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Pad concat: identity output: {}", e),
-            });
+            let id = network
+                .add_identity(input)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: identity: {}", e),
+                })?;
+            return id
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: identity output: {}", e),
+                });
         }
 
-        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad concat: dimensions: {}", e),
-        })?;
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad concat: dimensions: {}", e),
+            })?;
         let rank = dims.len();
         if axis >= rank {
             return Err(GraphError::ConversionFailed {
@@ -7903,26 +8035,27 @@ impl TrtxConverter {
             _ => unreachable!(),
         };
 
-        let mut make_const =
-            |axis_len: i64| -> Result<trtx::Tensor<'a>, GraphError> {
-                let mut shape = dims.clone();
-                shape[axis] = axis_len;
-                let n: usize = shape.iter().map(|&d| d.max(0) as usize).product();
-                let mut data = Vec::with_capacity(n * elem_size);
-                for _ in 0..n {
-                    data.extend_from_slice(&one_elem_bytes);
-                }
-                let layer = network
-                    .add_small_constant_copied(&shape, &data, trt_dtype)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad concat: constant: {}", e),
-                    })?;
-                layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+        let mut make_const = |axis_len: i64| -> Result<trtx::Tensor<'a>, GraphError> {
+            let mut shape = dims.clone();
+            shape[axis] = axis_len;
+            let n: usize = shape.iter().map(|&d| d.max(0) as usize).product();
+            let mut data = Vec::with_capacity(n * elem_size);
+            for _ in 0..n {
+                data.extend_from_slice(&one_elem_bytes);
+            }
+            let layer = network
+                .add_small_constant_copied(&shape, &data, trt_dtype)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: constant: {}", e),
+                })?;
+            layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad concat: constant output: {}", e),
                 })
-            };
+        };
 
         let mut pieces: Vec<&trtx::Tensor<'a>> = Vec::new();
         let pre_t = if pre > 0 {
@@ -7943,17 +8076,19 @@ impl TrtxConverter {
             pieces.push(t);
         }
 
-        let mut cat = network
-            .add_concatenation(&pieces)
+        let mut cat =
+            network
+                .add_concatenation(&pieces)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: concat: {}", e),
+                })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Pad concat: concat: {}", e),
-            })?;
-        cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad concat: concat out: {}", e),
-        })
+                reason: format!("Pad concat: concat out: {}", e),
+            })
     }
 
     /// Edge pad on one axis: replicate first / last slice along `axis` (WebNN `mode == "edge"`).
@@ -7965,23 +8100,26 @@ impl TrtxConverter {
         post: i32,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         if pre <= 0 && post <= 0 {
-            let id =
-                network
-                    .add_identity(input)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad edge: identity: {}", e),
-                    })?;
-            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Pad edge: identity output: {}", e),
-            });
+            let id = network
+                .add_identity(input)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad edge: identity: {}", e),
+                })?;
+            return id
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad edge: identity output: {}", e),
+                });
         }
 
-        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad edge: dimensions: {}", e),
-        })?;
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: dimensions: {}", e),
+            })?;
         let rank = dims.len();
         if axis >= rank {
             return Err(GraphError::ConversionFailed {
@@ -8002,37 +8140,37 @@ impl TrtxConverter {
         let start_left = vec![0i64; rank];
         let mut size_left = dims.clone();
         size_left[axis] = 1;
-        let left_layer =
-            network
-                .add_slice(input, &start_left, &size_left, &stride)
+        let left_layer = network
+            .add_slice(input, &start_left, &size_left, &stride)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: left slice: {}", e),
+            })?;
+        let left_t =
+            left_layer
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Pad edge: left slice: {}", e),
+                    reason: format!("Pad edge: left slice output: {}", e),
                 })?;
-        let left_t = left_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Pad edge: left slice output: {}", e),
-            }
-        })?;
 
         let mut start_right = vec![0i64; rank];
         start_right[axis] = d_ax - 1;
         let mut size_right = dims.clone();
         size_right[axis] = 1;
-        let right_layer =
-            network
-                .add_slice(input, &start_right, &size_right, &stride)
+        let right_layer = network
+            .add_slice(input, &start_right, &size_right, &stride)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: right slice: {}", e),
+            })?;
+        let right_t =
+            right_layer
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Pad edge: right slice: {}", e),
+                    reason: format!("Pad edge: right slice output: {}", e),
                 })?;
-        let right_t = right_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Pad edge: right slice output: {}", e),
-            }
-        })?;
 
         let mut cat_inputs: Vec<&trtx::Tensor<'a>> = Vec::new();
         for _ in 0..pre {
@@ -8043,17 +8181,19 @@ impl TrtxConverter {
             cat_inputs.push(&right_t);
         }
 
-        let mut cat = network
-            .add_concatenation(&cat_inputs)
+        let mut cat =
+            network
+                .add_concatenation(&cat_inputs)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad edge: concat: {}", e),
+                })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Pad edge: concat: {}", e),
-            })?;
-        cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad edge: concat out: {}", e),
-        })
+                reason: format!("Pad edge: concat out: {}", e),
+            })
     }
 
     /// Reflection pad on one axis (NumPy / ONNX `reflect`: mirror interior, excluding the edge).
@@ -8066,23 +8206,26 @@ impl TrtxConverter {
         post: i32,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         if pre <= 0 && post <= 0 {
-            let id =
-                network
-                    .add_identity(input)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad reflect: identity: {}", e),
-                    })?;
-            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Pad reflect: identity output: {}", e),
-            });
+            let id = network
+                .add_identity(input)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: identity: {}", e),
+                })?;
+            return id
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: identity output: {}", e),
+                });
         }
 
-        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad reflect: dimensions: {}", e),
-        })?;
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad reflect: dimensions: {}", e),
+            })?;
         let rank = dims.len();
         if axis >= rank {
             return Err(GraphError::ConversionFailed {
@@ -8114,19 +8257,19 @@ impl TrtxConverter {
             start[axis] = idx;
             let mut size = dims.clone();
             size[axis] = 1;
-            let layer =
-                network
-                    .add_slice(input, &start, &size, &stride)
+            let layer = network
+                .add_slice(input, &start, &size, &stride)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: pre slice: {}", e),
+                })?;
+            let slab =
+                layer
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Pad reflect: pre slice: {}", e),
+                        reason: format!("Pad reflect: pre slice out: {}", e),
                     })?;
-            let slab = layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Pad reflect: pre slice out: {}", e),
-                }
-            })?;
             pre_slabs.push(slab);
         }
 
@@ -8137,38 +8280,39 @@ impl TrtxConverter {
             start[axis] = idx;
             let mut size = dims.clone();
             size[axis] = 1;
-            let layer =
-                network
-                    .add_slice(input, &start, &size, &stride)
+            let layer = network
+                .add_slice(input, &start, &size, &stride)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: post slice: {}", e),
+                })?;
+            let slab =
+                layer
+                    .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Pad reflect: post slice: {}", e),
+                        reason: format!("Pad reflect: post slice out: {}", e),
                     })?;
-            let slab = layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Pad reflect: post slice out: {}", e),
-                }
-            })?;
             post_slabs.push(slab);
         }
 
-        let mut cat_inputs: Vec<&trtx::Tensor<'a>> =
-            pre_slabs.iter().collect::<Vec<_>>();
+        let mut cat_inputs: Vec<&trtx::Tensor<'a>> = pre_slabs.iter().collect::<Vec<_>>();
         cat_inputs.push(input);
         cat_inputs.extend(post_slabs.iter());
 
-        let mut cat = network
-            .add_concatenation(&cat_inputs)
+        let mut cat =
+            network
+                .add_concatenation(&cat_inputs)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: concat: {}", e),
+                })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Pad reflect: concat: {}", e),
-            })?;
-        cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pad reflect: concat out: {}", e),
-        })
+                reason: format!("Pad reflect: concat out: {}", e),
+            })
     }
 
     /// Add pad operation (pad tensor with constant/edge/reflection values)
@@ -8253,12 +8397,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Pad no-op: failed to add identity: {}", e),
                     })?;
-            let out = identity
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Pad no-op: identity output: {}", e),
-                })?;
+            let out =
+                identity
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad no-op: identity output: {}", e),
+                    })?;
             tensor_map.insert(operation.output_operands_slice()[0], out);
             return Ok(());
         }
@@ -8266,11 +8411,9 @@ impl TrtxConverter {
         let original_ndims = input_dims.len();
 
         let pad_mode_norm = pad_opts.mode.to_lowercase();
-        let is_constant_pad_mode =
-            pad_mode_norm.is_empty() || pad_mode_norm == "constant";
+        let is_constant_pad_mode = pad_mode_norm.is_empty() || pad_mode_norm == "constant";
         let is_edge_pad_mode = pad_mode_norm == "edge";
-        let is_reflect_pad_mode =
-            pad_mode_norm == "reflection" || pad_mode_norm == "reflect";
+        let is_reflect_pad_mode = pad_mode_norm == "reflection" || pad_mode_norm == "reflect";
         if !pad_mode_norm.is_empty()
             && !is_constant_pad_mode
             && !is_edge_pad_mode
@@ -8303,9 +8446,8 @@ impl TrtxConverter {
                 trt_d >= 2 || (pre_padding[wi] == 0 && post_padding[wi] == 0)
             })
         } else {
-            (0..original_ndims.saturating_sub(2)).all(|wi| {
-                pre_padding[wi] == 0 && post_padding[wi] == 0
-            })
+            (0..original_ndims.saturating_sub(2))
+                .all(|wi| pre_padding[wi] == 0 && post_padding[wi] == 0)
         };
 
         // `IPaddingLayer` is zero-only and 2D; edge / non-zero constant use slice+concat or constant+concat.
@@ -8327,10 +8469,12 @@ impl TrtxConverter {
                     continue;
                 }
                 any = true;
-                let t = tensor_map.get(&cur_key).ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Pad concat: tensor {cur_key} not found"),
-                })?;
+                let t = tensor_map
+                    .get(&cur_key)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad concat: tensor {cur_key} not found"),
+                    })?;
                 let new_t = if is_edge_pad_mode {
                     Self::trtx_pad_axis_edge_concat(network, t, ax, pr, po)?
                 } else if is_reflect_pad_mode {
@@ -8349,13 +8493,17 @@ impl TrtxConverter {
             if !any {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: "Pad: internal error (concat path but no non-zero axis pad)".to_string(),
+                    reason: "Pad: internal error (concat path but no non-zero axis pad)"
+                        .to_string(),
                 });
             }
-            let final_t = tensor_map.remove(&cur_key).ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Pad concat: missing final tensor".to_string(),
-            })?;
+            let final_t =
+                tensor_map
+                    .remove(&cur_key)
+                    .ok_or_else(|| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "Pad concat: missing final tensor".to_string(),
+                    })?;
             tensor_map.insert(out_id, final_t);
             return Ok(());
         }
@@ -9172,32 +9320,30 @@ impl TrtxConverter {
                     };
                 let bias_tensor_to_use = bias_tensor_for_conv.as_ref().or(bias_tensor_raw);
 
-                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> =
-                    if filter_layout != "oihw" {
-                        let perm = Self::conv_dynamic_filter_first_transpose(filter_layout)?;
-                        let mut shuffle = network
-                            .add_shuffle(filter_tensor_to_use)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("Conv2d dynamic filter layout shuffle: {}", e),
-                            })?;
-                        shuffle
-                            .set_first_transpose(network, &perm)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("Conv2d dynamic filter set_first_transpose: {}", e),
-                            })?;
-                        Some(
-                            shuffle
-                                .get_output(&*network, 0)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("Conv2d dynamic filter shuffle output: {}", e),
-                                })?,
-                        )
-                    } else {
-                        None
-                    };
+                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> = if filter_layout != "oihw"
+                {
+                    let perm = Self::conv_dynamic_filter_first_transpose(filter_layout)?;
+                    let mut shuffle = network.add_shuffle(filter_tensor_to_use).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Conv2d dynamic filter layout shuffle: {}", e),
+                        }
+                    })?;
+                    shuffle.set_first_transpose(network, &perm).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Conv2d dynamic filter set_first_transpose: {}", e),
+                        }
+                    })?;
+                    Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Conv2d dynamic filter shuffle output: {}", e),
+                        }
+                    })?)
+                } else {
+                    None
+                };
                 let filter_for_set_input = filter_layout_shuffle_out
                     .as_ref()
                     .unwrap_or(filter_tensor_to_use);
@@ -9666,41 +9812,33 @@ impl TrtxConverter {
                 };
                 let bias_tensor_to_use = bias_tensor_for_conv.as_ref().or(bias_tensor_raw);
 
-                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> =
-                    if filter_layout != "iohw" {
-                        let perm = Self::deconv_dynamic_filter_first_transpose(filter_layout)?;
-                        let mut shuffle = network
-                            .add_shuffle(filter_tensor_to_use)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!(
-                                    "convTranspose2d dynamic filter layout shuffle: {}",
-                                    e
-                                ),
-                            })?;
-                        shuffle
-                            .set_first_transpose(network, &perm)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!(
-                                    "convTranspose2d dynamic filter set_first_transpose: {}",
-                                    e
-                                ),
-                            })?;
-                        Some(
-                            shuffle
-                                .get_output(&*network, 0)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!(
-                                        "convTranspose2d dynamic filter shuffle output: {}",
-                                        e
-                                    ),
-                                })?,
-                        )
-                    } else {
-                        None
-                    };
+                let filter_layout_shuffle_out: Option<trtx::Tensor<'a>> = if filter_layout != "iohw"
+                {
+                    let perm = Self::deconv_dynamic_filter_first_transpose(filter_layout)?;
+                    let mut shuffle = network.add_shuffle(filter_tensor_to_use).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("convTranspose2d dynamic filter layout shuffle: {}", e),
+                        }
+                    })?;
+                    shuffle.set_first_transpose(network, &perm).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!(
+                                "convTranspose2d dynamic filter set_first_transpose: {}",
+                                e
+                            ),
+                        }
+                    })?;
+                    Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("convTranspose2d dynamic filter shuffle output: {}", e),
+                        }
+                    })?)
+                } else {
+                    None
+                };
                 let filter_for_set_input = filter_layout_shuffle_out
                     .as_ref()
                     .unwrap_or(filter_tensor_to_use);
@@ -9845,112 +9983,109 @@ impl TrtxConverter {
                 if in_shape.len() != 4 {
                     deconv_output
                 } else {
-                    let targets: Option<(i32, i32, i32)> =
-                        if let Some(sizes) = deconv_opts.and_then(|o| o.output_sizes.as_ref())
-                            && sizes.len() >= 2
-                        {
-                            Some((sizes[0] as i32, sizes[1] as i32, num_output_maps))
-                        } else if let Some(output_operand) = graph.operand(output_id) {
-                            let out_shape = &output_operand.descriptor.shape;
-                            if out_shape.len() != 4 {
-                                None
-                            } else if input_layout == "nhwc" {
-                                Some((
-                                    get_static_or_max_size(&out_shape[1]) as i32,
-                                    get_static_or_max_size(&out_shape[2]) as i32,
-                                    get_static_or_max_size(&out_shape[3]) as i32,
-                                ))
-                            } else {
-                                Some((
-                                    get_static_or_max_size(&out_shape[2]) as i32,
-                                    get_static_or_max_size(&out_shape[3]) as i32,
-                                    get_static_or_max_size(&out_shape[1]) as i32,
-                                ))
-                            }
-                        } else {
+                    let targets: Option<(i32, i32, i32)> = if let Some(sizes) =
+                        deconv_opts.and_then(|o| o.output_sizes.as_ref())
+                        && sizes.len() >= 2
+                    {
+                        Some((sizes[0] as i32, sizes[1] as i32, num_output_maps))
+                    } else if let Some(output_operand) = graph.operand(output_id) {
+                        let out_shape = &output_operand.descriptor.shape;
+                        if out_shape.len() != 4 {
                             None
-                        };
+                        } else if input_layout == "nhwc" {
+                            Some((
+                                get_static_or_max_size(&out_shape[1]) as i32,
+                                get_static_or_max_size(&out_shape[2]) as i32,
+                                get_static_or_max_size(&out_shape[3]) as i32,
+                            ))
+                        } else {
+                            Some((
+                                get_static_or_max_size(&out_shape[2]) as i32,
+                                get_static_or_max_size(&out_shape[3]) as i32,
+                                get_static_or_max_size(&out_shape[1]) as i32,
+                            ))
+                        }
+                    } else {
+                        None
+                    };
 
                     match targets {
-                        Some((target_h, target_w, out_c))
-                            if target_h > 0 && target_w > 0 =>
-                        {
-                    let (input_h, input_w): (i32, i32) = if input_layout == "nhwc" {
-                        (
-                            get_static_or_max_size(&in_shape[1]) as i32,
-                            get_static_or_max_size(&in_shape[2]) as i32,
-                        )
-                    } else {
-                        (
-                            get_static_or_max_size(&in_shape[2]) as i32,
-                            get_static_or_max_size(&in_shape[3]) as i32,
-                        )
-                    };
-                    let out_batch = get_static_or_max_size(&in_shape[0]) as i32;
-                        let effective_kernel_h = (kernel_size[0] - 1) * dilations[0] + 1;
-                        let effective_kernel_w = (kernel_size[1] - 1) * dilations[1] + 1;
-                        // Output = (Input - 1) * Stride + (Filter - 1) * Dilation + 1 - PrePadding - PostPadding + outputPadding.
-                        let current_h = (input_h - 1) * strides[0] + effective_kernel_h
-                            - pre_padding[0]
-                            - post_padding[0]
-                            + output_padding[0];
-                        let current_w = (input_w - 1) * strides[1] + effective_kernel_w
-                            - pre_padding[1]
-                            - post_padding[1]
-                            + output_padding[1];
-                        let slice_h = current_h.min(target_h);
-                        let slice_w = current_w.min(target_w);
-                        let mut current = deconv_output;
-                        if slice_h < current_h || slice_w < current_w {
-                            let start: Vec<i64> = vec![0, 0, 0, 0];
-                            let size: Vec<i64> = vec![
-                                out_batch as i64,
-                                out_c as i64,
-                                slice_h as i64,
-                                slice_w as i64,
-                            ];
-                            let stride: Vec<i64> = vec![1, 1, 1, 1];
-                            let slice_layer = network
-                                .add_slice(&current, &start, &size, &stride)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("convTranspose2d outputSizes slice: {}", e),
-                            })?;
-                            current = slice_layer.get_output(&*network, 0).map_err(|e| {
-                                GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!(
-                                        "convTranspose2d outputSizes slice output: {}",
-                                        e
-                                    ),
-                                }
-                            })?;
-                        }
-                        let pad_h = target_h - slice_h;
-                        let pad_w = target_w - slice_w;
-                        if pad_h > 0 || pad_w > 0 {
-                            let pre: Vec<i64> = vec![0, 0];
-                            let post: Vec<i64> = vec![pad_h as i64, pad_w as i64];
-                            let pad_layer =
-                                network.add_padding(&current, &pre, &post).map_err(|e| {
+                        Some((target_h, target_w, out_c)) if target_h > 0 && target_w > 0 => {
+                            let (input_h, input_w): (i32, i32) = if input_layout == "nhwc" {
+                                (
+                                    get_static_or_max_size(&in_shape[1]) as i32,
+                                    get_static_or_max_size(&in_shape[2]) as i32,
+                                )
+                            } else {
+                                (
+                                    get_static_or_max_size(&in_shape[2]) as i32,
+                                    get_static_or_max_size(&in_shape[3]) as i32,
+                                )
+                            };
+                            let out_batch = get_static_or_max_size(&in_shape[0]) as i32;
+                            let effective_kernel_h = (kernel_size[0] - 1) * dilations[0] + 1;
+                            let effective_kernel_w = (kernel_size[1] - 1) * dilations[1] + 1;
+                            // Output = (Input - 1) * Stride + (Filter - 1) * Dilation + 1 - PrePadding - PostPadding + outputPadding.
+                            let current_h = (input_h - 1) * strides[0] + effective_kernel_h
+                                - pre_padding[0]
+                                - post_padding[0]
+                                + output_padding[0];
+                            let current_w = (input_w - 1) * strides[1] + effective_kernel_w
+                                - pre_padding[1]
+                                - post_padding[1]
+                                + output_padding[1];
+                            let slice_h = current_h.min(target_h);
+                            let slice_w = current_w.min(target_w);
+                            let mut current = deconv_output;
+                            if slice_h < current_h || slice_w < current_w {
+                                let start: Vec<i64> = vec![0, 0, 0, 0];
+                                let size: Vec<i64> = vec![
+                                    out_batch as i64,
+                                    out_c as i64,
+                                    slice_h as i64,
+                                    slice_w as i64,
+                                ];
+                                let stride: Vec<i64> = vec![1, 1, 1, 1];
+                                let slice_layer = network
+                                    .add_slice(&current, &start, &size, &stride)
+                                    .map_err(|e| GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("convTranspose2d outputSizes slice: {}", e),
+                                    })?;
+                                current = slice_layer.get_output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
-                                        reason: format!("convTranspose2d outputSizes pad: {}", e),
+                                        reason: format!(
+                                            "convTranspose2d outputSizes slice output: {}",
+                                            e
+                                        ),
                                     }
                                 })?;
-                            pad_layer.get_output(&*network, 0).map_err(|e| {
-                                GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!(
-                                        "convTranspose2d outputSizes pad output: {}",
-                                        e
-                                    ),
-                                }
-                            })?
-                        } else {
-                            current
+                            }
+                            let pad_h = target_h - slice_h;
+                            let pad_w = target_w - slice_w;
+                            if pad_h > 0 || pad_w > 0 {
+                                let pre: Vec<i64> = vec![0, 0];
+                                let post: Vec<i64> = vec![pad_h as i64, pad_w as i64];
+                                let pad_layer = network
+                                    .add_padding(&current, &pre, &post)
+                                    .map_err(|e| GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("convTranspose2d outputSizes pad: {}", e),
+                                    })?;
+                                pad_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!(
+                                            "convTranspose2d outputSizes pad output: {}",
+                                            e
+                                        ),
+                                    }
+                                })?
+                            } else {
+                                current
+                            }
                         }
-                    }
                         _ => deconv_output,
                     }
                 }
@@ -10024,10 +10159,12 @@ impl TrtxConverter {
             return Ok([wd[0] as i64, wd[1] as i64]);
         }
 
-        let in_operand = graph.operand(input_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("Pool2d input operand {} not found", input_id),
-        })?;
+        let in_operand = graph
+            .operand(input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pool2d input operand {} not found", input_id),
+            })?;
 
         let layout = opts.layout.to_ascii_lowercase();
         let layout = if layout.is_empty() {
@@ -10098,12 +10235,13 @@ impl TrtxConverter {
             });
         }
         if tensors.len() == 1 {
-            let id_layer = network.add_identity(&tensors[0]).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("pool concat identity: {e}"),
-                }
-            })?;
+            let id_layer =
+                network
+                    .add_identity(&tensors[0])
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("pool concat identity: {e}"),
+                    })?;
             return id_layer
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -10112,12 +10250,13 @@ impl TrtxConverter {
                 });
         }
         let inputs: Vec<&trtx::Tensor<'a>> = tensors.iter().collect();
-        let mut layer = network
-            .add_concatenation(&inputs)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("pool concat: {e}"),
-            })?;
+        let mut layer =
+            network
+                .add_concatenation(&inputs)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool concat: {e}"),
+                })?;
         layer.set_axis(network, axis);
         layer
             .get_output(&*network, 0)
@@ -10271,42 +10410,38 @@ impl TrtxConverter {
                 let h_start = (oh_idx as i32) * sh_i - pb_hi;
                 let w_start = (ow_idx as i32) * sw_i - pb_wi;
 
-                let mut taps: Vec<trtx::Tensor<'a>> =
-                    Vec::with_capacity((kh * kw) as usize);
+                let mut taps: Vec<trtx::Tensor<'a>> = Vec::with_capacity((kh * kw) as usize);
                 for ih in 0..kh_i {
                     for iw in 0..kw_i {
                         let h_idx = h_start + ih * dil_hi;
                         let w_idx = w_start + iw * dil_wi;
-                        let tap_tensor = if h_idx >= 0
-                            && w_idx >= 0
-                            && h_idx < h_in_i
-                            && w_idx < w_in_i
-                        {
-                            let slice_layer = network
-                                .add_slice(
-                                    input,
-                                    &[0, 0, h_idx as i64, w_idx as i64],
-                                    &[n, c, 1, 1],
-                                    &[1, 1, 1, 1],
-                                )
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated max pool slice: {e}"),
-                                })?;
-                            slice_layer
-                                .get_output(&*network, 0)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated max pool slice output: {e}"),
+                        let tap_tensor =
+                            if h_idx >= 0 && w_idx >= 0 && h_idx < h_in_i && w_idx < w_in_i {
+                                let slice_layer = network
+                                    .add_slice(
+                                        input,
+                                        &[0, 0, h_idx as i64, w_idx as i64],
+                                        &[n, c, 1, 1],
+                                        &[1, 1, 1, 1],
+                                    )
+                                    .map_err(|e| GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated max pool slice: {e}"),
+                                    })?;
+                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated max pool slice output: {e}"),
+                                    }
                                 })?
-                        } else {
-                            neg_inf_layer.get_output(&*network, 0).map_err(|e| {
-                                GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated max pool neg-inf tap: {e}"),
-                                }
-                            })?
-                        };
+                            } else {
+                                neg_inf_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated max pool neg-inf tap: {e}"),
+                                    }
+                                })?
+                            };
                         taps.push(tap_tensor);
                     }
                 }
@@ -10325,12 +10460,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated max pool elementwise max: {e}"),
                         })?;
-                    acc = ew
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("dilated max pool max output: {e}"),
-                        })?;
+                    acc =
+                        ew.get_output(&*network, 0)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("dilated max pool max output: {e}"),
+                            })?;
                 }
                 cols.push(acc);
             }
@@ -10342,10 +10477,12 @@ impl TrtxConverter {
 
         // Match graph output dtype (pool path otherwise keeps input type).
         let out_id = operation.output_operands_slice()[0];
-        let out_operand = graph.operand(out_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("dilated max pool output operand {out_id} not found"),
-        })?;
+        let out_operand = graph
+            .operand(out_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated max pool output operand {out_id} not found"),
+            })?;
         let need_half = out_operand.descriptor.data_type == DataType::Float16;
         if need_half {
             let cast_layer = network
@@ -10508,42 +10645,38 @@ impl TrtxConverter {
                 let h_start = (oh_idx as i32) * sh_i - pb_hi;
                 let w_start = (ow_idx as i32) * sw_i - pb_wi;
 
-                let mut taps: Vec<trtx::Tensor<'a>> =
-                    Vec::with_capacity((kh * kw) as usize);
+                let mut taps: Vec<trtx::Tensor<'a>> = Vec::with_capacity((kh * kw) as usize);
                 for ih in 0..kh_i {
                     for iw in 0..kw_i {
                         let h_idx = h_start + ih * dil_hi;
                         let w_idx = w_start + iw * dil_wi;
-                        let tap_tensor = if h_idx >= 0
-                            && w_idx >= 0
-                            && h_idx < h_in_i
-                            && w_idx < w_in_i
-                        {
-                            let slice_layer = network
-                                .add_slice(
-                                    input,
-                                    &[0, 0, h_idx as i64, w_idx as i64],
-                                    &[n, c, 1, 1],
-                                    &[1, 1, 1, 1],
-                                )
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated average pool slice: {e}"),
-                                })?;
-                            slice_layer
-                                .get_output(&*network, 0)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated average pool slice output: {e}"),
+                        let tap_tensor =
+                            if h_idx >= 0 && w_idx >= 0 && h_idx < h_in_i && w_idx < w_in_i {
+                                let slice_layer = network
+                                    .add_slice(
+                                        input,
+                                        &[0, 0, h_idx as i64, w_idx as i64],
+                                        &[n, c, 1, 1],
+                                        &[1, 1, 1, 1],
+                                    )
+                                    .map_err(|e| GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated average pool slice: {e}"),
+                                    })?;
+                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated average pool slice output: {e}"),
+                                    }
                                 })?
-                        } else {
-                            zero_layer.get_output(&*network, 0).map_err(|e| {
-                                GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated average pool zero tap: {e}"),
-                                }
-                            })?
-                        };
+                            } else {
+                                zero_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated average pool zero tap: {e}"),
+                                    }
+                                })?
+                            };
                         taps.push(tap_tensor);
                     }
                 }
@@ -10562,12 +10695,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated average pool elementwise sum: {e}"),
                         })?;
-                    acc = ew
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("dilated average pool sum output: {e}"),
-                        })?;
+                    acc =
+                        ew.get_output(&*network, 0)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("dilated average pool sum output: {e}"),
+                            })?;
                 }
                 cols.push(acc);
             }
@@ -10581,35 +10714,43 @@ impl TrtxConverter {
         // because TRT may retain pointers until engine build. Use owned constant + elementwise prod.
         let inv = 1.0f32 / ((kh as f32) * (kw as f32));
         let inv_const_layer = network
-            .add_constant_owned(&[1, 1, 1, 1], inv.to_ne_bytes().to_vec(), TrtDataType::kFLOAT)
+            .add_constant_owned(
+                &[1, 1, 1, 1],
+                inv.to_ne_bytes().to_vec(),
+                TrtDataType::kFLOAT,
+            )
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("dilated average pool inv scale constant: {e}"),
             })?;
-        let inv_tensor = inv_const_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("dilated average pool inv scale output: {e}"),
-            })?;
+        let inv_tensor =
+            inv_const_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated average pool inv scale output: {e}"),
+                })?;
         let prod_layer = network
             .add_elementwise(&summed_nchw, &inv_tensor, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("dilated average pool multiply by 1/n: {e}"),
             })?;
-        let out_nchw = prod_layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("dilated average pool prod output: {e}"),
-            })?;
+        let out_nchw =
+            prod_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated average pool prod output: {e}"),
+                })?;
 
         let out_id = operation.output_operands_slice()[0];
-        let out_operand = graph.operand(out_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("dilated average pool output operand {out_id} not found"),
-        })?;
+        let out_operand = graph
+            .operand(out_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool output operand {out_id} not found"),
+            })?;
         let need_half = out_operand.descriptor.data_type == DataType::Float16;
         if need_half {
             let cast_layer = network
@@ -10651,10 +10792,7 @@ impl TrtxConverter {
         if dims.len() != 4 {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!(
-                    "dilated l2 pool expects 4D NCHW input, got {}D",
-                    dims.len()
-                ),
+                reason: format!("dilated l2 pool expects 4D NCHW input, got {}D", dims.len()),
             });
         }
         let n = dims[0];
@@ -10772,42 +10910,38 @@ impl TrtxConverter {
                 let h_start = (oh_idx as i32) * sh_i - pb_hi;
                 let w_start = (ow_idx as i32) * sw_i - pb_wi;
 
-                let mut taps: Vec<trtx::Tensor<'a>> =
-                    Vec::with_capacity((kh * kw) as usize);
+                let mut taps: Vec<trtx::Tensor<'a>> = Vec::with_capacity((kh * kw) as usize);
                 for ih in 0..kh_i {
                     for iw in 0..kw_i {
                         let h_idx = h_start + ih * dil_hi;
                         let w_idx = w_start + iw * dil_wi;
-                        let tap_tensor = if h_idx >= 0
-                            && w_idx >= 0
-                            && h_idx < h_in_i
-                            && w_idx < w_in_i
-                        {
-                            let slice_layer = network
-                                .add_slice(
-                                    input,
-                                    &[0, 0, h_idx as i64, w_idx as i64],
-                                    &[n, c, 1, 1],
-                                    &[1, 1, 1, 1],
-                                )
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated l2 pool slice: {e}"),
-                                })?;
-                            slice_layer
-                                .get_output(&*network, 0)
-                                .map_err(|e| GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated l2 pool slice output: {e}"),
+                        let tap_tensor =
+                            if h_idx >= 0 && w_idx >= 0 && h_idx < h_in_i && w_idx < w_in_i {
+                                let slice_layer = network
+                                    .add_slice(
+                                        input,
+                                        &[0, 0, h_idx as i64, w_idx as i64],
+                                        &[n, c, 1, 1],
+                                        &[1, 1, 1, 1],
+                                    )
+                                    .map_err(|e| GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated l2 pool slice: {e}"),
+                                    })?;
+                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated l2 pool slice output: {e}"),
+                                    }
                                 })?
-                        } else {
-                            zero_layer.get_output(&*network, 0).map_err(|e| {
-                                GraphError::ConversionFailed {
-                                    format: "trtx".to_string(),
-                                    reason: format!("dilated l2 pool zero tap: {e}"),
-                                }
-                            })?
-                        };
+                            } else {
+                                zero_layer.get_output(&*network, 0).map_err(|e| {
+                                    GraphError::ConversionFailed {
+                                        format: "trtx".to_string(),
+                                        reason: format!("dilated l2 pool zero tap: {e}"),
+                                    }
+                                })?
+                            };
                         taps.push(tap_tensor);
                     }
                 }
@@ -10826,12 +10960,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated l2 pool elementwise sum: {e}"),
                         })?;
-                    acc = ew
-                        .get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("dilated l2 pool sum output: {e}"),
-                        })?;
+                    acc =
+                        ew.get_output(&*network, 0)
+                            .map_err(|e| GraphError::ConversionFailed {
+                                format: "trtx".to_string(),
+                                reason: format!("dilated l2 pool sum output: {e}"),
+                            })?;
                 }
                 cols.push(acc);
             }
@@ -10868,7 +11002,8 @@ impl TrtxConverter {
             }
             Some(_) => Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: "pool2d: unexpected ceil_mode value from output_sizes inference".to_string(),
+                reason: "pool2d: unexpected ceil_mode value from output_sizes inference"
+                    .to_string(),
             }),
         }
     }
@@ -10944,30 +11079,30 @@ impl TrtxConverter {
         };
 
         // TensorRT pooling is NCHW; WebNN NHWC must be transposed first (same as conv2d).
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(input)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("pool2d NHWC->NCHW shuffle: {e}"),
-                })?;
-            shuffle
-                .set_first_transpose(network, &[0, 3, 1, 2])
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("pool2d set_first_transpose NHWC: {e}"),
-                })?;
-            Some(
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
+            if layout == "nhwc" {
+                let mut shuffle =
+                    network
+                        .add_shuffle(input)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("pool2d NHWC->NCHW shuffle: {e}"),
+                        })?;
                 shuffle
-                    .get_output(&*network, 0)
+                    .set_first_transpose(network, &[0, 3, 1, 2])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("pool2d set_first_transpose NHWC: {e}"),
+                    })?;
+                Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("pool2d NHWC shuffle output: {e}"),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let pool_nchw_in = nhwc_to_nchw.as_ref().unwrap_or(input);
 
         let dh = opts.dilations.get(0).copied().unwrap_or(1);
@@ -10987,23 +11122,22 @@ impl TrtxConverter {
                 .map(|o| o.descriptor.data_type)
                 .unwrap_or(DataType::Float32);
 
-            let half_to_float: Option<trtx::Tensor<'a>> =
-                if input_dtype == DataType::Float16 {
-                    let cast_layer = network
-                        .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("pool2d dilated Half->Float: {e}"),
-                        })?;
-                    Some(cast_layer.get_output(&*network, 0).map_err(|e| {
-                        GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("pool2d dilated cast output: {e}"),
-                        }
-                    })?)
-                } else {
-                    None
-                };
+            let half_to_float: Option<trtx::Tensor<'a>> = if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("pool2d dilated Half->Float: {e}"),
+                    })?;
+                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("pool2d dilated cast output: {e}"),
+                    }
+                })?)
+            } else {
+                None
+            };
             let dilated_input = half_to_float.as_ref().unwrap_or(pool_nchw_in);
 
             let out_nchw = if pool_type == PoolingType::kMAX {
@@ -11027,12 +11161,13 @@ impl TrtxConverter {
             };
 
             let output = if layout == "nhwc" {
-                let mut shuffle = network
-                    .add_shuffle(&out_nchw)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("pool2d dilated NCHW->NHWC shuffle: {e}"),
-                    })?;
+                let mut shuffle =
+                    network
+                        .add_shuffle(&out_nchw)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("pool2d dilated NCHW->NHWC shuffle: {e}"),
+                        })?;
                 shuffle
                     .set_first_transpose(network, &[0, 2, 3, 1])
                     .map_err(|e| GraphError::ConversionFailed {
@@ -11064,20 +11199,22 @@ impl TrtxConverter {
 
         Self::trtx_apply_pool2d_options(&mut layer, network, opts, round_up);
 
-        let pooled_nchw = layer
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
-
-        let output = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(&pooled_nchw)
+        let pooled_nchw =
+            layer
+                .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("pool2d NCHW->NHWC shuffle: {e}"),
+                    reason: format!("Failed to get layer output: {}", e),
                 })?;
+
+        let output = if layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(&pooled_nchw)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("pool2d NCHW->NHWC shuffle: {e}"),
+                    })?;
             shuffle
                 .set_first_transpose(network, &[0, 2, 3, 1])
                 .map_err(|e| GraphError::ConversionFailed {
@@ -11373,15 +11510,20 @@ impl TrtxConverter {
             }
         };
 
-        let input = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("resample2d: input operand {input_id} not found"),
-        })?;
+        let input = tensor_map
+            .get(&input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("resample2d: input operand {input_id} not found"),
+            })?;
 
-        let input_operand = graph.operand(input_id).ok_or_else(|| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: format!("resample2d: operand {input_id} missing from graph"),
-        })?;
+        let input_operand =
+            graph
+                .operand(input_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("resample2d: operand {input_id} missing from graph"),
+                })?;
 
         let dims_trt = input
             .dimensions(&*network)
@@ -11410,9 +11552,7 @@ impl TrtxConverter {
         if rank != 4 {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!(
-                    "resample2d: WebNN requires a 4-D input tensor, got rank {rank}"
-                ),
+                reason: format!("resample2d: WebNN requires a 4-D input tensor, got rank {rank}"),
             });
         }
 
@@ -11446,10 +11586,7 @@ impl TrtxConverter {
             if sizes.len() != 2 {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!(
-                        "resample2d: sizes must have length 2, got {:?}",
-                        sizes
-                    ),
+                    reason: format!("resample2d: sizes must have length 2, got {:?}", sizes),
                 });
             }
             sizes.iter().map(|&u| u as i64).collect()
@@ -11815,18 +11952,20 @@ impl TrtxConverter {
                 reason: format!("gatherElements: clamp max constant: {}", e),
             })?;
 
-        let min_const_out = min_const
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherElements: clamp min output: {}", e),
-            })?;
-        let max_const_out = max_const
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherElements: clamp max output: {}", e),
-            })?;
+        let min_const_out =
+            min_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherElements: clamp min output: {}", e),
+                })?;
+        let max_const_out =
+            max_const
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherElements: clamp max output: {}", e),
+                })?;
 
         let clamped_upper = network
             .add_elementwise(indices_tensor, &max_const_out, ElementWiseOperation::kMIN)
@@ -11834,12 +11973,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("gatherElements: indices clamp (min upper): {}", e),
             })?;
-        let clamped_upper_out = clamped_upper
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherElements: clamp upper output: {}", e),
-            })?;
+        let clamped_upper_out =
+            clamped_upper
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherElements: clamp upper output: {}", e),
+                })?;
 
         let clamped = network
             .add_elementwise(
@@ -11851,12 +11991,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("gatherElements: indices clamp (max lower): {}", e),
             })?;
-        let clamped_indices = clamped
-            .get_output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("gatherElements: clamped indices output: {}", e),
-            })?;
+        let clamped_indices =
+            clamped
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("gatherElements: clamped indices output: {}", e),
+                })?;
 
         let mut layer = network
             .add_gather(data_tensor, &clamped_indices, axis)
@@ -11898,12 +12039,13 @@ impl TrtxConverter {
             }
         };
 
-        let input_tensor = tensor_map
-            .get(&input_id)
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", input_id),
-            })?;
+        let input_tensor =
+            tensor_map
+                .get(&input_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Input operand {} not found", input_id),
+                })?;
 
         // Step 1: Square the input (x^2)
         let square_layer = network
@@ -11935,30 +12077,30 @@ impl TrtxConverter {
             s => s,
         };
 
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(&squared)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("l2Pool2d NHWC->NCHW shuffle: {e}"),
-                })?;
-            shuffle
-                .set_first_transpose(network, &[0, 3, 1, 2])
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("l2Pool2d set_first_transpose NHWC: {e}"),
-                })?;
-            Some(
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
+            if layout == "nhwc" {
+                let mut shuffle =
+                    network
+                        .add_shuffle(&squared)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("l2Pool2d NHWC->NCHW shuffle: {e}"),
+                        })?;
                 shuffle
-                    .get_output(&*network, 0)
+                    .set_first_transpose(network, &[0, 3, 1, 2])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
+                        reason: format!("l2Pool2d set_first_transpose NHWC: {e}"),
+                    })?;
+                Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
                         reason: format!("l2Pool2d NHWC shuffle output: {e}"),
-                    })?,
-            )
-        } else {
-            None
-        };
+                    }
+                })?)
+            } else {
+                None
+            };
         let pool_in = nhwc_to_nchw.as_ref().unwrap_or(&squared);
 
         let input_dtype = graph
@@ -12048,12 +12190,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d kernel volume constant: {e}"),
                 })?;
-            let k_tensor = k_const_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
+            let k_tensor = k_const_layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d kernel volume output: {e}"),
-                })?;
+                }
+            })?;
             let sum_sq_layer = network
                 .add_elementwise(&mean_for_prod, &k_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -12069,12 +12211,13 @@ impl TrtxConverter {
         };
 
         let pooled = if layout == "nhwc" {
-            let mut shuffle = network
-                .add_shuffle(&pooled_nchw)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("l2Pool2d NCHW->NHWC shuffle: {e}"),
-                })?;
+            let mut shuffle =
+                network
+                    .add_shuffle(&pooled_nchw)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d NCHW->NHWC shuffle: {e}"),
+                    })?;
             shuffle
                 .set_first_transpose(network, &[0, 2, 3, 1])
                 .map_err(|e| GraphError::ConversionFailed {
@@ -12541,8 +12684,14 @@ mod tests {
 
     #[test]
     fn test_engine_binding_name_stable() {
-        assert_eq!(TrtxConverter::engine_binding_name(0).as_str(), "webnn_operand_0");
-        assert_eq!(TrtxConverter::engine_binding_name(42).as_str(), "webnn_operand_42");
+        assert_eq!(
+            TrtxConverter::engine_binding_name(0).as_str(),
+            "webnn_operand_0"
+        );
+        assert_eq!(
+            TrtxConverter::engine_binding_name(42).as_str(),
+            "webnn_operand_42"
+        );
     }
 
     /// HWIO -> OIHW transpose: perm (3,2,0,1) => output[o,i,h,w] = input[h,w,i,o].

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -824,7 +824,7 @@ impl TrtxConverter {
             "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation, temp_weights)?,
             "where" => Self::add_where_op(graph, network, tensor_map, operation)?,
             "linear" => Self::add_linear_op(graph, network, tensor_map, operation, temp_weights)?,
-            "pad" => Self::add_pad_op(network, tensor_map, operation)?,
+            "pad" => Self::add_pad_op(graph, network, tensor_map, operation)?,
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
             "concat" => Self::add_concat_op(network, tensor_map, operation)?,
             "isNaN" => Self::add_is_nan_op(network, tensor_map, operation)?,
@@ -7791,8 +7791,363 @@ impl TrtxConverter {
         Ok(())
     }
 
+    /// Parse WebNN `MLPadOptions.value` (`MLNumber`: number or special float strings like `"NaN"`).
+    fn pad_mlnumber_to_f32(v: &serde_json::Value) -> Option<f32> {
+        if let Some(f) = v.as_f64() {
+            return Some(f as f32);
+        }
+        if let Some(i) = v.as_i64() {
+            return Some(i as f32);
+        }
+        if let Some(u) = v.as_u64() {
+            return Some(u as f32);
+        }
+        let s = v.as_str()?.trim();
+        let lower = s.to_lowercase();
+        Some(match lower.as_str() {
+            "nan" => f32::NAN,
+            "infinity" | "+infinity" | "inf" | "+inf" => f32::INFINITY,
+            "-infinity" | "-inf" => f32::NEG_INFINITY,
+            _ => s.parse::<f32>().ok()?,
+        })
+    }
+
+    /// Pad one axis by concatenating constant-filled tensors (constant-pad only).
+    fn trtx_pad_axis_constant_concat<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        axis: usize,
+        pre: i32,
+        post: i32,
+        fill_f32: f32,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if pre <= 0 && post <= 0 {
+            let id =
+                network
+                    .add_identity(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad concat: identity: {}", e),
+                    })?;
+            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad concat: identity output: {}", e),
+            });
+        }
+
+        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad concat: dimensions: {}", e),
+        })?;
+        let rank = dims.len();
+        if axis >= rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad concat: axis {axis} >= rank {rank}"),
+            });
+        }
+
+        let trt_dtype = input.get_type(&*network);
+        let elem_size = match trt_dtype {
+            TrtDataType::kFLOAT => 4usize,
+            TrtDataType::kHALF => 2,
+            TrtDataType::kINT32 => 4,
+            TrtDataType::kINT64 => 8,
+            TrtDataType::kINT8 | TrtDataType::kUINT8 | TrtDataType::kBOOL => 1,
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "Pad concat: unsupported TensorRT dtype for constant fill: {:?}",
+                        trt_dtype
+                    ),
+                });
+            }
+        };
+
+        let one_elem_bytes: Vec<u8> = match trt_dtype {
+            TrtDataType::kFLOAT => fill_f32.to_le_bytes().to_vec(),
+            TrtDataType::kHALF => f16::from_f32(fill_f32).to_bits().to_le_bytes().to_vec(),
+            TrtDataType::kINT32 => (fill_f32 as i32).to_le_bytes().to_vec(),
+            TrtDataType::kINT64 => (fill_f32 as i64).to_le_bytes().to_vec(),
+            TrtDataType::kINT8 => [(fill_f32 as i8) as u8].to_vec(),
+            TrtDataType::kUINT8 | TrtDataType::kBOOL => {
+                vec![if fill_f32 != 0.0 { 1u8 } else { 0u8 }]
+            }
+            _ => unreachable!(),
+        };
+
+        let mut make_const =
+            |axis_len: i64| -> Result<trtx::Tensor<'a>, GraphError> {
+                let mut shape = dims.clone();
+                shape[axis] = axis_len;
+                let n: usize = shape.iter().map(|&d| d.max(0) as usize).product();
+                let mut data = Vec::with_capacity(n * elem_size);
+                for _ in 0..n {
+                    data.extend_from_slice(&one_elem_bytes);
+                }
+                let layer = network
+                    .add_small_constant_copied(&shape, &data, trt_dtype)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad concat: constant: {}", e),
+                    })?;
+                layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: constant output: {}", e),
+                })
+            };
+
+        let mut pieces: Vec<&trtx::Tensor<'a>> = Vec::new();
+        let pre_t = if pre > 0 {
+            Some(make_const(pre as i64)?)
+        } else {
+            None
+        };
+        if let Some(ref t) = pre_t {
+            pieces.push(t);
+        }
+        pieces.push(input);
+        let post_t = if post > 0 {
+            Some(make_const(post as i64)?)
+        } else {
+            None
+        };
+        if let Some(ref t) = post_t {
+            pieces.push(t);
+        }
+
+        let mut cat = network
+            .add_concatenation(&pieces)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad concat: concat: {}", e),
+            })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad concat: concat out: {}", e),
+        })
+    }
+
+    /// Edge pad on one axis: replicate first / last slice along `axis` (WebNN `mode == "edge"`).
+    fn trtx_pad_axis_edge_concat<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        axis: usize,
+        pre: i32,
+        post: i32,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if pre <= 0 && post <= 0 {
+            let id =
+                network
+                    .add_identity(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad edge: identity: {}", e),
+                    })?;
+            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: identity output: {}", e),
+            });
+        }
+
+        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad edge: dimensions: {}", e),
+        })?;
+        let rank = dims.len();
+        if axis >= rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: axis {axis} >= rank {rank}"),
+            });
+        }
+        let d_ax = dims[axis];
+        if d_ax <= 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: non-positive dim {d_ax} on axis {axis}"),
+            });
+        }
+
+        let stride: Vec<i64> = vec![1i64; rank];
+
+        let start_left = vec![0i64; rank];
+        let mut size_left = dims.clone();
+        size_left[axis] = 1;
+        let left_layer =
+            network
+                .add_slice(input, &start_left, &size_left, &stride)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad edge: left slice: {}", e),
+                })?;
+        let left_t = left_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: left slice output: {}", e),
+            }
+        })?;
+
+        let mut start_right = vec![0i64; rank];
+        start_right[axis] = d_ax - 1;
+        let mut size_right = dims.clone();
+        size_right[axis] = 1;
+        let right_layer =
+            network
+                .add_slice(input, &start_right, &size_right, &stride)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad edge: right slice: {}", e),
+                })?;
+        let right_t = right_layer.get_output(&*network, 0).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: right slice output: {}", e),
+            }
+        })?;
+
+        let mut cat_inputs: Vec<&trtx::Tensor<'a>> = Vec::new();
+        for _ in 0..pre {
+            cat_inputs.push(&left_t);
+        }
+        cat_inputs.push(input);
+        for _ in 0..post {
+            cat_inputs.push(&right_t);
+        }
+
+        let mut cat = network
+            .add_concatenation(&cat_inputs)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: concat: {}", e),
+            })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad edge: concat out: {}", e),
+        })
+    }
+
+    /// Reflection pad on one axis (NumPy / ONNX `reflect`: mirror interior, excluding the edge).
+    /// Requires `pre < dim` and `post < dim` on this axis.
+    fn trtx_pad_axis_reflect_concat<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        axis: usize,
+        pre: i32,
+        post: i32,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if pre <= 0 && post <= 0 {
+            let id =
+                network
+                    .add_identity(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad reflect: identity: {}", e),
+                    })?;
+            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad reflect: identity output: {}", e),
+            });
+        }
+
+        let dims = input.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad reflect: dimensions: {}", e),
+        })?;
+        let rank = dims.len();
+        if axis >= rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad reflect: axis {axis} >= rank {rank}"),
+            });
+        }
+        let d_ax = dims[axis];
+        if d_ax <= 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad reflect: non-positive dim {d_ax} on axis {axis}"),
+            });
+        }
+        if pre as i64 >= d_ax || post as i64 >= d_ax {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "Pad reflect: axis {axis} dim {d_ax} requires pre/post padding each < dim (got pre={pre} post={post})"
+                ),
+            });
+        }
+
+        let stride: Vec<i64> = vec![1i64; rank];
+        let mut pre_slabs: Vec<trtx::Tensor<'a>> = Vec::new();
+        for off in (1_i32..=pre).rev() {
+            let idx = i64::from(off);
+            let mut start = vec![0i64; rank];
+            start[axis] = idx;
+            let mut size = dims.clone();
+            size[axis] = 1;
+            let layer =
+                network
+                    .add_slice(input, &start, &size, &stride)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad reflect: pre slice: {}", e),
+                    })?;
+            let slab = layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: pre slice out: {}", e),
+                }
+            })?;
+            pre_slabs.push(slab);
+        }
+
+        let mut post_slabs: Vec<trtx::Tensor<'a>> = Vec::new();
+        for t in 0..post {
+            let idx = d_ax - 2 - i64::from(t);
+            let mut start = vec![0i64; rank];
+            start[axis] = idx;
+            let mut size = dims.clone();
+            size[axis] = 1;
+            let layer =
+                network
+                    .add_slice(input, &start, &size, &stride)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad reflect: post slice: {}", e),
+                    })?;
+            let slab = layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: post slice out: {}", e),
+                }
+            })?;
+            post_slabs.push(slab);
+        }
+
+        let mut cat_inputs: Vec<&trtx::Tensor<'a>> =
+            pre_slabs.iter().collect::<Vec<_>>();
+        cat_inputs.push(input);
+        cat_inputs.extend(post_slabs.iter());
+
+        let mut cat = network
+            .add_concatenation(&cat_inputs)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad reflect: concat: {}", e),
+            })?;
+        cat.set_axis(network, axis as i32);
+        cat.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Pad reflect: concat out: {}", e),
+        })
+    }
+
     /// Add pad operation (pad tensor with constant/edge/reflection values)
     fn add_pad_op<'a>(
+        _graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -7804,7 +8159,7 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let (beginning_padding, ending_padding, _opts) = match operation {
+        let (beginning_padding, ending_padding, pad_opts) = match operation {
             Operation::Pad {
                 beginning_padding,
                 ending_padding,
@@ -7829,12 +8184,6 @@ impl TrtxConverter {
         };
         let pre_padding: Vec<i32> = beginning_padding.iter().map(|&u| u as i32).collect();
         let post_padding: Vec<i32> = ending_padding.iter().map(|&u| u as i32).collect();
-        if pre_padding.is_empty() || post_padding.is_empty() {
-            return Err(GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Pad operation missing beginningPadding or endingPadding".to_string(),
-            });
-        }
 
         // Get input dimensions
         let input_dims = input
@@ -7844,27 +8193,151 @@ impl TrtxConverter {
                 reason: format!("Failed to get input dimensions: {}", e),
             })?;
 
-        let original_ndims = input_dims.len();
-        eprintln!(
-            "[PAD DEBUG] Input dims: {:?}, len={}",
-            input_dims, original_ndims
-        );
-        eprintln!(
-            "[PAD DEBUG] Pre-padding: {:?}, Post-padding: {:?}",
-            pre_padding, post_padding
-        );
+        if pre_padding.len() != post_padding.len() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "Pad: beginningPadding len {} != endingPadding len {}",
+                    pre_padding.len(),
+                    post_padding.len()
+                ),
+            });
+        }
+        if pre_padding.len() != input_dims.len() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "Pad: padding length {} does not match input rank {}",
+                    pre_padding.len(),
+                    input_dims.len()
+                ),
+            });
+        }
 
-        // TensorRT padding requires at least 4D input (NCHW format)
-        // If input is less than 4D, reshape to 4D first
+        // WebNN: empty paddings on rank-0 input (or all zeros) is a no-op; TRT IPaddingLayer still needs work.
+        let no_pad_amounts = pre_padding
+            .iter()
+            .chain(post_padding.iter())
+            .all(|&p| p == 0);
+        if no_pad_amounts {
+            let identity =
+                network
+                    .add_identity(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Pad no-op: failed to add identity: {}", e),
+                    })?;
+            let out = identity
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad no-op: identity output: {}", e),
+                })?;
+            tensor_map.insert(operation.output_operands_slice()[0], out);
+            return Ok(());
+        }
+
+        let original_ndims = input_dims.len();
+
+        let pad_mode_norm = pad_opts.mode.to_lowercase();
+        let is_constant_pad_mode =
+            pad_mode_norm.is_empty() || pad_mode_norm == "constant";
+        let is_edge_pad_mode = pad_mode_norm == "edge";
+        let is_reflect_pad_mode =
+            pad_mode_norm == "reflection" || pad_mode_norm == "reflect";
+        if !pad_mode_norm.is_empty()
+            && !is_constant_pad_mode
+            && !is_edge_pad_mode
+            && !is_reflect_pad_mode
+        {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "Pad: TensorRT pad supports constant, edge, and reflection mode (got {:?})",
+                    pad_opts.mode
+                ),
+            });
+        }
+        let fill_f32 = pad_opts
+            .value
+            .as_ref()
+            .and_then(Self::pad_mlnumber_to_f32)
+            .unwrap_or(0.0);
+
+        // TensorRT `addPaddingNd` only accepts **two** padding values (last two tensor dims). When
+        // WebNN padding affects other axes (e.g. 3D with pad on axis 0), use concat + constants.
+        let lead_if_reshaped = if original_ndims < 4 {
+            4 - original_ndims
+        } else {
+            0
+        };
+        let trt_ipadding_covers = if original_ndims < 4 {
+            (0..original_ndims).all(|wi| {
+                let trt_d = lead_if_reshaped + wi;
+                trt_d >= 2 || (pre_padding[wi] == 0 && post_padding[wi] == 0)
+            })
+        } else {
+            (0..original_ndims.saturating_sub(2)).all(|wi| {
+                pre_padding[wi] == 0 && post_padding[wi] == 0
+            })
+        };
+
+        // `IPaddingLayer` is zero-only and 2D; edge / non-zero constant use slice+concat or constant+concat.
+        let use_concat_pad = !trt_ipadding_covers
+            || !is_constant_pad_mode
+            || fill_f32 != 0.0
+            || fill_f32.is_nan()
+            || fill_f32.is_infinite();
+        if use_concat_pad {
+            let in_id = operation.input_operands()[0];
+            let out_id = operation.output_operands_slice()[0];
+            let mut cur_key = in_id;
+            let mut step: u32 = 0;
+            let mut any = false;
+            for ax in 0..original_ndims {
+                let pr = pre_padding[ax];
+                let po = post_padding[ax];
+                if pr == 0 && po == 0 {
+                    continue;
+                }
+                any = true;
+                let t = tensor_map.get(&cur_key).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad concat: tensor {cur_key} not found"),
+                })?;
+                let new_t = if is_edge_pad_mode {
+                    Self::trtx_pad_axis_edge_concat(network, t, ax, pr, po)?
+                } else if is_reflect_pad_mode {
+                    Self::trtx_pad_axis_reflect_concat(network, t, ax, pr, po)?
+                } else {
+                    Self::trtx_pad_axis_constant_concat(network, t, ax, pr, po, fill_f32)?
+                };
+                let next_key = 0xFA_B0_0000u32.wrapping_add(step);
+                step = step.saturating_add(1);
+                if cur_key != in_id {
+                    let _ = tensor_map.remove(&cur_key);
+                }
+                tensor_map.insert(next_key, new_t);
+                cur_key = next_key;
+            }
+            if !any {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "Pad: internal error (concat path but no non-zero axis pad)".to_string(),
+                });
+            }
+            let final_t = tensor_map.remove(&cur_key).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "Pad concat: missing final tensor".to_string(),
+            })?;
+            tensor_map.insert(out_id, final_t);
+            return Ok(());
+        }
+
+        // Rank < 4: left-pad shape with 1s to 4D; WebNN axis i maps to TRT axis (4 - original_ndims + i).
         let input_to_pad = if original_ndims < 4 {
-            eprintln!(
-                "[PAD DEBUG] Reshaping to 4D (original was {}D)",
-                original_ndims
-            );
-            // Calculate 4D shape: pad with 1s on the left
             let mut shape_4d: Vec<i64> = vec![1i64; 4 - original_ndims];
             shape_4d.extend_from_slice(&input_dims);
-            eprintln!("[PAD DEBUG] Shape 4D: {:?}", shape_4d);
 
             // Reshape to 4D
             let mut reshape_layer =
@@ -7889,8 +8362,6 @@ impl TrtxConverter {
                     reason: format!("Failed to get reshape output: {}", e),
                 })?
         } else {
-            eprintln!("[PAD DEBUG] Input already >= 4D, using identity layer");
-            // Use identity layer to pass through without reshape
             let identity =
                 network
                     .add_identity(input)
@@ -7906,53 +8377,52 @@ impl TrtxConverter {
                 })?
         };
 
-        // TensorRT addPaddingNd for 4D tensors (NCHW) expects 2D padding (H, W dimensions only)
-        // Padding must be RIGHT-ALIGNED to match the rightmost dimensions of the reshaped input
-        // For 1D input [d0] → reshaped to [1,1,1,d0], padding on d0 → W dimension (index 1)
-        // For 2D input [d0,d1] → reshaped to [1,1,d0,d1], padding on d0,d1 → H,W dimensions (indices 0,1)
-        let spatial_dims = 2; // H, W dimensions in NCHW
-
-        // Right-align: If we have fewer than 2 padding values, pad LEFT with zeros
-        let mut pre_padding_spatial: Vec<i64> = vec![0; spatial_dims];
-        let mut post_padding_spatial: Vec<i64> = vec![0; spatial_dims];
-
-        let len = pre_padding.len().min(spatial_dims);
-        let pad_offset = spatial_dims.saturating_sub(pre_padding.len());
-
-        for i in 0..len {
-            pre_padding_spatial[pad_offset + i] = pre_padding[i] as i64;
-            post_padding_spatial[pad_offset + i] = post_padding[i] as i64;
-        }
-
-        // Check actual dimensions of input_to_pad
-        let input_to_pad_dims =
-            input_to_pad
-                .dimensions(&*network)
-                .map_err(|e| GraphError::ConversionFailed {
+        let (pre_spatial, post_spatial): (Vec<i64>, Vec<i64>) = if original_ndims < 4 {
+            let lead = 4 - original_ndims;
+            let wn_pre = |trt_ax: usize| -> i64 {
+                if trt_ax < lead {
+                    return 0;
+                }
+                let wi = trt_ax - lead;
+                if wi < original_ndims {
+                    pre_padding[wi] as i64
+                } else {
+                    0
+                }
+            };
+            let wn_post = |trt_ax: usize| -> i64 {
+                if trt_ax < lead {
+                    return 0;
+                }
+                let wi = trt_ax - lead;
+                if wi < original_ndims {
+                    post_padding[wi] as i64
+                } else {
+                    0
+                }
+            };
+            (vec![wn_pre(2), wn_pre(3)], vec![wn_post(2), wn_post(3)])
+        } else {
+            if original_ndims < 2 {
+                return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Failed to get input_to_pad dimensions: {}", e),
-                })?;
+                    reason: format!("Pad: rank {original_ndims} < 2 for IPaddingLayer"),
+                });
+            }
+            (
+                vec![
+                    pre_padding[original_ndims - 2] as i64,
+                    pre_padding[original_ndims - 1] as i64,
+                ],
+                vec![
+                    post_padding[original_ndims - 2] as i64,
+                    post_padding[original_ndims - 1] as i64,
+                ],
+            )
+        };
 
-        eprintln!("[PAD DEBUG] Final padding arrays (spatial only):");
-        eprintln!(
-            "[PAD DEBUG]   pre_spatial:  {:?} (len={})",
-            pre_padding_spatial,
-            pre_padding_spatial.len()
-        );
-        eprintln!(
-            "[PAD DEBUG]   post_spatial: {:?} (len={})",
-            post_padding_spatial,
-            post_padding_spatial.len()
-        );
-        eprintln!(
-            "[PAD DEBUG] input_to_pad actual dims: {:?} (len={})",
-            input_to_pad_dims,
-            input_to_pad_dims.len()
-        );
-
-        // Add padding layer (4D input with 2D spatial padding)
         let padding_layer = network
-            .add_padding(&input_to_pad, &pre_padding_spatial, &post_padding_spatial)
+            .add_padding(&input_to_pad, &pre_spatial, &post_spatial)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add padding layer: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -392,11 +392,9 @@ impl TrtxConverter {
     }
 
     /// Build TensorRT network from WebNN graph.
-    /// `temp_weights` must be supplied by the caller and kept alive until engine serialization completes.
     fn build_network<'a>(
         graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
-        temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let mut tensor_map: HashMap<u32, trtx::Tensor<'a>> = HashMap::new();
         let promoted_constants: HashSet<u32> = HashSet::new();
@@ -527,7 +525,6 @@ impl TrtxConverter {
                 graph,
                 network,
                 &mut tensor_map,
-                temp_weights,
                 &promoted_constants,
                 &constants_stored_flat,
                 operation,
@@ -559,7 +556,6 @@ impl TrtxConverter {
         graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
-        temp_weights: &mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -628,7 +624,7 @@ impl TrtxConverter {
             "tanh" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kTANH)?
             }
-            "elu" => Self::add_elu_op(graph, network, tensor_map, operation, temp_weights)?,
+            "elu" => Self::add_elu_op(graph, network, tensor_map, operation)?,
             "softsign" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kSOFTSIGN)?
             }
@@ -638,16 +634,10 @@ impl TrtxConverter {
             "gelu" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kGELU_ERF)?
             }
-            "leakyRelu" => {
-                Self::add_leaky_relu_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "leakyRelu" => Self::add_leaky_relu_op(graph, network, tensor_map, operation)?,
             "prelu" => Self::add_prelu_op(network, tensor_map, operation)?,
-            "hardSigmoid" => {
-                Self::add_hard_sigmoid_op(graph, network, tensor_map, operation, temp_weights)?
-            }
-            "hardSwish" => {
-                Self::add_hard_swish_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "hardSigmoid" => Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?,
+            "hardSwish" => Self::add_hard_swish_op(graph, network, tensor_map, operation)?,
 
             // Unary mathematical operations (use IUnaryLayer)
             // Exponential and logarithmic
@@ -677,7 +667,6 @@ impl TrtxConverter {
                 graph,
                 network,
                 tensor_map,
-                temp_weights,
                 promoted_constants,
                 constants_stored_flat,
                 operation,
@@ -691,7 +680,7 @@ impl TrtxConverter {
 
             // Matrix operations
             "matmul" => Self::add_matmul_op(network, tensor_map, operation)?,
-            "gemm" => Self::add_gemm_op(graph, network, tensor_map, temp_weights, operation)?,
+            "gemm" => Self::add_gemm_op(graph, network, tensor_map, operation)?,
 
             // Convolution operations
             "conv2d" => Self::add_conv2d_op(graph, network, tensor_map, operation)?,
@@ -717,20 +706,12 @@ impl TrtxConverter {
             "batchNormalization" => {
                 Self::add_batch_normalization_op(graph, network, tensor_map, operation)?
             }
-            "instanceNormalization" => Self::add_instance_normalization_op(
-                graph,
-                network,
-                tensor_map,
-                operation,
-                temp_weights,
-            )?,
-            "layerNormalization" => Self::add_layer_normalization_op(
-                graph,
-                network,
-                tensor_map,
-                operation,
-                temp_weights,
-            )?,
+            "instanceNormalization" => {
+                Self::add_instance_normalization_op(graph, network, tensor_map, operation)?
+            }
+            "layerNormalization" => {
+                Self::add_layer_normalization_op(graph, network, tensor_map, operation)?
+            }
 
             // Reduction operations
             "reduceSum" => {
@@ -759,7 +740,7 @@ impl TrtxConverter {
             "split" => Self::add_split_op(network, tensor_map, operation)?,
             "squeeze" => Self::add_squeeze_op(network, tensor_map, operation)?,
             "unsqueeze" => Self::add_unsqueeze_op(network, tensor_map, operation)?,
-            "expand" => Self::add_expand_op(graph, network, tensor_map, operation, temp_weights)?,
+            "expand" => Self::add_expand_op(graph, network, tensor_map, operation)?,
             "tile" => Self::add_tile_op(network, tensor_map, operation)?,
 
             // Comparison operations (return Float32 with 0.0/1.0 values)
@@ -810,12 +791,10 @@ impl TrtxConverter {
                 operation,
                 ElementWiseOperation::kXOR,
             )?,
-            "logicalNot" => {
-                Self::add_logical_not_op(graph, network, tensor_map, operation, temp_weights)?
-            }
+            "logicalNot" => Self::add_logical_not_op(graph, network, tensor_map, operation)?,
 
             // Indexing/Gathering operations
-            "gather" => Self::add_gather_op(graph, network, tensor_map, operation, temp_weights)?,
+            "gather" => Self::add_gather_op(graph, network, tensor_map, operation)?,
             "gatherND" => Self::add_gather_nd_op(graph, network, tensor_map, operation)?,
             "scatterElements" => Self::add_scatter_elements_op(network, tensor_map, operation)?,
             "scatterND" => Self::add_scatter_nd_op(network, tensor_map, operation)?,
@@ -823,9 +802,9 @@ impl TrtxConverter {
             "argMin" => Self::add_arg_min_op(graph, network, tensor_map, operation)?,
 
             // Other operations
-            "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation, temp_weights)?,
+            "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation)?,
             "where" => Self::add_where_op(graph, network, tensor_map, operation)?,
-            "linear" => Self::add_linear_op(graph, network, tensor_map, operation, temp_weights)?,
+            "linear" => Self::add_linear_op(graph, network, tensor_map, operation)?,
             "pad" => Self::add_pad_op(graph, network, tensor_map, operation)?,
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
             "concat" => Self::add_concat_op(network, tensor_map, operation)?,
@@ -1434,7 +1413,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];
         let input = tensor_map
@@ -1559,7 +1537,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -1797,7 +1774,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2029,7 +2005,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2215,7 +2190,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -2415,7 +2389,6 @@ impl TrtxConverter {
         graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
-        _temp_weights: &mut Vec<Vec<u8>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -4432,7 +4405,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Instance normalization computes statistics per-instance (N, C) over spatial dims
         // Input operands: input, scale (optional), bias (optional)
@@ -4781,7 +4753,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         // Layer normalization computes statistics over specified axes
         // Input operands: input, scale (optional), bias (optional)
@@ -6279,7 +6250,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -6736,7 +6706,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -7479,7 +7448,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -7809,7 +7777,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
-        _temp_weights: &mut Vec<Vec<u8>>,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -8657,7 +8624,6 @@ impl TrtxConverter {
         graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
-        _temp_weights: &mut Vec<Vec<u8>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let a_id = operation.input_operands()[0];
@@ -12615,9 +12581,7 @@ impl GraphConverter for TrtxConverter {
                 reason: format!("Failed to create TensorRT network: {}", e),
             })?;
 
-        // Temporary weight buffers referenced by the network; must outlive `build_serialized_network`.
-        let mut temp_weights: Vec<Vec<u8>> = Vec::new();
-        Self::build_network(graph_info, &mut network, &mut temp_weights)?;
+        Self::build_network(graph_info, &mut network)?;
 
         // Create builder config
         let mut config = builder

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -31,7 +31,7 @@ use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
-use crate::shape_inference::infer_arg_reduce_shape;
+use crate::shape_inference::{infer_arg_reduce_shape, infer_where_shape};
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
     OwnedConvWeights, OwnedWeights, PoolingType, ReduceOperation, ResizeMode, ScatterMode,
@@ -774,7 +774,7 @@ impl TrtxConverter {
 
             // Other operations
             "clamp" => Self::add_clamp_op(graph, network, tensor_map, operation, temp_weights)?,
-            "where" => Self::add_where_op(network, tensor_map, operation)?,
+            "where" => Self::add_where_op(graph, network, tensor_map, operation)?,
             "linear" => Self::add_linear_op(graph, network, tensor_map, operation, temp_weights)?,
             "pad" => Self::add_pad_op(network, tensor_map, operation)?,
             "softmax" => Self::add_softmax_op(network, tensor_map, operation)?,
@@ -1068,6 +1068,119 @@ impl TrtxConverter {
         } else {
             Ok((kept, reshaped))
         }
+    }
+
+    /// Static shape dimensions for TRTX broadcast (all dims must be known).
+    fn operand_shape_u32_static(graph: &GraphInfo, id: u32) -> Result<Vec<u32>, GraphError> {
+        let operand = graph.operand(id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("operand {} not in graph", id),
+        })?;
+        let mut out = Vec::with_capacity(operand.descriptor.shape.len());
+        for d in &operand.descriptor.shape {
+            let s = get_static_or_max_size(d);
+            if s == 0 {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "operand {} needs static dimensions for TRTX broadcast (got 0)",
+                        id
+                    ),
+                });
+            }
+            out.push(s);
+        }
+        Ok(out)
+    }
+
+    /// Expand `tensor` from `from_dims` to `target_dims` (NumPy-style; dimensions must be conformable).
+    fn broadcast_trtx_tensor_to_dims<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        from_dims: &[i64],
+        target_dims: &[i64],
+        op_label: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if from_dims == target_dims {
+            let layer = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast identity: {e}"),
+            })?;
+            return layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast identity output: {e}"),
+            });
+        }
+
+        let mut cur: &trtx::Tensor<'a> = tensor;
+        let mut dims = from_dims.to_vec();
+        let mut staged: Option<trtx::Tensor<'a>> = None;
+
+        if dims.len() < target_dims.len() {
+            let rank_diff = target_dims.len() - dims.len();
+            let mut new_shape: Vec<i64> = vec![1i64; rank_diff];
+            new_shape.extend_from_slice(&dims);
+            let mut shuffle_layer = network.add_shuffle(cur).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast shuffle: {e}"),
+            })?;
+            shuffle_layer
+                .set_reshape_dimensions(network, &new_shape)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast reshape: {e}"),
+                })?;
+            let out = shuffle_layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast shuffle output: {e}"),
+            })?;
+            staged = Some(out);
+            dims = new_shape;
+            cur = staged.as_ref().ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast shuffle missing tensor"),
+            })?;
+        }
+
+        if dims.len() != target_dims.len() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "{op_label} broadcast: rank mismatch {:?} vs {:?}",
+                    dims, target_dims
+                ),
+            });
+        }
+
+        for (&d, &t) in dims.iter().zip(target_dims.iter()) {
+            if d != t && d != 1 {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast: cannot expand dim {d} to {t}"),
+                });
+            }
+        }
+
+        if dims == target_dims {
+            return if let Some(t) = staged {
+                Ok(t)
+            } else {
+                Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast: missing tensor after rank pad"),
+                })
+            };
+        }
+
+        let mut resize_layer = network.add_resize(cur).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{op_label} broadcast resize: {e}"),
+        })?;
+        resize_layer.set_output_dimensions(network, target_dims);
+        resize_layer.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{op_label} broadcast resize output: {e}"),
+        })
     }
 
     /// Add elementwise operation
@@ -6184,47 +6297,70 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add where operation (select elements based on condition)
+    /// Add where operation (select elements based on condition).
+    /// WebNN broadcasts **condition**, **true**, and **false** to one common shape ([`infer_where_shape`]);
+    /// pairwise [`ensure_broadcast_compatible`] is not enough. `ISelectLayer` needs BOOL condition:
+    /// broadcast condition as Float32 (promote UInt8/Int8), then `cast_to_bool` after resize.
     fn add_where_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
+        let cond_id = operation.input_operands()[0];
+        let true_id = operation.input_operands()[1];
+        let false_id = operation.input_operands()[2];
+
         let condition = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&cond_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!(
-                    "Condition operand {} not found",
-                    operation.input_operands()[0]
-                ),
+                reason: format!("Condition operand {} not found", cond_id),
             })?;
 
         let true_value = tensor_map
-            .get(&operation.input_operands()[1])
+            .get(&true_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!(
-                    "True value operand {} not found",
-                    operation.input_operands()[1]
-                ),
+                reason: format!("True value operand {} not found", true_id),
             })?;
 
         let false_value = tensor_map
-            .get(&operation.input_operands()[2])
+            .get(&false_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!(
-                    "False value operand {} not found",
-                    operation.input_operands()[2]
-                ),
+                reason: format!("False value operand {} not found", false_id),
             })?;
 
-        // Cast condition from Float32 to BOOL (ISelectLayer requires BOOL condition)
-        let condition_bool = Self::cast_to_bool(network, condition)?;
+        let shape_c = Self::operand_shape_u32_static(graph, cond_id)?;
+        let shape_t = Self::operand_shape_u32_static(graph, true_id)?;
+        let shape_f = Self::operand_shape_u32_static(graph, false_id)?;
+        let out_shape_u32 = infer_where_shape(&shape_c, &shape_t, &shape_f)?;
+        let target_i64: Vec<i64> = out_shape_u32.iter().map(|&x| x as i64).collect();
+
+        let cond_in: Vec<i64> = shape_c.iter().map(|&x| x as i64).collect();
+        let true_in: Vec<i64> = shape_t.iter().map(|&x| x as i64).collect();
+        let false_in: Vec<i64> = shape_f.iter().map(|&x| x as i64).collect();
+
+        let cond_float_promoted = match graph.operand(cond_id).map(|o| o.descriptor.data_type) {
+            Some(DataType::Uint8) | Some(DataType::Int8) => {
+                Some(Self::cast_to_float32(network, condition)?)
+            }
+            _ => None,
+        };
+        let cond_f: &trtx::Tensor<'a> = cond_float_promoted.as_ref().unwrap_or(condition);
+
+        let cond_bc =
+            Self::broadcast_trtx_tensor_to_dims(network, cond_f, &cond_in, &target_i64, "where_cond")?;
+        let true_bc =
+            Self::broadcast_trtx_tensor_to_dims(network, true_value, &true_in, &target_i64, "where_true")?;
+        let false_bc =
+            Self::broadcast_trtx_tensor_to_dims(network, false_value, &false_in, &target_i64, "where_false")?;
+
+        let condition_bool = Self::cast_to_bool(network, &cond_bc)?;
 
         let layer = network
-            .add_select(&condition_bool, true_value, false_value)
+            .add_select(&condition_bool, &true_bc, &false_bc)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add select layer: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -3537,6 +3537,10 @@ impl TrtxConverter {
             }
         };
 
+        let input_operand = graph.operand(in_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("dequantizeLinear input operand {in_id} not found"),
+        })?;
         let scale_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
             format: "trtx".to_string(),
             reason: format!("dequantizeLinear scale operand {sc_id} not found"),
@@ -3565,11 +3569,43 @@ impl TrtxConverter {
             reason: format!("Scale operand {sc_id} not found"),
         })?;
 
-        let input_q = Self::trtx_qdq_ensure_rank1(network, input, "dequantizeLinear input")?;
-        let scale_q = Self::trtx_qdq_ensure_rank1(network, scale, "dequantizeLinear scale")?;
+        let input_dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear input dimensions: {e}"),
+            })?;
+        let scale_dims = scale
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear scale dimensions: {e}"),
+            })?;
+        let in_shape_web = input_operand.descriptor.static_or_max_shape();
+        let sc_shape_web = scale_operand.descriptor.static_or_max_shape();
+        // Per-tensor 0D: DO NOT insert Shuffle before DQ (QDQ fusion needs int8 binding -> DQ).
+        // TensorRT may report scalars as rank-1 while WebNN uses `[]`, so trust graph shapes too.
+        let scalar_dq = (in_shape_web.is_empty() && sc_shape_web.is_empty())
+            || (input_dims.is_empty() && scale_dims.is_empty());
+
+        let input_q_holder;
+        let scale_q_holder;
+        // `scale_for_zp` must be assigned next to `scale_q_holder` so the compiler proves it is
+        // only `&scale_q_holder` when that binding was initialized (nested `if ins.len() > 2` loses
+        // the `scalar_dq` / init correlation for `let scale_q_holder;` otherwise -> E0381).
+        let scale_for_zp: &trtx::Tensor<'a>;
+        let (input_for_dq, scale_for_dq): (&trtx::Tensor<'a>, &trtx::Tensor<'a>) = if scalar_dq {
+            scale_for_zp = scale;
+            (input, scale)
+        } else {
+            input_q_holder = Self::trtx_qdq_ensure_rank1(network, input, "dequantizeLinear input")?;
+            scale_q_holder = Self::trtx_qdq_ensure_rank1(network, scale, "dequantizeLinear scale")?;
+            scale_for_zp = &scale_q_holder;
+            (&input_q_holder, &scale_q_holder)
+        };
 
         let dq_layer = network
-            .add_dequantize(&input_q, &scale_q, out_trt)
+            .add_dequantize(input_for_dq, scale_for_dq, out_trt)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add dequantize layer: {}", e),
@@ -3588,7 +3624,42 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Zero point operand {z_id} not found"),
             })?;
-            let zp_q = Self::trtx_qdq_ensure_rank1(network, zp, "dequantizeLinear zero_point")?;
+            let z_operand = graph.operand(z_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dequantizeLinear zero_point operand {z_id} not in graph"),
+            })?;
+            // kINT8/kUINT8 constants must feed Constant -> DQ before other layers (QDQ validator).
+            let zp_q = if matches!(
+                zp.get_type(&*network),
+                TrtDataType::kINT8 | TrtDataType::kUINT8
+            ) {
+                let zp_dq = Self::trtx_int8_uint8_identity_dequantize(
+                    network,
+                    zp,
+                    fp_trt,
+                    "dequantizeLinear zero_point",
+                    z_operand.descriptor.data_type,
+                )?;
+                let zp_shape_web = z_operand.descriptor.static_or_max_shape();
+                if scalar_dq && zp_shape_web.is_empty() {
+                    zp_dq
+                } else {
+                    Self::trtx_qdq_ensure_rank1(network, &zp_dq, "dequantizeLinear zero_point")?
+                }
+            } else if scalar_dq && z_operand.descriptor.static_or_max_shape().is_empty()
+                && Self::trtx_tensor_dims_empty(network, zp)?
+            {
+                let id = network.add_identity(zp).map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point identity: {e}"),
+                })?;
+                id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point identity output: {e}"),
+                })?
+            } else {
+                Self::trtx_qdq_ensure_rank1(network, zp, "dequantizeLinear zero_point")?
+            };
             let zp_fp_layer = network.add_cast(&zp_q, fp_trt).map_err(|e| {
                 GraphError::ConversionFailed {
                     format: "trtx".to_string(),
@@ -3602,7 +3673,7 @@ impl TrtxConverter {
                     reason: format!("dequantizeLinear zero_point cast output: {}", e),
                 })?;
             let zp_times_scale = network
-                .add_elementwise(&zp_fp, &scale_q, ElementWiseOperation::kPROD)
+                .add_elementwise(&zp_fp, scale_for_zp, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dequantizeLinear zero_point * scale: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -9691,6 +9691,270 @@ impl TrtxConverter {
         }
     }
 
+    /// Dilated average-pool: same slice grid as max-pool; OOB taps are 0; sum then scale by `1/(kh*kw)`.
+    ///
+    /// `input` must be NCHW. Denominator is the full window size (WebNN / ONNX dilated average pool).
+    fn add_average_pool2d_dilated_via_slices<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        operation: &Operation,
+        opts: &MLPool2dOptions,
+        window_hw: [i64; 2],
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        const MAX_DILATED_POOL_TAPS: usize = 4096;
+
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool input dimensions: {e}"),
+            })?;
+        if dims.len() != 4 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated average pool expects 4D NCHW input, got {}D",
+                    dims.len()
+                ),
+            });
+        }
+        let n = dims[0];
+        let c = dims[1];
+        let h_in = dims[2];
+        let w_in = dims[3];
+        if n <= 0 || c <= 0 || h_in <= 0 || w_in <= 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool invalid dims {dims:?}"),
+            });
+        }
+
+        let kh = window_hw[0] as u32;
+        let kw = window_hw[1] as u32;
+        if kh == 0 || kw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated average pool zero window".to_string(),
+            });
+        }
+
+        let sh = opts.strides.get(0).copied().unwrap_or(1);
+        let sw = opts.strides.get(1).copied().unwrap_or(1);
+        if sh == 0 || sw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated average pool zero stride".to_string(),
+            });
+        }
+
+        let dh = opts.dilations.get(0).copied().unwrap_or(1);
+        let dw = opts.dilations.get(1).copied().unwrap_or(1);
+        if dh == 0 || dw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated average pool zero dilation".to_string(),
+            });
+        }
+
+        let (pb_h, pe_h, pb_w, pe_w) = if opts.padding.len() >= 4 {
+            (
+                opts.padding[0],
+                opts.padding[1],
+                opts.padding[2],
+                opts.padding[3],
+            )
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        let shape_u32: Vec<u32> = dims
+            .iter()
+            .map(|&d| u32::try_from(d.max(0)).unwrap_or(0))
+            .collect();
+        let pool_opts = Pool2dOptions {
+            window_dimensions: vec![kh, kw],
+            strides: vec![sh, sw],
+            dilations: vec![dh, dw],
+            pads: vec![pb_h, pe_h, pb_w, pe_w],
+            layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: Self::trtx_pool_padding_round_up(graph, operation, opts)?,
+        };
+        let out_shape = infer_pool2d_shape(&shape_u32, &pool_opts).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool shape inference: {e}"),
+            }
+        })?;
+        let oh = out_shape[2];
+        let ow = out_shape[3];
+
+        let num_taps = (kh as usize)
+            .saturating_mul(kw as usize)
+            .saturating_mul(oh as usize)
+            .saturating_mul(ow as usize);
+        if num_taps > MAX_DILATED_POOL_TAPS {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated average pool too many taps ({num_taps} > {MAX_DILATED_POOL_TAPS}); reduce size or dilation"
+                ),
+            });
+        }
+
+        let z = 0.0f32.to_ne_bytes();
+        let nc_count = (n * c) as usize;
+        let mut zero_weights = Vec::with_capacity(nc_count * 4);
+        for _ in 0..nc_count {
+            zero_weights.extend_from_slice(&z);
+        }
+        let zero_layer = network
+            .add_constant_owned(&[n, c, 1, 1], zero_weights, TrtDataType::kFLOAT)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool zero constant: {e}"),
+            })?;
+
+        let kh_i = kh as i32;
+        let kw_i = kw as i32;
+        let dil_hi = dh as i32;
+        let dil_wi = dw as i32;
+        let sh_i = sh as i32;
+        let sw_i = sw as i32;
+        let pb_hi = pb_h as i32;
+        let pb_wi = pb_w as i32;
+        let h_in_i = h_in as i32;
+        let w_in_i = w_in as i32;
+
+        let mut rows: Vec<trtx::Tensor<'a>> = Vec::with_capacity(oh as usize);
+
+        for oh_idx in 0..oh {
+            let mut cols: Vec<trtx::Tensor<'a>> = Vec::with_capacity(ow as usize);
+            for ow_idx in 0..ow {
+                let h_start = (oh_idx as i32) * sh_i - pb_hi;
+                let w_start = (ow_idx as i32) * sw_i - pb_wi;
+
+                let mut taps: Vec<trtx::Tensor<'a>> =
+                    Vec::with_capacity((kh * kw) as usize);
+                for ih in 0..kh_i {
+                    for iw in 0..kw_i {
+                        let h_idx = h_start + ih * dil_hi;
+                        let w_idx = w_start + iw * dil_wi;
+                        let tap_tensor = if h_idx >= 0
+                            && w_idx >= 0
+                            && h_idx < h_in_i
+                            && w_idx < w_in_i
+                        {
+                            let slice_layer = network
+                                .add_slice(
+                                    input,
+                                    &[0, 0, h_idx as i64, w_idx as i64],
+                                    &[n, c, 1, 1],
+                                    &[1, 1, 1, 1],
+                                )
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated average pool slice: {e}"),
+                                })?;
+                            slice_layer
+                                .get_output(&*network, 0)
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated average pool slice output: {e}"),
+                                })?
+                        } else {
+                            zero_layer.get_output(&*network, 0).map_err(|e| {
+                                GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated average pool zero tap: {e}"),
+                                }
+                            })?
+                        };
+                        taps.push(tap_tensor);
+                    }
+                }
+
+                if taps.is_empty() {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "dilated average pool empty tap list".to_string(),
+                    });
+                }
+                let mut acc = taps.remove(0);
+                for t in taps {
+                    let ew = network
+                        .add_elementwise(&acc, &t, ElementWiseOperation::kSUM)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated average pool elementwise sum: {e}"),
+                        })?;
+                    acc = ew
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated average pool sum output: {e}"),
+                        })?;
+                }
+                cols.push(acc);
+            }
+            let row = Self::trtx_concat_tensors_along_axis(network, &cols, 3)?;
+            rows.push(row);
+        }
+
+        let summed_nchw = Self::trtx_concat_tensors_along_axis(network, &rows, 2)?;
+
+        // `add_scale` Weights take raw pointers; passing `&f32::to_ne_bytes()` temporaries is unsafe
+        // because TRT may retain pointers until engine build. Use owned constant + elementwise prod.
+        let inv = 1.0f32 / ((kh as f32) * (kw as f32));
+        let inv_const_layer = network
+            .add_constant_owned(&[1, 1, 1, 1], inv.to_ne_bytes().to_vec(), TrtDataType::kFLOAT)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool inv scale constant: {e}"),
+            })?;
+        let inv_tensor = inv_const_layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool inv scale output: {e}"),
+            })?;
+        let prod_layer = network
+            .add_elementwise(&summed_nchw, &inv_tensor, ElementWiseOperation::kPROD)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool multiply by 1/n: {e}"),
+            })?;
+        let out_nchw = prod_layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated average pool prod output: {e}"),
+            })?;
+
+        let out_id = operation.output_operands_slice()[0];
+        let out_operand = graph.operand(out_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("dilated average pool output operand {out_id} not found"),
+        })?;
+        let need_half = out_operand.descriptor.data_type == DataType::Float16;
+        if need_half {
+            let cast_layer = network
+                .add_cast(&out_nchw, TrtDataType::kHALF)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated average pool Float->Half: {e}"),
+                })?;
+            cast_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated average pool cast output: {e}"),
+                })
+        } else {
+            Ok(out_nchw)
+        }
+    }
+
     /// TensorRT `kEXPLICIT_ROUND_UP` when WebNN needs ceil spatial size: `outputShapeRounding` or
     /// [`output_sizes`](crate::operator_options::MLPool2dOptions::output_sizes) matching the ceil implicit shape.
     fn trtx_pool_padding_round_up(
@@ -9819,11 +10083,11 @@ impl TrtxConverter {
         let dh = opts.dilations.get(0).copied().unwrap_or(1);
         let dw = opts.dilations.get(1).copied().unwrap_or(1);
         if dh != 1 || dw != 1 {
-            if pool_type != PoolingType::kMAX {
+            if pool_type != PoolingType::kMAX && pool_type != PoolingType::kAVERAGE {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason:
-                        "TRTX: pooling with dilations other than 1 is only supported for maxPool2d"
+                        "TRTX: pooling with dilations other than 1 is only supported for maxPool2d and averagePool2d"
                             .to_string(),
                 });
             }
@@ -9839,12 +10103,12 @@ impl TrtxConverter {
                         .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
-                            reason: format!("maxPool2d dilated Half->Float: {e}"),
+                            reason: format!("pool2d dilated Half->Float: {e}"),
                         })?;
                     Some(cast_layer.get_output(&*network, 0).map_err(|e| {
                         GraphError::ConversionFailed {
                             format: "trtx".to_string(),
-                            reason: format!("maxPool2d dilated cast output: {e}"),
+                            reason: format!("pool2d dilated cast output: {e}"),
                         }
                     })?)
                 } else {
@@ -9852,33 +10116,44 @@ impl TrtxConverter {
                 };
             let dilated_input = half_to_float.as_ref().unwrap_or(pool_nchw_in);
 
-            let out_nchw = Self::add_max_pool2d_dilated_via_slices(
-                graph,
-                network,
-                dilated_input,
-                operation,
-                opts,
-                window,
-            )?;
+            let out_nchw = if pool_type == PoolingType::kMAX {
+                Self::add_max_pool2d_dilated_via_slices(
+                    graph,
+                    network,
+                    dilated_input,
+                    operation,
+                    opts,
+                    window,
+                )?
+            } else {
+                Self::add_average_pool2d_dilated_via_slices(
+                    graph,
+                    network,
+                    dilated_input,
+                    operation,
+                    opts,
+                    window,
+                )?
+            };
 
             let output = if layout == "nhwc" {
                 let mut shuffle = network
                     .add_shuffle(&out_nchw)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("maxPool2d dilated NCHW->NHWC shuffle: {e}"),
+                        reason: format!("pool2d dilated NCHW->NHWC shuffle: {e}"),
                     })?;
                 shuffle
                     .set_first_transpose(network, &[0, 2, 3, 1])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("maxPool2d dilated NCHW->NHWC transpose: {e}"),
+                        reason: format!("pool2d dilated NCHW->NHWC transpose: {e}"),
                     })?;
                 shuffle
                     .get_output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("maxPool2d dilated NCHW shuffle output: {e}"),
+                        reason: format!("pool2d dilated NCHW shuffle output: {e}"),
                     })?
             } else {
                 out_nchw

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -4727,7 +4727,7 @@ impl TrtxConverter {
                 _ => (0.0f32.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
             };
             let zero_const = network
-                .add_small_constant_copied(&[1], &zero_bytes, zero_dtype)
+                .add_small_constant_copied(&[], &zero_bytes, zero_dtype)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm 0D: failed to add zero constant: {}", e),
@@ -4747,7 +4747,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Bias operand {} not found", bias_id),
                         })?;
-                // Bias may be scalar; broadcast to result shape [1] so ElementWise accepts same dims.
+                // Bias may be [1] or scalar; reshape to rank-0 so output matches WebNN 0D (see quantizeLinear scalar shuffle).
                 let mut bias_shuffle =
                     network
                         .add_shuffle(bias)
@@ -4756,7 +4756,7 @@ impl TrtxConverter {
                             reason: format!("LayerNorm 0D: failed to add bias shuffle: {}", e),
                         })?;
                 bias_shuffle
-                    .set_reshape_dimensions(network, &[1i64])
+                    .set_reshape_dimensions(network, &[])
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -830,7 +830,7 @@ impl TrtxConverter {
             "isNaN" => Self::add_is_nan_op(network, tensor_map, operation)?,
             "isInfinite" => Self::add_is_infinite_op(network, tensor_map, operation)?,
             "roundEven" => Self::add_round_even_op(network, tensor_map, operation)?,
-            "gatherElements" => Self::add_gather_elements_op(network, tensor_map, operation)?,
+            "gatherElements" => Self::add_gather_elements_op(graph, network, tensor_map, operation)?,
             "l2Pool2d" => Self::add_l2_pool2d_op(graph, network, tensor_map, operation)?,
             "reverse" => Self::add_reverse_op(graph, network, tensor_map, operation)?,
             "cumulativeSum" => Self::add_cumulative_sum_op(graph, network, tensor_map, operation)?,
@@ -11088,8 +11088,11 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add gatherElements operation (gather using index tensor along axis)
+    /// Add gatherElements operation (gather using index tensor along axis).
+    /// Clamps indices to `[-dim_size, dim_size - 1]` on the gather axis (WebNN / WPT), matching
+    /// [`add_gather_op`]: TensorRT Gather otherwise returns 0 for out-of-range indices.
     fn add_gather_elements_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -11111,22 +11114,128 @@ impl TrtxConverter {
                 ),
             })?;
 
-        // Get axis parameter (default to 0)
         let axis = operation
             .attributes()
             .as_gather()
             .map(|o| o.axis as i32)
             .unwrap_or(0);
 
-        // Create gather layer with ELEMENT mode
+        let data_operand = graph
+            .operand(operation.input_operands()[0])
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherElements: data operand {} not in graph",
+                    operation.input_operands()[0]
+                ),
+            })?;
+        let axis_usize = axis as usize;
+        if axis_usize >= data_operand.descriptor.shape.len() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherElements axis {} out of bounds for rank {}",
+                    axis,
+                    data_operand.descriptor.shape.len()
+                ),
+            });
+        }
+        let dim_size = get_static_or_max_size(&data_operand.descriptor.shape[axis_usize]) as i32;
+
+        let indices_operand = graph
+            .operand(operation.input_operands()[1])
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherElements: indices operand {} not in graph",
+                    operation.input_operands()[1]
+                ),
+            })?;
+        let indices_shape: Vec<i32> = indices_operand
+            .descriptor
+            .shape
+            .iter()
+            .map(|d| get_static_or_max_size(d) as i32)
+            .collect();
+        let indices_shape_i64: Vec<i64> = indices_shape.iter().map(|&d| d as i64).collect();
+
+        let clamp_min_val = -dim_size;
+        let clamp_max_val = dim_size - 1;
+        let num_elements: usize = indices_operand
+            .descriptor
+            .shape
+            .iter()
+            .map(get_static_or_max_size)
+            .product::<u32>() as usize;
+        let min_data: Vec<u8> = (0..num_elements)
+            .flat_map(|_| clamp_min_val.to_le_bytes())
+            .collect();
+        let max_data: Vec<u8> = (0..num_elements)
+            .flat_map(|_| clamp_max_val.to_le_bytes())
+            .collect();
+        let min_const = network
+            .add_small_constant_copied(&indices_shape_i64, &min_data, trtx::DataType::kINT32)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamp min constant: {}", e),
+            })?;
+        let max_const = network
+            .add_small_constant_copied(&indices_shape_i64, &max_data, trtx::DataType::kINT32)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamp max constant: {}", e),
+            })?;
+
+        let min_const_out = min_const
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamp min output: {}", e),
+            })?;
+        let max_const_out = max_const
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamp max output: {}", e),
+            })?;
+
+        let clamped_upper = network
+            .add_elementwise(indices_tensor, &max_const_out, ElementWiseOperation::kMIN)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: indices clamp (min upper): {}", e),
+            })?;
+        let clamped_upper_out = clamped_upper
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamp upper output: {}", e),
+            })?;
+
+        let clamped = network
+            .add_elementwise(
+                &min_const_out,
+                &clamped_upper_out,
+                ElementWiseOperation::kMAX,
+            )
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: indices clamp (max lower): {}", e),
+            })?;
+        let clamped_indices = clamped
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherElements: clamped indices output: {}", e),
+            })?;
+
         let mut layer = network
-            .add_gather(data_tensor, indices_tensor, axis)
+            .add_gather(data_tensor, &clamped_indices, axis)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create gather layer: {}", e),
             })?;
 
-        // Set gather mode to ELEMENT
         layer.set_gather_mode(network, trtx::GatherMode::kELEMENT);
 
         let output = layer

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -36,8 +36,9 @@ use crate::shape_inference::{
 };
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
-    OwnedConvWeights, OwnedWeights, PaddingMode, PoolingType, ReduceOperation, ResizeMode,
-    ScatterMode, TopKOperation, UnaryOperation,
+    OwnedConvWeights, OwnedWeights, PaddingMode, PoolingType, ReduceOperation,
+    ResizeCoordinateTransformation, ResizeMode, ResizeRoundMode, ScatterMode, TopKOperation,
+    UnaryOperation,
 };
 use trtx::network::PoolingLayer;
 
@@ -836,7 +837,7 @@ impl TrtxConverter {
             "triangular" => Self::add_triangular_op(graph, network, tensor_map, operation)?,
             "transpose" => Self::add_transpose_op(graph, network, tensor_map, operation)?,
             "reshape" => Self::add_reshape_op(graph, network, tensor_map, operation)?,
-            "resample2d" => Self::add_resample2d_op(network, tensor_map, operation)?,
+            "resample2d" => Self::add_resample2d_op(graph, network, tensor_map, operation)?,
 
             // NOTE: RNN operations (lstm, lstmCell, gru, gruCell) deferred
             // IRNNv2Layer is deprecated in TensorRT and autocxx cannot generate bindings for it
@@ -10720,60 +10721,148 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add resample2d operation (resize/interpolate 2D tensor)
+    /// Add resample2d operation (resize/interpolate 2D tensor).
+    ///
+    /// WebNN: <https://www.w3.org/TR/webnn/#api-mlgraphbuilder-resample2d-method>
+    /// Defaults per `MLResample2dOptions`: `axes` = [2, 3], `scales` = [1.0, 1.0] when omitted;
+    /// `sizes` (length 2) overrides `scales`.
     fn add_resample2d_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let input = tensor_map
-            .get(&operation.input_operands()[0])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
-            })?;
-
-        // Parse mode attribute (default to "nearest-neighbor")
-        let mode_str = operation
-            .attributes()
-            .get("mode")
-            .and_then(|v| v.as_str().map(String::from))
-            .unwrap_or_else(|| "nearest-neighbor".to_string());
-
-        // Map WebNN mode to TensorRT ResizeMode (typedef for InterpolationMode)
-        let resize_mode = match mode_str.as_str() {
-            "nearest-neighbor" => ResizeMode::kNEAREST,
-            "linear" => ResizeMode::kLINEAR,
-            _ => ResizeMode::kNEAREST, // Default to nearest
+        let (input_id, opts) = match operation {
+            Operation::Resample2d { input, options, .. } => {
+                (*input, options.clone().unwrap_or_default())
+            }
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "resample2d: expected Operation::Resample2d".to_string(),
+                });
+            }
         };
 
-        // Parse sizes from attributes (should be output spatial dimensions)
-        // WebNN resample2d uses [newHeight, newWidth]
-        let sizes = operation
-            .attributes()
-            .get("sizes")
-            .and_then(|v| v.as_array().cloned())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_i64().map(|i| i as i32))
-                    .collect::<Vec<i32>>()
-            })
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: "Missing sizes attribute for resample2d".to_string(),
-            })?;
+        let input = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("resample2d: input operand {input_id} not found"),
+        })?;
 
-        if sizes.len() != 2 {
+        let input_operand = graph.operand(input_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("resample2d: operand {input_id} missing from graph"),
+        })?;
+
+        let dims_trt = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("resample2d: input dimensions: {e}"),
+            })?;
+        let desc_shape: Vec<i64> = input_operand
+            .descriptor
+            .shape
+            .iter()
+            .map(|d| get_static_or_max_size(d) as i64)
+            .collect();
+
+        let rank = if !dims_trt.is_empty() {
+            dims_trt.len()
+        } else if !desc_shape.is_empty() {
+            desc_shape.len()
+        } else {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "resample2d: cannot determine input rank".to_string(),
+            });
+        };
+
+        if rank != 4 {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!(
-                    "resample2d sizes must have 2 elements (height, width), got {}",
-                    sizes.len()
+                    "resample2d: WebNN requires a 4-D input tensor, got rank {rank}"
                 ),
             });
         }
 
-        // Create resize layer
+        let mut input_shape = vec![1_i64; rank];
+        for i in 0..rank {
+            let from_trt = dims_trt.get(i).copied().unwrap_or(0);
+            let from_desc = desc_shape.get(i).copied().unwrap_or(1);
+            input_shape[i] = if from_trt > 0 {
+                from_trt
+            } else {
+                from_desc.max(1)
+            };
+        }
+
+        let axes: Vec<usize> = if opts.axes.len() == 2 {
+            opts.axes.iter().map(|&a| a as usize).collect()
+        } else {
+            vec![2, 3]
+        };
+        if axes.len() != 2 || axes[0] >= rank || axes[1] >= rank || axes[0] == axes[1] {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "resample2d: axes must be two distinct valid indices for rank {rank}, got {:?}",
+                    opts.axes
+                ),
+            });
+        }
+
+        let spatial_sizes: Vec<i64> = if let Some(ref sizes) = opts.sizes {
+            if sizes.len() != 2 {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "resample2d: sizes must have length 2, got {:?}",
+                        sizes
+                    ),
+                });
+            }
+            sizes.iter().map(|&u| u as i64).collect()
+        } else {
+            let (s0, s1) = if opts.scales.is_empty() {
+                (1.0_f32, 1.0_f32)
+            } else if opts.scales.len() == 2 {
+                (opts.scales[0], opts.scales[1])
+            } else {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "resample2d: scales must have length 2 or be omitted (default [1, 1]), got {:?}",
+                        opts.scales
+                    ),
+                });
+            };
+            vec![
+                (input_shape[axes[0]].max(1) as f64 * f64::from(s0))
+                    .round()
+                    .max(1.0) as i64,
+                (input_shape[axes[1]].max(1) as f64 * f64::from(s1))
+                    .round()
+                    .max(1.0) as i64,
+            ]
+        };
+
+        let mut output_dims = input_shape.clone();
+        output_dims[axes[0]] = spatial_sizes[0];
+        output_dims[axes[1]] = spatial_sizes[1];
+
+        let mode_norm = if opts.mode.is_empty() {
+            "nearest-neighbor".to_string()
+        } else {
+            opts.mode.to_ascii_lowercase()
+        };
+        let resize_mode = match mode_norm.as_str() {
+            "linear" => ResizeMode::kLINEAR,
+            "nearest-neighbor" | "nearest" => ResizeMode::kNEAREST,
+            _ => ResizeMode::kNEAREST,
+        };
+
         let mut layer = network
             .add_resize(input)
             .map_err(|e| GraphError::ConversionFailed {
@@ -10781,17 +10870,17 @@ impl TrtxConverter {
                 reason: format!("Failed to add resize layer: {}", e),
             })?;
 
-        // TensorRT expects full output dimensions [N, C, H, W]
-        // WebNN resample2d only specifies [H, W], so we need to preserve N and C
-        // For now, we'll assume 4D NCHW input and set full dimensions
-        // TODO: Get actual input dimensions to preserve N and C
-        let output_dims: Vec<i64> = vec![1, 1, sizes[0] as i64, sizes[1] as i64]; // Placeholder: [N=1, C=1, H, W]
-
-        // Set output dimensions
         layer.set_output_dimensions(network, &output_dims);
 
         // Set resize mode (uses ResizeMode typedef for InterpolationMode)
         layer.set_resize_mode(network, resize_mode);
+        // WebNN `resample2d` uses the half-pixel grid; TensorRT default is kASYMMETRIC.
+        layer.set_coordinate_transformation(network, ResizeCoordinateTransformation::kHALF_PIXEL);
+        // WebNN nearest: `ceil(coord - 0.5)` == `floor(coord + 0.5)` on the sampling grid; TRT default
+        // `kFLOOR` uses `floor(coord)` and mis-aligns upsampling (e.g. 2x nearest on float grid).
+        if resize_mode == ResizeMode::kNEAREST {
+            layer.set_nearest_rounding(network, ResizeRoundMode::kHALF_UP);
+        }
 
         let output = layer
             .get_output(&*network, 0)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -47,6 +47,15 @@ impl TrtxConverter {
         TrtxConverter
     }
 
+    /// TensorRT engine I/O tensor name for operand index `operand_id` (`GraphInfo::operands` index).
+    ///
+    /// WebNN/WPT names are intentionally not used as TRT binding names: TensorRT's QDQ rewrite
+    /// matches ONNX-style tokens (e.g. `ZeroPoint`) and can fail engine build for unrelated native graphs.
+    pub fn engine_binding_name(operand_id: u32) -> String {
+        format!("webnn_operand_{operand_id}")
+    }
+
+    #[allow(dead_code)]
     #[inline]
     fn trtx_dims_i64(dims: &[i32]) -> Vec<i64> {
         dims.iter().map(|&d| d as i64).collect()
@@ -62,13 +71,12 @@ impl TrtxConverter {
             DataType::Int8 => Ok(TrtDataType::kINT8),
             DataType::Int32 => Ok(TrtDataType::kINT32),
             DataType::Uint8 => Ok(TrtDataType::kUINT8),
+            // TensorRT has no distinct uint4; store 0..=15 in kUINT8 (one byte per element, same as rustnn).
+            DataType::Uint4 => Ok(TrtDataType::kUINT8),
             DataType::Uint32 => Ok(TrtDataType::kINT32),
             DataType::Int64 => Ok(TrtDataType::kINT64),
             DataType::Uint64 => Ok(TrtDataType::kINT64),
-            _ => Err(GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Unsupported data type: {:?}", dtype),
-            }),
+            DataType::Int4 => Ok(TrtDataType::kINT4),
         }
     }
 
@@ -368,17 +376,17 @@ impl TrtxConverter {
                     .iter()
                     .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
-                let name = operand.name.as_deref().unwrap_or("input");
+                let trt_io_name = Self::engine_binding_name(operand_id as u32);
 
-                let tensor = network.add_input(name, dtype, &dims).map_err(|e| {
-                    GraphError::ConversionFailed {
+                let tensor = network
+                    .add_input(&trt_io_name, dtype, &dims)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Failed to add input {}: {}", name, e),
-                    }
-                })?;
+                        reason: format!("Failed to add input {}: {}", trt_io_name, e),
+                    })?;
 
                 tensor
-                    .set_name(network, name)
+                    .set_name(network, &trt_io_name)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to set input name: {}", e),
@@ -428,11 +436,15 @@ impl TrtxConverter {
                     });
                 }
 
-                // TensorRT Constant permits kINT8 (not kUINT8). Use int8 for Int8/Uint8 constants:
-                // same byte layout, no promotion; LogicalNot accepts int8/uint8 input.
+                // TensorRT Constant permits kINT8 (not kUINT8). Use kINT8 for Int8/Uint8/Int4/Uint4
+                // graph constants: rustnn stores one byte per logical int4/uint4 element (unpacked).
+                //
+                // Do not pass `kINT4` / sub-byte dtypes to `add_constant` / `add_small_constant_copied`:
+                // trtx-rs validates weight size as `(element_count * size_bits) / 8` with truncating
+                // division, so e.g. one INT4 scalar expects 0 bytes and panics. We do not patch trtx-rs.
                 let use_int8_constant = matches!(
                     operand.descriptor.data_type,
-                    DataType::Int8 | DataType::Uint8
+                    DataType::Int8 | DataType::Uint8 | DataType::Int4 | DataType::Uint4
                 );
 
                 // TensorRT add_constant does not support kINT64; convert Int64 constants to Int32.
@@ -496,10 +508,8 @@ impl TrtxConverter {
                     }
                 })?;
 
-                // Set the output tensor name if available
-                if let Some(name) = &operand.name {
-                    let _ = tensor.set_name(network, name); // Ignore error if name setting fails
-                }
+                let trt_io_name = Self::engine_binding_name(operand_id as u32);
+                let _ = tensor.set_name(network, &trt_io_name);
 
                 network.mark_output(tensor);
             }
@@ -636,8 +646,12 @@ impl TrtxConverter {
                 constants_stored_flat,
                 operation,
             )?,
-            "quantizeLinear" => Self::add_quantize_linear_op(network, tensor_map, operation)?,
-            "dequantizeLinear" => Self::add_dequantize_linear_op(network, tensor_map, operation)?,
+            "quantizeLinear" => {
+                Self::add_quantize_linear_op(graph, network, tensor_map, operation)?
+            }
+            "dequantizeLinear" => {
+                Self::add_dequantize_linear_op(graph, network, tensor_map, operation)?
+            }
 
             // Matrix operations
             "matmul" => Self::add_matmul_op(network, tensor_map, operation)?,
@@ -2584,33 +2598,894 @@ impl TrtxConverter {
         Ok(())
     }
 
+    /// TensorRT `IQuantizeLayer` / `IDequantizeLayer` require `input.nbDims > 0`.
+    /// Expand 0D (scalar) tensors to `[1]` before Q/DQ.
+    ///
+    /// **Do not** reshape Q/DQ output back to rank-0: Myelin can assert when mask rank and
+    /// tensor rank disagree on empty `IShuffleLayer` reshapes.
+    fn trtx_qdq_ensure_rank1<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        label: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let dims = tensor.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{label}: dimensions: {e}"),
+        })?;
+        if dims.is_empty() {
+            let mut sh = network.add_shuffle(tensor).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: rank-1 shuffle: {e}"),
+            })?;
+            sh.set_reshape_dimensions(network, &[1i64])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: reshape [1]: {e}"),
+                })?;
+            sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: shuffle output: {e}"),
+            })
+        } else {
+            let id = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: identity: {e}"),
+            })?;
+            id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: identity output: {e}"),
+            })
+        }
+    }
+
+    /// Prepend size-1 dimensions so `tensor` has rank `target_rank` (NumPy-style leading ones).
+    fn trtx_prepend_ones_to_trt_rank<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        target_rank: usize,
+        label: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let dims = tensor.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{label}: prepend dimensions: {e}"),
+        })?;
+        if dims.len() == target_rank {
+            let id = network.add_identity(tensor).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: prepend identity: {e}"),
+            })?;
+            return id.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: prepend identity output: {e}"),
+            });
+        }
+        if dims.len() > target_rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "{label}: tensor rank {} exceeds target rank {}",
+                    dims.len(),
+                    target_rank
+                ),
+            });
+        }
+        let mut new_shape = vec![1_i64; target_rank - dims.len()];
+        new_shape.extend_from_slice(&dims);
+        let mut sh = network.add_shuffle(tensor).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{label}: prepend shuffle: {e}"),
+        })?;
+        sh.set_reshape_dimensions(network, &new_shape)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: prepend reshape: {e}"),
+            })?;
+        sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{label}: prepend shuffle output: {e}"),
+        })
+    }
+
+    /// After `IDequantizeLayer` (scale = 1) on **kINT8** weights that hold **WebNN Uint8** bytes, recover
+    /// ONNX zero-point 0..255: the constant uses the same raw bytes as WebNN but TRT reads them as
+    /// int8 (−128..127), so e.g. zp byte 128 becomes −128 after DQ. Use `dq + 256` where `dq < 0`.
+    fn trtx_int8_dq_reinterpret_uint8_storage<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        dq_out: &trtx::Tensor<'a>,
+        dq_out_ty: TrtDataType,
+        label: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let dims = dq_out.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("{label} uint8 storage fix dimensions: {e}"),
+        })?;
+        let bshape: Vec<i64> = if dims.is_empty() {
+            vec![]
+        } else {
+            vec![1_i64; dims.len()]
+        };
+        let (zero_bytes, c256_bytes) = match dq_out_ty {
+            TrtDataType::kFLOAT => (
+                0.0f32.to_le_bytes().to_vec(),
+                256.0f32.to_le_bytes().to_vec(),
+            ),
+            TrtDataType::kHALF => (
+                f16::from_f32(0.0f32).to_le_bytes().to_vec(),
+                f16::from_f32(256.0f32).to_le_bytes().to_vec(),
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label} uint8 storage fix: expected float DQ output"),
+                });
+            }
+        };
+        let zero_t = network
+            .add_small_constant_copied(&bshape, &zero_bytes, dq_out_ty)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix zero: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix zero out: {e}"),
+            })?;
+        let c256_t = network
+            .add_small_constant_copied(&bshape, &c256_bytes, dq_out_ty)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix 256: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix 256 out: {e}"),
+            })?;
+        let less = network
+            .add_elementwise(dq_out, &zero_t, ElementWiseOperation::kLESS)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix less0: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix less0 out: {e}"),
+            })?;
+        let cond = Self::cast_to_bool(network, &less)?;
+        let shifted = network
+            .add_elementwise(dq_out, &c256_t, ElementWiseOperation::kSUM)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix +256: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix +256 out: {e}"),
+            })?;
+        let layer = network
+            .add_select(&cond, &shifted, dq_out)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix select: {e}"),
+            })?;
+        layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} uint8 zp fix select out: {e}"),
+            })
+    }
+
+    /// `IDequantizeLayer` with scale = 1 so int8/uint8 constants can feed float math (QDQ validator).
+    ///
+    /// WebNN **Uint8** operands are stored as **kINT8** constants (TensorRT); `webnn_integer_dtype`
+    /// selects correct float conversion. True **kUINT8** tensors use symmetric DQ (+ **128** after DQ).
+    fn trtx_int8_uint8_identity_dequantize<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        dq_out_ty: TrtDataType,
+        label: &str,
+        webnn_integer_dtype: DataType,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let input_ty = tensor.get_type(&*network);
+        // Always use a **scalar** (0D) scale for identity DQ. Matching zp rank (e.g. `[1,1]`) hits
+        // TensorRT `ScaleMode is illegal`; per-tensor scale broadcasts. Myelin: data rank >= scale rank.
+        let scale_shape: Vec<i64> = vec![];
+        let scale_bytes: Vec<u8> = match dq_out_ty {
+            TrtDataType::kFLOAT => 1.0f32.to_le_bytes().to_vec(),
+            TrtDataType::kHALF => f16::from_f32(1.0f32).to_le_bytes().to_vec(),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "{label} identity DQ expects kFLOAT/kHALF output, got {:?}",
+                        dq_out_ty
+                    ),
+                });
+            }
+        };
+        let scale_t = network
+            .add_small_constant_copied(&scale_shape, &scale_bytes, dq_out_ty)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} identity DQ scale constant: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} identity DQ scale tensor: {e}"),
+            })?;
+        let dq_layer = network
+            .add_dequantize(tensor, &scale_t, dq_out_ty)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} identity DQ: {e}"),
+            })?;
+        let dq_out = dq_layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} identity DQ output: {e}"),
+            })?;
+
+        match (webnn_integer_dtype, input_ty) {
+            (DataType::Uint8, TrtDataType::kINT8) => {
+                Self::trtx_int8_dq_reinterpret_uint8_storage(network, &dq_out, dq_out_ty, label)
+            }
+            (DataType::Uint8, TrtDataType::kUINT8) => {
+                let dq_dims =
+                    dq_out.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label} kUINT8 DQ+128 dimensions: {e}"),
+                    })?;
+                let bias_shape: Vec<i64> = if dq_dims.is_empty() {
+                    vec![]
+                } else {
+                    vec![1_i64; dq_dims.len()]
+                };
+                let bias_bytes: Vec<u8> = match dq_out_ty {
+                    TrtDataType::kFLOAT => 128.0f32.to_le_bytes().to_vec(),
+                    TrtDataType::kHALF => f16::from_f32(128.0f32).to_le_bytes().to_vec(),
+                    _ => {
+                        return Err(GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("{label} kUINT8 DQ+128: unexpected DQ dtype"),
+                        });
+                    }
+                };
+                let bias_t = network
+                    .add_small_constant_copied(&bias_shape, &bias_bytes, dq_out_ty)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label} kUINT8 +128 bias: {e}"),
+                    })?
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label} kUINT8 +128 tensor: {e}"),
+                    })?;
+                network
+                    .add_elementwise(&dq_out, &bias_t, ElementWiseOperation::kSUM)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label} kUINT8 +128 sum: {e}"),
+                    })?
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label} kUINT8 +128 output: {e}"),
+                    })
+            }
+            _ => Ok(dq_out),
+        }
+    }
+
+    /// Expand `scale` / `zero_point` from WebNN **block** shapes (e.g. `[1,2]` vs input `[3,4]`) so
+    /// TensorRT elementwise `x / scale` sees ordinary broadcast rules. Matches ONNX converter
+    /// `align_param_with_input` (reshape + tile) using concatenation along each axis.
+    ///
+    /// When `int8_uint8_identity_dq_to` is `Some(fp)`, **`kINT8` / `kUINT8` tensors are passed through
+    /// `IDequantizeLayer` (scale = 1) before any Shuffle** so `QuantizedConstantValidator` sees
+    /// Constant → DQ. Must be `None` for float `scale` tensors.
+    ///
+    /// `identity_dq_webnn_dtype`: WebNN dtype of the **integer** param (zero_point). Uint8 zp is stored
+    /// as `kINT8` in TRT; pass `DataType::Uint8` so bytes 128..255 map correctly.
+    fn trtx_align_quantize_param_for_elementwise<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        _param_shape: &[u32],
+        input_shape: &[u32],
+        label: &str,
+        int8_uint8_identity_dq_to: Option<TrtDataType>,
+        identity_dq_webnn_dtype: Option<DataType>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let dq_tensor: Option<trtx::Tensor<'a>> =
+            if let Some(dq_ty) = int8_uint8_identity_dq_to {
+                if matches!(
+                    tensor.get_type(&*network),
+                    TrtDataType::kINT8 | TrtDataType::kUINT8
+                ) {
+                    let wd = identity_dq_webnn_dtype.unwrap_or(DataType::Int8);
+                    Some(Self::trtx_int8_uint8_identity_dequantize(
+                        network, tensor, dq_ty, label, wd,
+                    )?)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+        let src_for_rank1 = dq_tensor.as_ref().unwrap_or(tensor);
+        let mut cur = Self::trtx_qdq_ensure_rank1(network, src_for_rank1, label)?;
+
+        if input_shape.is_empty() {
+            return Ok(cur);
+        }
+
+        cur = Self::trtx_prepend_ones_to_trt_rank(
+            network,
+            &cur,
+            input_shape.len(),
+            label,
+        )?;
+
+        let eff_shape_u32: Vec<u32> = cur
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: aligned param dimensions: {e}"),
+            })?
+            .iter()
+            .map(|&d| d as u32)
+            .collect();
+
+        if eff_shape_u32 == *input_shape {
+            return Ok(cur);
+        }
+
+        let broadcastable = eff_shape_u32
+            .iter()
+            .zip(input_shape.iter())
+            .all(|(&p, &i)| p == 1 || p == i);
+        if broadcastable {
+            return Ok(cur);
+        }
+
+        let tileable = eff_shape_u32
+            .iter()
+            .zip(input_shape.iter())
+            .all(|(&p, &i)| p > 0 && i % p == 0);
+        if !tileable {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "{label}: shape {:?} is not broadcastable or block-tileable to input {:?}",
+                    eff_shape_u32, input_shape
+                ),
+            });
+        }
+
+        // ONNX `align_param_with_input` uses Reshape+Tile so each **block** repeats consecutively
+        // (e.g. `[1,2,1]` → `[1,4,1]` gives `[a,a,b,b]` along the tiled axis). Concatenating **r**
+        // full copies of the param yields `[a,b,a,b]`, which is wrong for blockwise quantize.
+        for ax in 0..input_shape.len() {
+            let target = input_shape[ax] as i64;
+            let cur_dims = cur
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: block tile cur dimensions: {e}"),
+                })?;
+            let p = cur_dims[ax];
+            if p == target {
+                continue;
+            }
+            if p <= 0 || target % p != 0 {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "{label}: block tile ax={ax}: dim {p} cannot expand to {target}",
+                    ),
+                });
+            }
+            let r_us = (target / p) as usize;
+            if r_us <= 1 {
+                continue;
+            }
+            let rank = cur_dims.len();
+            let p_us = p as usize;
+            let mut expanded_parts: Vec<trtx::Tensor<'a>> = Vec::with_capacity(p_us);
+            for k in 0..p_us {
+                let mut start = vec![0_i64; rank];
+                start[ax] = k as i64;
+                let mut size = cur_dims.clone();
+                size[ax] = 1;
+                let stride = vec![1_i64; rank];
+                let slice_out = network
+                    .add_slice(&cur, &start, &size, &stride)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label}: block tile slice ax={ax} k={k}: {e}"),
+                    })?
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label}: block tile slice output ax={ax} k={k}: {e}"),
+                    })?;
+                let dup_inputs: Vec<&trtx::Tensor<'a>> =
+                    (0..r_us).map(|_| &slice_out).collect();
+                let mut cat = network.add_concatenation(&dup_inputs).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{label}: block tile dup concat ax={ax} k={k}: {e}"),
+                    }
+                })?;
+                cat.set_axis(network, ax as i32);
+                expanded_parts.push(
+                    cat.get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("{label}: block tile dup out ax={ax} k={k}: {e}"),
+                        })?,
+                );
+            }
+            let part_refs: Vec<&trtx::Tensor<'a>> = expanded_parts.iter().collect();
+            let mut cat2 = network.add_concatenation(&part_refs).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: block tile merge concat ax={ax}: {e}"),
+                }
+            })?;
+            cat2.set_axis(network, ax as i32);
+            cur = cat2
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{label}: block tile merge out ax={ax}: {e}"),
+                })?;
+        }
+
+        Ok(cur)
+    }
+
+    #[inline]
+    fn trtx_tensor_dims_empty<'a>(
+        network: &trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+    ) -> Result<bool, GraphError> {
+        let dims = tensor.dimensions(network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("tensor dimensions: {e}"),
+        })?;
+        Ok(dims.is_empty())
+    }
+
+    /// `quantizeLinear` via elementwise ops (ONNX: `clip(round(x / scale) + zero_point, qmin, qmax)`).
+    /// Used when any tensor is rank-0: `IQuantizeLayer` plus shuffles can hit a Myelin assert, and this
+    /// path wires `zero_point` so no 0D network input stays unused.
+    fn add_quantize_linear_elementwise_manual<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        scale: &trtx::Tensor<'a>,
+        zero_point: &trtx::Tensor<'a>,
+        fp_trt: TrtDataType,
+        out_trt: TrtDataType,
+        out_dtype: DataType,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let (qmin_f32, qmax_f32) = match out_dtype {
+            DataType::Int8 => (-128.0_f32, 127.0_f32),
+            DataType::Uint8 => (0.0_f32, 255.0_f32),
+            DataType::Int4 => (-8.0_f32, 7.0_f32),
+            DataType::Uint4 => (0.0_f32, 15.0_f32),
+            DataType::Int32 => (i32::MIN as f32, i32::MAX as f32),
+            DataType::Uint32 => (0.0_f32, u32::MAX as f32),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "quantizeLinear elementwise fallback: unsupported output dtype {:?}",
+                        out_dtype
+                    ),
+                });
+            }
+        };
+
+        // 32-bit quantize output: `round(x/scale)+zp` can be far outside float16 range; qmin/qmax as
+        // f16 do not represent i32::MIN/MAX (clamp breaks → INT_MIN). Run div/round/sum/clamp in f32.
+        let compute_fp = if matches!(out_dtype, DataType::Int32 | DataType::Uint32) {
+            TrtDataType::kFLOAT
+        } else {
+            fp_trt
+        };
+
+        let input_q = Self::trtx_qdq_ensure_rank1(network, input, "quantizeLinear input")?;
+        let scale_q = Self::trtx_qdq_ensure_rank1(network, scale, "quantizeLinear scale")?;
+        // Zero_point is already block-aligned; int8/uint8 zp was dequantized in
+        // `trtx_align_quantize_param_for_elementwise` before any shuffle.
+        let zp_q = Self::trtx_qdq_ensure_rank1(network, zero_point, "quantizeLinear zero_point")?;
+
+        let mut cast_if_needed = |t: trtx::Tensor<'a>, lab: &str| -> Result<trtx::Tensor<'a>, GraphError> {
+            if t.get_type(&*network) == compute_fp {
+                Ok(t)
+            } else {
+                network
+                    .add_cast(&t, compute_fp)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear manual {lab} to compute fp: {e}"),
+                    })?
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear manual {lab} cast out: {e}"),
+                    })
+            }
+        };
+        let input_e = cast_if_needed(input_q, "input")?;
+        let scale_e = cast_if_needed(scale_q, "scale")?;
+        let zp_fp = cast_if_needed(zp_q, "zero_point")?;
+
+        let div_out = network
+            .add_elementwise(&input_e, &scale_e, ElementWiseOperation::kDIV)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual div: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual div output: {e}"),
+            })?;
+
+        let rounded = network
+            .add_unary(&div_out, UnaryOperation::kROUND)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual round: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual round output: {e}"),
+            })?;
+
+        let summed = network
+            .add_elementwise(&rounded, &zp_fp, ElementWiseOperation::kSUM)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual add zero_point: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual add output: {e}"),
+            })?;
+
+        // qmin/qmax must broadcast with `summed`. A single `[1]` constant is rank-1 and TRT rejects
+        // elementwise with e.g. `[3,2]` (`nbDims` mismatch). Use `[1; rank]` so broadcasting applies.
+        let summed_dims = summed.dimensions(&*network).map_err(|e| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("quantizeLinear manual summed dimensions: {e}"),
+        })?;
+        let broadcast_shape: Vec<i64> = vec![1_i64; summed_dims.len()];
+
+        let (min_bytes, max_bytes) = match compute_fp {
+            TrtDataType::kFLOAT => (
+                qmin_f32.to_le_bytes().to_vec(),
+                qmax_f32.to_le_bytes().to_vec(),
+            ),
+            TrtDataType::kHALF => (
+                f16::from_f32(qmin_f32).to_le_bytes().to_vec(),
+                f16::from_f32(qmax_f32).to_le_bytes().to_vec(),
+            ),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "quantizeLinear manual clamp: unsupported compute type {:?}",
+                        compute_fp
+                    ),
+                });
+            }
+        };
+
+        let min_t = network
+            .add_small_constant_copied(&broadcast_shape, &min_bytes, compute_fp)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual qmin constant: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual qmin output: {e}"),
+            })?;
+
+        let max_t = network
+            .add_small_constant_copied(&broadcast_shape, &max_bytes, compute_fp)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual qmax constant: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual qmax output: {e}"),
+            })?;
+
+        let clamped_lo = network
+            .add_elementwise(&summed, &min_t, ElementWiseOperation::kMAX)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual clamp max(qmin): {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual clamp lo output: {e}"),
+            })?;
+
+        let clamped = network
+            .add_elementwise(&clamped_lo, &max_t, ElementWiseOperation::kMIN)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual clamp min(qmax): {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual clamp hi output: {e}"),
+            })?;
+
+        let out = network
+            .add_cast(&clamped, out_trt)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual output cast: {e}"),
+            })?
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("quantizeLinear manual output: {e}"),
+            })?;
+
+        Ok(out)
+    }
+
     /// Add quantizeLinear operation (float to quantized integer)
     fn add_quantize_linear_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let input = tensor_map
-            .get(&operation.input_operands()[0])
-            .ok_or_else(|| GraphError::ConversionFailed {
+        let ins = operation.input_operands();
+        let in_id = ins[0];
+        let sc_id = ins[1];
+
+        let output_id = operation.output_operands_slice()[0];
+        let out_operand = graph.operand(output_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("quantizeLinear output operand {output_id} not found"),
+        })?;
+        let out_dtype = out_operand.descriptor.data_type;
+        let out_trt = Self::webnn_to_trt_dtype(out_dtype)?;
+
+        let in_operand = graph.operand(ins[0]).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("quantizeLinear input operand {} not found", ins[0]),
+        })?;
+        let fp_trt = Self::webnn_to_trt_dtype(in_operand.descriptor.data_type)?;
+        if fp_trt != TrtDataType::kFLOAT && fp_trt != TrtDataType::kHALF {
+            return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
-            })?;
+                reason: format!(
+                    "quantizeLinear expects float16 or float32 input, got {:?}",
+                    in_operand.descriptor.data_type
+                ),
+            });
+        }
 
-        let scale = tensor_map
-            .get(&operation.input_operands()[1])
-            .ok_or_else(|| GraphError::ConversionFailed {
+        let in_rank0 = {
+            let t = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Scale operand {} not found", operation.input_operands()[1]),
+                reason: format!("Input operand {in_id} not found"),
             })?;
+            Self::trtx_tensor_dims_empty(&*network, t)?
+        };
+        let sc_rank0 = {
+            let t = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Scale operand {sc_id} not found"),
+            })?;
+            Self::trtx_tensor_dims_empty(&*network, t)?
+        };
+        let zp_rank0 = if ins.len() > 2 {
+            let zid = ins[2];
+            let zp = tensor_map.get(&zid).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Zero point operand {zid} not found"),
+            })?;
+            Self::trtx_tensor_dims_empty(&*network, zp)?
+        } else {
+            false
+        };
 
-        // Note: WebNN quantizeLinear also has zeroPoint parameter (operand 2)
-        // TensorRT's IQuantizeLayer only takes scale, so we ignore zeroPoint for now
-        // This is a limitation that should be documented
+        // IQuantizeLayer has no zero-point input and rejects UInt8 output; Int4/Uint4 and 32-bit
+        // integer outputs use the elementwise path (explicit zero-point and clamp range).
+        let use_manual = in_rank0
+            || sc_rank0
+            || zp_rank0
+            || ins.len() > 2
+            || matches!(
+                out_dtype,
+                DataType::Uint8
+                    | DataType::Int4
+                    | DataType::Uint4
+                    | DataType::Int32
+                    | DataType::Uint32
+            );
 
-        // Create quantize layer - output type is INT8 for quantization
+        if use_manual {
+            let in_shape = in_operand.descriptor.static_or_max_shape();
+            let out = if ins.len() > 2 {
+                let zid = ins[2];
+                let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Input operand {in_id} not found"),
+                })?;
+                let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Scale operand {sc_id} not found"),
+                })?;
+                let zp = tensor_map.get(&zid).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Zero point operand {zid} not found"),
+                })?;
+                let sc_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear scale operand {sc_id} missing from graph"),
+                })?;
+                let z_operand = graph.operand(zid).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear zero_point operand {zid} missing from graph"),
+                })?;
+                let sc_shape = sc_operand.descriptor.static_or_max_shape();
+                let z_shape = z_operand.descriptor.static_or_max_shape();
+                let scale_a = Self::trtx_align_quantize_param_for_elementwise(
+                    network,
+                    scale,
+                    &sc_shape,
+                    &in_shape,
+                    "quantizeLinear scale",
+                    None,
+                    None,
+                )?;
+                let zp_a = Self::trtx_align_quantize_param_for_elementwise(
+                    network,
+                    zp,
+                    &z_shape,
+                    &in_shape,
+                    "quantizeLinear zero_point",
+                    Some(fp_trt),
+                    Some(z_operand.descriptor.data_type),
+                )?;
+                Self::add_quantize_linear_elementwise_manual(
+                    network, input, &scale_a, &zp_a, fp_trt, out_trt, out_dtype,
+                )?
+            } else {
+                let (zdt, zp_bytes): (TrtDataType, &[u8]) = match out_dtype {
+                    DataType::Int8 => (TrtDataType::kINT8, &[0u8][..]),
+                    DataType::Uint8 => (TrtDataType::kUINT8, &[0u8][..]),
+                    // Scalar default zp `[0]` must not use kINT4 with `add_small_constant_copied` (trtx-rs
+                    // byte-size check). kINT8 zero is fine: manual path casts zp to float.
+                    DataType::Int4 => (TrtDataType::kINT8, &[0u8][..]),
+                    DataType::Uint4 => (TrtDataType::kUINT8, &[0u8][..]),
+                    DataType::Int32 | DataType::Uint32 => {
+                        (TrtDataType::kINT32, &[0u8, 0u8, 0u8, 0u8][..])
+                    }
+                    _ => {
+                        return Err(GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!(
+                                "quantizeLinear default zero point: unsupported output dtype {:?}",
+                                out_dtype
+                            ),
+                        });
+                    }
+                };
+                let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Input operand {in_id} not found"),
+                })?;
+                let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Scale operand {sc_id} not found"),
+                })?;
+                let zp_const = network
+                    .add_small_constant_copied(&[1_i64], zp_bytes, zdt)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear default zero_point constant: {e}"),
+                    })?
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear default zero_point output: {e}"),
+                    })?;
+                let sc_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear scale operand {sc_id} missing from graph"),
+                })?;
+                let sc_shape = sc_operand.descriptor.static_or_max_shape();
+                let scale_a = Self::trtx_align_quantize_param_for_elementwise(
+                    network,
+                    scale,
+                    &sc_shape,
+                    &in_shape,
+                    "quantizeLinear scale",
+                    None,
+                    None,
+                )?;
+                let zp_a = Self::trtx_align_quantize_param_for_elementwise(
+                    network,
+                    &zp_const,
+                    &[1],
+                    &in_shape,
+                    "quantizeLinear zero_point",
+                    Some(fp_trt),
+                    Some(out_dtype),
+                )?;
+                Self::add_quantize_linear_elementwise_manual(
+                    network,
+                    input,
+                    &scale_a,
+                    &zp_a,
+                    fp_trt,
+                    out_trt,
+                    out_dtype,
+                )?
+            };
+            // Elementwise path uses `trtx_qdq_ensure_rank1`, so scalar inputs become `[1]`. WebNN
+            // output rank must match the float input (e.g. `[]` not `[1]`).
+            let out = if in_shape.is_empty() {
+                let mut sh = network.add_shuffle(&out).map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear scalar output shuffle: {e}"),
+                })?;
+                sh.set_reshape_dimensions(network, &[])
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("quantizeLinear scalar output reshape: {e}"),
+                    })?;
+                sh.get_output(&*network, 0).map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("quantizeLinear scalar shuffle output: {e}"),
+                })?
+            } else {
+                out
+            };
+            tensor_map.insert(output_id, out);
+            return Ok(());
+        }
+
+        let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Input operand {in_id} not found"),
+        })?;
+        let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Scale operand {sc_id} not found"),
+        })?;
+
+        let input_q = Self::trtx_qdq_ensure_rank1(network, input, "quantizeLinear input")?;
+        let scale_q = Self::trtx_qdq_ensure_rank1(network, scale, "quantizeLinear scale")?;
+
         let layer = network
-            .add_quantize(input, scale, TrtDataType::kINT8)
+            .add_quantize(&input_q, &scale_q, out_trt)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add quantize layer: {}", e),
@@ -2623,54 +3498,134 @@ impl TrtxConverter {
                 reason: format!("Failed to get quantize output: {}", e),
             })?;
 
-        let output_ids = operation.output_operands_slice();
-        let output_id = output_ids[0];
         tensor_map.insert(output_id, output);
         Ok(())
     }
 
-    /// Add dequantizeLinear operation (quantized integer to float)
+    /// Add dequantizeLinear operation (quantized integer to float).
+    ///
+    /// TensorRT `IDequantizeLayer` is `(input - zeroPt) * scale` when zero-point is wired, with tight
+    /// constraints on `zeroPt`. For a general WebNN zero-point tensor, use implicit zero-point 0
+    /// (`input * scale`) and subtract `cast(zero_point) * scale`.
     fn add_dequantize_linear_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let input = tensor_map
-            .get(&operation.input_operands()[0])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
-            })?;
+        let ins = operation.input_operands();
+        let in_id = ins[0];
+        let sc_id = ins[1];
 
-        let scale = tensor_map
-            .get(&operation.input_operands()[1])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Scale operand {} not found", operation.input_operands()[1]),
-            })?;
+        let output_ids = operation.output_operands_slice();
+        let output_id = output_ids[0];
+        let out_operand = graph.operand(output_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("dequantizeLinear output operand {output_id} not found"),
+        })?;
+        let out_trt = match out_operand.descriptor.data_type {
+            DataType::Float32 => TrtDataType::kFLOAT,
+            DataType::Float16 => TrtDataType::kHALF,
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "dequantizeLinear expects float16 or float32 output, got {:?}",
+                        out_operand.descriptor.data_type
+                    ),
+                });
+            }
+        };
 
-        // Note: WebNN dequantizeLinear also has zeroPoint parameter (operand 2)
-        // TensorRT's IDequantizeLayer only takes scale, so we ignore zeroPoint for now
-        // This is a limitation that should be documented
+        let scale_operand = graph.operand(sc_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("dequantizeLinear scale operand {sc_id} not found"),
+        })?;
+        let fp_trt = match scale_operand.descriptor.data_type {
+            DataType::Float32 => TrtDataType::kFLOAT,
+            DataType::Float16 => TrtDataType::kHALF,
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "dequantizeLinear expects float16 or float32 scale, got {:?}",
+                        scale_operand.descriptor.data_type
+                    ),
+                });
+            }
+        };
 
-        // Create dequantize layer - output type is FLOAT for dequantization
-        let layer = network
-            .add_dequantize(input, scale, TrtDataType::kFLOAT)
+        let input = tensor_map.get(&in_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Input operand {in_id} not found"),
+        })?;
+
+        let scale = tensor_map.get(&sc_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("Scale operand {sc_id} not found"),
+        })?;
+
+        let input_q = Self::trtx_qdq_ensure_rank1(network, input, "dequantizeLinear input")?;
+        let scale_q = Self::trtx_qdq_ensure_rank1(network, scale, "dequantizeLinear scale")?;
+
+        let dq_layer = network
+            .add_dequantize(&input_q, &scale_q, out_trt)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add dequantize layer: {}", e),
             })?;
 
-        let output = layer
+        let mut dq_out = dq_layer
             .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get dequantize output: {}", e),
             })?;
 
-        let output_ids = operation.output_operands_slice();
-        let output_id = output_ids[0];
-        tensor_map.insert(output_id, output);
+        if ins.len() > 2 {
+            let z_id = ins[2];
+            let zp = tensor_map.get(&z_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Zero point operand {z_id} not found"),
+            })?;
+            let zp_q = Self::trtx_qdq_ensure_rank1(network, zp, "dequantizeLinear zero_point")?;
+            let zp_fp_layer = network.add_cast(&zp_q, fp_trt).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point cast: {}", e),
+                }
+            })?;
+            let zp_fp = zp_fp_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point cast output: {}", e),
+                })?;
+            let zp_times_scale = network
+                .add_elementwise(&zp_fp, &scale_q, ElementWiseOperation::kPROD)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point * scale: {}", e),
+                })?
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear zero_point * scale output: {}", e),
+                })?;
+            dq_out = network
+                .add_elementwise(&dq_out, &zp_times_scale, ElementWiseOperation::kSUB)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear subtract zp*scale: {}", e),
+                })?
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dequantizeLinear corrected output: {}", e),
+                })?;
+        }
+
+        tensor_map.insert(output_id, dq_out);
         Ok(())
     }
 
@@ -9410,6 +10365,12 @@ mod tests {
             TrtxConverter::webnn_to_trt_dtype(DataType::Int32).unwrap(),
             TrtDataType::kINT32
         ));
+    }
+
+    #[test]
+    fn test_engine_binding_name_stable() {
+        assert_eq!(TrtxConverter::engine_binding_name(0).as_str(), "webnn_operand_0");
+        assert_eq!(TrtxConverter::engine_binding_name(42).as_str(), "webnn_operand_42");
     }
 
     /// HWIO -> OIHW transpose: perm (3,2,0,1) => output[o,i,h,w] = input[h,w,i,o].

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -814,7 +814,7 @@ impl TrtxConverter {
 
             // Indexing/Gathering operations
             "gather" => Self::add_gather_op(graph, network, tensor_map, operation, temp_weights)?,
-            "gatherND" => Self::add_gather_nd_op(network, tensor_map, operation)?,
+            "gatherND" => Self::add_gather_nd_op(graph, network, tensor_map, operation)?,
             "scatterElements" => Self::add_scatter_elements_op(network, tensor_map, operation)?,
             "scatterND" => Self::add_scatter_nd_op(network, tensor_map, operation)?,
             "argMax" => Self::add_arg_max_op(graph, network, tensor_map, operation)?,
@@ -6758,8 +6758,11 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add gatherND operation (N-dimensional gather)
+    /// Add gatherND operation (N-dimensional gather).
+    /// Clamps each index component to `[-dim_size, dim_size - 1]` on the corresponding data axis
+    /// (WebNN / ONNX / WPT); TensorRT Gather-ND otherwise returns 0 for out-of-range indices.
     fn add_gather_nd_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -6781,16 +6784,146 @@ impl TrtxConverter {
                 ),
             })?;
 
-        // Create gather layer with axis 0 (required by addGather API)
+        let data_operand = graph
+            .operand(operation.input_operands()[0])
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherND: data operand {} not in graph",
+                    operation.input_operands()[0]
+                ),
+            })?;
+        let indices_operand = graph
+            .operand(operation.input_operands()[1])
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherND: indices operand {} not in graph",
+                    operation.input_operands()[1]
+                ),
+            })?;
+
+        let data_rank = data_operand.descriptor.shape.len();
+        let k = indices_operand
+            .descriptor
+            .shape
+            .last()
+            .map(get_static_or_max_size)
+            .unwrap_or(1) as usize;
+        if k == 0 || k > data_rank {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "gatherND: invalid indices last dim {} for data rank {}",
+                    k, data_rank
+                ),
+            });
+        }
+
+        let mins_k: Vec<i32> = data_operand.descriptor.shape[..k]
+            .iter()
+            .map(|d| -(get_static_or_max_size(d) as i32))
+            .collect();
+        let maxs_k: Vec<i32> = data_operand.descriptor.shape[..k]
+            .iter()
+            .map(|d| get_static_or_max_size(d) as i32 - 1)
+            .collect();
+
+        let idx_dims: Vec<u32> = indices_operand
+            .descriptor
+            .shape
+            .iter()
+            .map(get_static_or_max_size)
+            .collect();
+        let r = idx_dims.len();
+        if r < 1 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "gatherND: indices tensor must have rank >= 1".to_string(),
+            });
+        }
+        let prefix_count: usize = if r <= 1 {
+            1usize
+        } else {
+            idx_dims[..r - 1]
+                .iter()
+                .map(|&x| x as usize)
+                .product()
+        };
+        let mut min_data: Vec<u8> = Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
+        let mut max_data: Vec<u8> = Vec::with_capacity(prefix_count.saturating_mul(k).saturating_mul(4));
+        for _ in 0..prefix_count {
+            for j in 0..k {
+                min_data.extend_from_slice(&mins_k[j].to_le_bytes());
+                max_data.extend_from_slice(&maxs_k[j].to_le_bytes());
+            }
+        }
+
+        let indices_shape_i64: Vec<i64> = idx_dims.iter().map(|&d| d as i64).collect();
+        let min_const = network
+            .add_small_constant_copied(&indices_shape_i64, &min_data, trtx::DataType::kINT32)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamp min constant: {}", e),
+            })?;
+        let max_const = network
+            .add_small_constant_copied(&indices_shape_i64, &max_data, trtx::DataType::kINT32)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamp max constant: {}", e),
+            })?;
+
+        let min_const_out = min_const
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamp min output: {}", e),
+            })?;
+        let max_const_out = max_const
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamp max output: {}", e),
+            })?;
+
+        let clamped_upper = network
+            .add_elementwise(indices, &max_const_out, ElementWiseOperation::kMIN)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: indices clamp upper: {}", e),
+            })?;
+        let clamped_upper_out = clamped_upper
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamp upper tensor: {}", e),
+            })?;
+
+        let clamped = network
+            .add_elementwise(
+                &min_const_out,
+                &clamped_upper_out,
+                ElementWiseOperation::kMAX,
+            )
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: indices clamp lower: {}", e),
+            })?;
+        let clamped_indices = clamped
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("gatherND: clamped indices: {}", e),
+            })?;
+
         let mut layer =
             network
-                .add_gather(input, indices, 0)
+                .add_gather(input, &clamped_indices, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add gatherND layer: {}", e),
                 })?;
 
-        // Set gather mode to kND for N-dimensional gather
         layer.set_gather_mode(network, trtx::GatherMode::kND);
 
         let output = layer

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1961,9 +1961,11 @@ impl TrtxConverter {
                     reason: format!("Failed to get negative part: {}", e),
                 })?;
 
-        // slope * min(0, x)
+        // slope * min(0, x) — TRT requires same rank for elementwise; reshape slope with leading 1s (WebNN broadcast).
+        let (neg_bc, slope_bc) =
+            Self::ensure_broadcast_compatible(network, &neg_part, slope, "prelu_slope")?;
         let scaled_neg_layer = network
-            .add_elementwise(&neg_part, slope, ElementWiseOperation::kPROD)
+            .add_elementwise(&neg_bc, &slope_bc, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale negative part: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -552,10 +552,10 @@ impl TrtxConverter {
     }
 
     /// Add a single operation to the network
-    fn add_operation<'a>(
-        graph: &'a GraphInfo,
-        network: &mut trtx::NetworkDefinition<'a>,
-        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
+    fn add_operation<'network_definition>(
+        graph: &'network_definition GraphInfo,
+        network: &mut trtx::NetworkDefinition<'network_definition>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'network_definition>>,
         promoted_constants: &HashSet<u32>,
         constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
@@ -634,10 +634,16 @@ impl TrtxConverter {
             "gelu" => {
                 Self::add_activation_op(network, tensor_map, operation, ActivationType::kGELU_ERF)?
             }
-            "leakyRelu" => Self::add_leaky_relu_op(graph, network, tensor_map, operation)?,
+            "leakyRelu" => {
+                Self::add_leaky_relu_op(graph, network, tensor_map, operation)?
+            }
             "prelu" => Self::add_prelu_op(network, tensor_map, operation)?,
-            "hardSigmoid" => Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?,
-            "hardSwish" => Self::add_hard_swish_op(graph, network, tensor_map, operation)?,
+            "hardSigmoid" => {
+                Self::add_hard_sigmoid_op(graph, network, tensor_map, operation)?
+            }
+            "hardSwish" => {
+                Self::add_hard_swish_op(graph, network, tensor_map, operation)?
+            }
 
             // Unary mathematical operations (use IUnaryLayer)
             // Exponential and logarithmic
@@ -791,7 +797,9 @@ impl TrtxConverter {
                 operation,
                 ElementWiseOperation::kXOR,
             )?,
-            "logicalNot" => Self::add_logical_not_op(graph, network, tensor_map, operation)?,
+            "logicalNot" => {
+                Self::add_logical_not_op(graph, network, tensor_map, operation)?
+            }
 
             // Indexing/Gathering operations
             "gather" => Self::add_gather_op(graph, network, tensor_map, operation)?,

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -9955,6 +9955,222 @@ impl TrtxConverter {
         }
     }
 
+    /// Dilated L2 pool: `sqrt(sum(x^2))` over dilated taps — same slice grid as dilated average/max.
+    ///
+    /// `input` must be **x^2** in NCHW (typically `float32`; callers may upcast from half).
+    fn add_l2_pool2d_dilated_via_slices<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        operation: &Operation,
+        opts: &MLPool2dOptions,
+        window_hw: [i64; 2],
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        const MAX_DILATED_POOL_TAPS: usize = 4096;
+
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated l2 pool input dimensions: {e}"),
+            })?;
+        if dims.len() != 4 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated l2 pool expects 4D NCHW input, got {}D",
+                    dims.len()
+                ),
+            });
+        }
+        let n = dims[0];
+        let c = dims[1];
+        let h_in = dims[2];
+        let w_in = dims[3];
+        if n <= 0 || c <= 0 || h_in <= 0 || w_in <= 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated l2 pool invalid dims {dims:?}"),
+            });
+        }
+
+        let kh = window_hw[0] as u32;
+        let kw = window_hw[1] as u32;
+        if kh == 0 || kw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated l2 pool zero window".to_string(),
+            });
+        }
+
+        let sh = opts.strides.get(0).copied().unwrap_or(1);
+        let sw = opts.strides.get(1).copied().unwrap_or(1);
+        if sh == 0 || sw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated l2 pool zero stride".to_string(),
+            });
+        }
+
+        let dh = opts.dilations.get(0).copied().unwrap_or(1);
+        let dw = opts.dilations.get(1).copied().unwrap_or(1);
+        if dh == 0 || dw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated l2 pool zero dilation".to_string(),
+            });
+        }
+
+        let (pb_h, pe_h, pb_w, pe_w) = if opts.padding.len() >= 4 {
+            (
+                opts.padding[0],
+                opts.padding[1],
+                opts.padding[2],
+                opts.padding[3],
+            )
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        let shape_u32: Vec<u32> = dims
+            .iter()
+            .map(|&d| u32::try_from(d.max(0)).unwrap_or(0))
+            .collect();
+        let pool_opts = Pool2dOptions {
+            window_dimensions: vec![kh, kw],
+            strides: vec![sh, sw],
+            dilations: vec![dh, dw],
+            pads: vec![pb_h, pe_h, pb_w, pe_w],
+            layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: Self::trtx_pool_padding_round_up(graph, operation, opts)?,
+        };
+        let out_shape = infer_pool2d_shape(&shape_u32, &pool_opts).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated l2 pool shape inference: {e}"),
+            }
+        })?;
+        let oh = out_shape[2];
+        let ow = out_shape[3];
+
+        let num_taps = (kh as usize)
+            .saturating_mul(kw as usize)
+            .saturating_mul(oh as usize)
+            .saturating_mul(ow as usize);
+        if num_taps > MAX_DILATED_POOL_TAPS {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated l2 pool too many taps ({num_taps} > {MAX_DILATED_POOL_TAPS}); reduce size or dilation"
+                ),
+            });
+        }
+
+        let z = 0.0f32.to_ne_bytes();
+        let nc_count = (n * c) as usize;
+        let mut zero_weights = Vec::with_capacity(nc_count * 4);
+        for _ in 0..nc_count {
+            zero_weights.extend_from_slice(&z);
+        }
+        let zero_layer = network
+            .add_constant_owned(&[n, c, 1, 1], zero_weights, TrtDataType::kFLOAT)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated l2 pool zero constant: {e}"),
+            })?;
+
+        let kh_i = kh as i32;
+        let kw_i = kw as i32;
+        let dil_hi = dh as i32;
+        let dil_wi = dw as i32;
+        let sh_i = sh as i32;
+        let sw_i = sw as i32;
+        let pb_hi = pb_h as i32;
+        let pb_wi = pb_w as i32;
+        let h_in_i = h_in as i32;
+        let w_in_i = w_in as i32;
+
+        let mut rows: Vec<trtx::Tensor<'a>> = Vec::with_capacity(oh as usize);
+
+        for oh_idx in 0..oh {
+            let mut cols: Vec<trtx::Tensor<'a>> = Vec::with_capacity(ow as usize);
+            for ow_idx in 0..ow {
+                let h_start = (oh_idx as i32) * sh_i - pb_hi;
+                let w_start = (ow_idx as i32) * sw_i - pb_wi;
+
+                let mut taps: Vec<trtx::Tensor<'a>> =
+                    Vec::with_capacity((kh * kw) as usize);
+                for ih in 0..kh_i {
+                    for iw in 0..kw_i {
+                        let h_idx = h_start + ih * dil_hi;
+                        let w_idx = w_start + iw * dil_wi;
+                        let tap_tensor = if h_idx >= 0
+                            && w_idx >= 0
+                            && h_idx < h_in_i
+                            && w_idx < w_in_i
+                        {
+                            let slice_layer = network
+                                .add_slice(
+                                    input,
+                                    &[0, 0, h_idx as i64, w_idx as i64],
+                                    &[n, c, 1, 1],
+                                    &[1, 1, 1, 1],
+                                )
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated l2 pool slice: {e}"),
+                                })?;
+                            slice_layer
+                                .get_output(&*network, 0)
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated l2 pool slice output: {e}"),
+                                })?
+                        } else {
+                            zero_layer.get_output(&*network, 0).map_err(|e| {
+                                GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated l2 pool zero tap: {e}"),
+                                }
+                            })?
+                        };
+                        taps.push(tap_tensor);
+                    }
+                }
+
+                if taps.is_empty() {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "dilated l2 pool empty tap list".to_string(),
+                    });
+                }
+                let mut acc = taps.remove(0);
+                for t in taps {
+                    let ew = network
+                        .add_elementwise(&acc, &t, ElementWiseOperation::kSUM)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated l2 pool elementwise sum: {e}"),
+                        })?;
+                    acc = ew
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated l2 pool sum output: {e}"),
+                        })?;
+                }
+                cols.push(acc);
+            }
+            let row = Self::trtx_concat_tensors_along_axis(network, &cols, 3)?;
+            rows.push(row);
+        }
+
+        let sum_sq_nchw = Self::trtx_concat_tensors_along_axis(network, &rows, 2)?;
+
+        // Keep sum(x^2) in Float32: values often exceed f16 range before sqrt; caller casts after sqrt.
+        Ok(sum_sq_nchw)
+    }
+
     /// TensorRT `kEXPLICIT_ROUND_UP` when WebNN needs ceil spatial size: `outputShapeRounding` or
     /// [`output_sizes`](crate::operator_options::MLPool2dOptions::output_sizes) matching the ceil implicit shape.
     fn trtx_pool_padding_round_up(
@@ -10764,7 +10980,8 @@ impl TrtxConverter {
         Ok(())
     }
 
-    /// Add l2Pool2d operation (L2 pooling: square → avgPool → sqrt)
+    /// Add l2Pool2d operation (L2 pooling: WebNN/ONNX LpPool p=2 is `sqrt(sum(x^2))` over the window,
+    /// not RMS: square → mean pool → multiply by kernel area → sqrt).
     fn add_l2_pool2d_op<'a>(
         graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
@@ -10810,14 +11027,6 @@ impl TrtxConverter {
 
         let dh = opts.dilations.get(0).copied().unwrap_or(1);
         let dw = opts.dilations.get(1).copied().unwrap_or(1);
-        if dh != 1 || dw != 1 {
-            return Err(GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason:
-                    "TRTX: l2Pool2d with dilations other than 1 is not supported (TensorRT pooling has no dilation)"
-                        .to_string(),
-            });
-        }
 
         let window = Self::pool2d_window_from_graph_input(graph, input_id, operation, opts)?;
 
@@ -10852,24 +11061,112 @@ impl TrtxConverter {
         };
         let pool_in = nhwc_to_nchw.as_ref().unwrap_or(&squared);
 
-        let round_up = Self::trtx_pool_padding_round_up(graph, operation, opts)?;
+        let input_dtype = graph
+            .operand(input_id)
+            .map(|o| o.descriptor.data_type)
+            .unwrap_or(DataType::Float32);
 
-        let mut pool_layer = network
-            .add_pooling(pool_in, PoolingType::kAVERAGE, &window)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
-            })?;
+        let half_to_float: Option<trtx::Tensor<'a>> =
+            if (dh != 1 || dw != 1) && input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(pool_in, TrtDataType::kFLOAT)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d dilated Half->Float: {e}"),
+                    })?;
+                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d dilated cast output: {e}"),
+                    }
+                })?)
+            } else {
+                None
+            };
+        let dilated_pool_in = half_to_float.as_ref().unwrap_or(pool_in);
 
-        Self::trtx_apply_pool2d_options(&mut pool_layer, network, opts, round_up);
+        let pooled_nchw = if dh != 1 || dw != 1 {
+            Self::add_l2_pool2d_dilated_via_slices(
+                graph,
+                network,
+                dilated_pool_in,
+                operation,
+                opts,
+                window,
+            )?
+        } else {
+            let round_up = Self::trtx_pool_padding_round_up(graph, operation, opts)?;
 
-        let pooled_nchw =
-            pool_layer
+            let mut pool_layer = network
+                .add_pooling(pool_in, PoolingType::kAVERAGE, &window)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
+                })?;
+
+            Self::trtx_apply_pool2d_options(&mut pool_layer, network, opts, round_up);
+
+            // Default TRT average pooling excludes padding from the divisor (overlap with unpadded input),
+            // so the effective count varies per output cell. LpPool is sum(x²) over the full window on the
+            // padded tensor, then sqrt — match that by dividing every position by kh*kw.
+            pool_layer.set_average_count_excludes_padding(network, false);
+
+            let mean_sq_nchw =
+                pool_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get pooled output: {}", e),
+                    })?;
+
+            // Mean of squares × (kh * kw) = sum of squares (Lp norm^2 before the final sqrt).
+            // Sum of squares can exceed f16 range (~65504); do this multiply in Float32 when input is half.
+            let k_vol = (window[0].max(0) as f32) * (window[1].max(0) as f32);
+            let mean_for_prod = if input_dtype == DataType::Float16 {
+                let cast_layer = network
+                    .add_cast(&mean_sq_nchw, TrtDataType::kFLOAT)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d mean_sq Half->Float: {e}"),
+                    })?;
+                cast_layer
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d mean_sq cast output: {e}"),
+                    })?
+            } else {
+                mean_sq_nchw
+            };
+            let k_const_layer = network
+                .add_constant_owned(
+                    &[1, 1, 1, 1],
+                    k_vol.to_ne_bytes().to_vec(),
+                    TrtDataType::kFLOAT,
+                )
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d kernel volume constant: {e}"),
+                })?;
+            let k_tensor = k_const_layer
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("Failed to get pooled output: {}", e),
+                    reason: format!("l2Pool2d kernel volume output: {e}"),
                 })?;
+            let sum_sq_layer = network
+                .add_elementwise(&mean_for_prod, &k_tensor, ElementWiseOperation::kPROD)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d mean_sq to sum_sq: {e}"),
+                })?;
+            sum_sq_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d sum_sq output: {e}"),
+                })?
+        };
 
         let pooled = if layout == "nhwc" {
             let mut shuffle = network
@@ -10902,13 +11199,30 @@ impl TrtxConverter {
                 reason: format!("Failed to create sqrt layer for l2Pool2d: {}", e),
             })?;
 
-        let output =
+        let sqrt_out =
             sqrt_layer
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get l2Pool2d output: {}", e),
                 })?;
+
+        let output = if input_dtype == DataType::Float16 {
+            let cast_layer = network
+                .add_cast(&sqrt_out, TrtDataType::kHALF)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d sqrt Float->Half: {e}"),
+                })?;
+            cast_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d sqrt half cast output: {e}"),
+                })?
+        } else {
+            sqrt_out
+        };
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -6279,17 +6279,36 @@ impl TrtxConverter {
                 });
             }
         };
-        if repetitions.is_empty() {
+
+        let input_id = operation.input_operands()[0];
+        let input_rank = {
+            let input = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Tile: input operand {} not found", input_id),
+            })?;
+            input
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Tile: input dimensions: {}", e),
+                })?
+                .len()
+        };
+        if repetitions.len() != input_rank {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: "Tile operation missing 'repetitions' attribute".to_string(),
+                reason: format!(
+                    "Tile: repetitions length {} must equal input rank {} (WebNN tile)",
+                    repetitions.len(),
+                    input_rank
+                ),
             });
         }
 
         // Tile by concatenating the tensor multiple times along each axis
         // We process each axis sequentially: tile axis 0, then axis 1, etc.
-        // Start with the input tensor's ID
-        let mut current_id = operation.input_operands()[0];
+        let mut current_id = input_id;
+        let mut produced_temp = false;
 
         for (axis, &reps) in repetitions.iter().enumerate() {
             if reps <= 1 {
@@ -6333,33 +6352,38 @@ impl TrtxConverter {
             // We use a large number to avoid collisions with actual operand IDs
             current_id = 1_000_000 + axis as u32;
             tensor_map.insert(current_id, output_tensor);
+            produced_temp = true;
         }
 
         // Insert the final result with the actual output operand ID
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
 
-        // Move the final tensor from temporary ID to output ID
-        if let Some(final_tensor) = tensor_map.remove(&current_id) {
+        if produced_temp {
+            let final_tensor = tensor_map.remove(&current_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Tile: missing intermediate tensor {}", current_id),
+            })?;
             tensor_map.insert(output_id, final_tensor);
         } else {
-            // No tiling happened (all reps were 1), just use input
-            if let Some(input_tensor) = tensor_map.get(&operation.input_operands()[0]) {
-                // We need to create an identity layer to "clone" the tensor reference
-                let identity_layer = network.add_identity(input_tensor).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to add identity layer: {}", e),
-                    }
-                })?;
-                let output_tensor = identity_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get identity output: {}", e),
-                    }
-                })?;
-                tensor_map.insert(output_id, output_tensor);
-            }
+            // No concat tiling (all reps <= 1, or rank-0 with repetitions []): keep input in map, identity to output.
+            let input_tensor = tensor_map.get(&input_id).ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Tile: input {} missing for identity", input_id),
+            })?;
+            let identity_layer = network.add_identity(input_tensor).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Tile: identity: {}", e),
+                }
+            })?;
+            let output_tensor = identity_layer.get_output(&*network, 0).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Tile: identity output: {}", e),
+                }
+            })?;
+            tensor_map.insert(output_id, output_tensor);
         }
 
         Ok(())

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -25,18 +25,21 @@ use std::collections::{HashMap, HashSet};
 
 use half::f16;
 
-use super::{ConvertedGraph, GraphConverter};
+use super::{pool2d_shared::infer_pool2d_ceil_mode_from_output_sizes, ConvertedGraph, GraphConverter};
 use crate::error::GraphError;
 use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
-use crate::shape_inference::{infer_arg_reduce_shape, infer_where_shape};
+use crate::shape_inference::{
+    infer_arg_reduce_shape, infer_pool2d_shape, infer_where_shape, Conv2dInputLayout, Pool2dOptions,
+};
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,
-    OwnedConvWeights, OwnedWeights, PoolingType, ReduceOperation, ResizeMode, ScatterMode,
-    TopKOperation, UnaryOperation,
+    OwnedConvWeights, OwnedWeights, PaddingMode, PoolingType, ReduceOperation, ResizeMode,
+    ScatterMode, TopKOperation, UnaryOperation,
 };
+use trtx::network::PoolingLayer;
 
 /// TensorRT native converter
 pub struct TrtxConverter;
@@ -3707,23 +3710,65 @@ impl TrtxConverter {
         operation: &Operation,
         pool_type: PoolingType,
     ) -> Result<(), GraphError> {
+        let (input_id, opts_ref) = match operation {
+            Operation::GlobalAveragePool { input, options, .. } => (*input, options.as_ref()),
+            Operation::GlobalMaxPool { input, options, .. } => (*input, options.as_ref()),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: "add_global_pooling_op: expected globalAveragePool or globalMaxPool"
+                        .to_string(),
+                });
+            }
+        };
+
+        let default_pool = MLPool2dOptions::default();
+        let opts = opts_ref.unwrap_or(&default_pool);
+        let layout = match opts.layout.as_str() {
+            "" => "nchw",
+            s => s,
+        };
+
         let input = tensor_map
-            .get(&operation.input_operands()[0])
+            .get(&input_id)
             .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
+                reason: format!("Input operand {} not found", input_id),
             })?;
 
-        // Get input dimensions to determine window size
-        let input_dims = input
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(input)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool NHWC->NCHW shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("globalPool NHWC shuffle output: {e}"),
+                    })?,
+            )
+        } else {
+            None
+        };
+        let pool_in = nhwc_to_nchw.as_ref().unwrap_or(input);
+
+        let input_dims = pool_in
             .dimensions(&*network)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get input dimensions: {}", e),
             })?;
 
-        // For global pooling, window size = spatial dimensions (H, W)
-        // Assuming NCHW format: [batch, channels, height, width]
         if input_dims.len() < 4 {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -3737,18 +3782,41 @@ impl TrtxConverter {
         let window: [i64; 2] = [input_dims[2], input_dims[3]];
 
         let layer = network
-            .add_pooling(input, pool_type, &window)
+            .add_pooling(pool_in, pool_type, &window)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add global pooling: {}", e),
             })?;
 
-        let output = layer
+        let pooled_nchw = layer
             .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
             })?;
+
+        let output = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(&pooled_nchw)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool NCHW->NHWC shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool set_first_transpose NCHW: {e}"),
+                })?;
+            shuffle
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool NCHW shuffle output: {e}"),
+                })?
+        } else {
+            pooled_nchw
+        };
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -9343,6 +9411,345 @@ impl TrtxConverter {
         Ok([h, w])
     }
 
+    /// Concatenate same-rank tensors along `axis` (see `IConcatenationLayer::setAxis`).
+    fn trtx_concat_tensors_along_axis<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensors: &[trtx::Tensor<'a>],
+        axis: i32,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if tensors.is_empty() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "trtx_concat_tensors_along_axis: empty input list".to_string(),
+            });
+        }
+        if tensors.len() == 1 {
+            let id_layer = network.add_identity(&tensors[0]).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool concat identity: {e}"),
+                }
+            })?;
+            return id_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool concat identity output: {e}"),
+                });
+        }
+        let inputs: Vec<&trtx::Tensor<'a>> = tensors.iter().collect();
+        let mut layer = network
+            .add_concatenation(&inputs)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("pool concat: {e}"),
+            })?;
+        layer.set_axis(network, axis);
+        layer
+            .get_output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("pool concat output: {e}"),
+            })
+    }
+
+    /// Dilated max-pool: TensorRT `IPoolingLayer` has no dilation; decompose into slices + `kMAX`.
+    ///
+    /// `input` must be NCHW. WebNN padding order:
+    /// `[beginning_height, ending_height, beginning_width, ending_width]`.
+    fn add_max_pool2d_dilated_via_slices<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        input: &trtx::Tensor<'a>,
+        operation: &Operation,
+        opts: &MLPool2dOptions,
+        window_hw: [i64; 2],
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        const MAX_DILATED_POOL_TAPS: usize = 4096;
+
+        let dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated max pool input dimensions: {e}"),
+            })?;
+        if dims.len() != 4 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated max pool expects 4D NCHW input, got {}D",
+                    dims.len()
+                ),
+            });
+        }
+        let n = dims[0];
+        let c = dims[1];
+        let h_in = dims[2];
+        let w_in = dims[3];
+        if n <= 0 || c <= 0 || h_in <= 0 || w_in <= 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated max pool invalid dims {dims:?}"),
+            });
+        }
+
+        let kh = window_hw[0] as u32;
+        let kw = window_hw[1] as u32;
+        if kh == 0 || kw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated max pool zero window".to_string(),
+            });
+        }
+
+        let sh = opts.strides.get(0).copied().unwrap_or(1);
+        let sw = opts.strides.get(1).copied().unwrap_or(1);
+        if sh == 0 || sw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated max pool zero stride".to_string(),
+            });
+        }
+
+        let dh = opts.dilations.get(0).copied().unwrap_or(1);
+        let dw = opts.dilations.get(1).copied().unwrap_or(1);
+        if dh == 0 || dw == 0 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "dilated max pool zero dilation".to_string(),
+            });
+        }
+
+        let (pb_h, pe_h, pb_w, pe_w) = if opts.padding.len() >= 4 {
+            (
+                opts.padding[0],
+                opts.padding[1],
+                opts.padding[2],
+                opts.padding[3],
+            )
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        let shape_u32: Vec<u32> = dims
+            .iter()
+            .map(|&d| u32::try_from(d.max(0)).unwrap_or(0))
+            .collect();
+        let pool_opts = Pool2dOptions {
+            window_dimensions: vec![kh, kw],
+            strides: vec![sh, sw],
+            dilations: vec![dh, dw],
+            pads: vec![pb_h, pe_h, pb_w, pe_w],
+            layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: Self::trtx_pool_padding_round_up(graph, operation, opts)?,
+        };
+        let out_shape = infer_pool2d_shape(&shape_u32, &pool_opts).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated max pool shape inference: {e}"),
+            }
+        })?;
+        let oh = out_shape[2];
+        let ow = out_shape[3];
+
+        let num_taps = (kh as usize)
+            .saturating_mul(kw as usize)
+            .saturating_mul(oh as usize)
+            .saturating_mul(ow as usize);
+        if num_taps > MAX_DILATED_POOL_TAPS {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "dilated max pool too many taps ({num_taps} > {MAX_DILATED_POOL_TAPS}); reduce size or dilation"
+                ),
+            });
+        }
+
+        let neg_inf = f32::NEG_INFINITY.to_ne_bytes();
+        let nc_count = (n * c) as usize;
+        let mut neg_inf_weights = Vec::with_capacity(nc_count * 4);
+        for _ in 0..nc_count {
+            neg_inf_weights.extend_from_slice(&neg_inf);
+        }
+        let neg_inf_layer = network
+            .add_constant_owned(&[n, c, 1, 1], neg_inf_weights, TrtDataType::kFLOAT)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("dilated max pool neg-inf constant: {e}"),
+            })?;
+
+        let kh_i = kh as i32;
+        let kw_i = kw as i32;
+        let dil_hi = dh as i32;
+        let dil_wi = dw as i32;
+        let sh_i = sh as i32;
+        let sw_i = sw as i32;
+        let pb_hi = pb_h as i32;
+        let pb_wi = pb_w as i32;
+        let h_in_i = h_in as i32;
+        let w_in_i = w_in as i32;
+
+        let mut rows: Vec<trtx::Tensor<'a>> = Vec::with_capacity(oh as usize);
+
+        for oh_idx in 0..oh {
+            let mut cols: Vec<trtx::Tensor<'a>> = Vec::with_capacity(ow as usize);
+            for ow_idx in 0..ow {
+                let h_start = (oh_idx as i32) * sh_i - pb_hi;
+                let w_start = (ow_idx as i32) * sw_i - pb_wi;
+
+                let mut taps: Vec<trtx::Tensor<'a>> =
+                    Vec::with_capacity((kh * kw) as usize);
+                for ih in 0..kh_i {
+                    for iw in 0..kw_i {
+                        let h_idx = h_start + ih * dil_hi;
+                        let w_idx = w_start + iw * dil_wi;
+                        let tap_tensor = if h_idx >= 0
+                            && w_idx >= 0
+                            && h_idx < h_in_i
+                            && w_idx < w_in_i
+                        {
+                            let slice_layer = network
+                                .add_slice(
+                                    input,
+                                    &[0, 0, h_idx as i64, w_idx as i64],
+                                    &[n, c, 1, 1],
+                                    &[1, 1, 1, 1],
+                                )
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated max pool slice: {e}"),
+                                })?;
+                            slice_layer
+                                .get_output(&*network, 0)
+                                .map_err(|e| GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated max pool slice output: {e}"),
+                                })?
+                        } else {
+                            neg_inf_layer.get_output(&*network, 0).map_err(|e| {
+                                GraphError::ConversionFailed {
+                                    format: "trtx".to_string(),
+                                    reason: format!("dilated max pool neg-inf tap: {e}"),
+                                }
+                            })?
+                        };
+                        taps.push(tap_tensor);
+                    }
+                }
+
+                if taps.is_empty() {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: "dilated max pool empty tap list".to_string(),
+                    });
+                }
+                let mut acc = taps.remove(0);
+                for t in taps {
+                    let ew = network
+                        .add_elementwise(&acc, &t, ElementWiseOperation::kMAX)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated max pool elementwise max: {e}"),
+                        })?;
+                    acc = ew
+                        .get_output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated max pool max output: {e}"),
+                        })?;
+                }
+                cols.push(acc);
+            }
+            let row = Self::trtx_concat_tensors_along_axis(network, &cols, 3)?;
+            rows.push(row);
+        }
+
+        let out_nchw = Self::trtx_concat_tensors_along_axis(network, &rows, 2)?;
+
+        // Match graph output dtype (pool path otherwise keeps input type).
+        let out_id = operation.output_operands_slice()[0];
+        let out_operand = graph.operand(out_id).ok_or_else(|| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("dilated max pool output operand {out_id} not found"),
+        })?;
+        let need_half = out_operand.descriptor.data_type == DataType::Float16;
+        if need_half {
+            let cast_layer = network
+                .add_cast(&out_nchw, TrtDataType::kHALF)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated max pool Float->Half: {e}"),
+                })?;
+            cast_layer
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dilated max pool cast output: {e}"),
+                })
+        } else {
+            Ok(out_nchw)
+        }
+    }
+
+    /// TensorRT `kEXPLICIT_ROUND_UP` when WebNN needs ceil spatial size: `outputShapeRounding` or
+    /// [`output_sizes`](crate::operator_options::MLPool2dOptions::output_sizes) matching the ceil implicit shape.
+    fn trtx_pool_padding_round_up(
+        graph: &GraphInfo,
+        operation: &Operation,
+        opts: &MLPool2dOptions,
+    ) -> Result<bool, GraphError> {
+        match infer_pool2d_ceil_mode_from_output_sizes(operation, graph) {
+            Some(1) => Ok(true),
+            Some(0) => Ok(false),
+            None => {
+                if opts.output_sizes.as_ref().is_some_and(|v| v.len() >= 2) {
+                    return Err(GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason:
+                            "pool2d output_sizes do not match floor or ceil implicit output shapes"
+                                .to_string(),
+                    });
+                }
+                Ok(opts.output_shape_rounding.eq_ignore_ascii_case("ceil"))
+            }
+            Some(_) => Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: "pool2d: unexpected ceil_mode value from output_sizes inference".to_string(),
+            }),
+        }
+    }
+
+    /// Apply WebNN `MLPool2dOptions` stride and asymmetric padding to a TensorRT pooling layer.
+    /// Padding order: `[beginning_height, ending_height, beginning_width, ending_width]`.
+    fn trtx_apply_pool2d_options<'a>(
+        layer: &mut PoolingLayer<'a>,
+        network: &mut trtx::NetworkDefinition<'a>,
+        opts: &MLPool2dOptions,
+        round_up: bool,
+    ) {
+        let stride_h = opts.strides.get(0).copied().unwrap_or(1) as i64;
+        let stride_w = opts.strides.get(1).copied().unwrap_or(1) as i64;
+        layer.set_stride_nd(network, &[stride_h, stride_w]);
+
+        let (pre_h, post_h, pre_w, post_w) = if opts.padding.len() >= 4 {
+            (
+                opts.padding[0] as i64,
+                opts.padding[1] as i64,
+                opts.padding[2] as i64,
+                opts.padding[3] as i64,
+            )
+        } else {
+            (0, 0, 0, 0)
+        };
+        // NCHW spatial order: pre/post per dimension [H, W].
+        layer.set_pre_padding(network, &[pre_h, pre_w]);
+        layer.set_post_padding(network, &[post_h, post_w]);
+
+        if round_up {
+            layer.set_padding_mode(network, PaddingMode::kEXPLICIT_ROUND_UP);
+        }
+    }
+
     /// Add pooling operation
     fn add_pooling_op<'a>(
         graph: &GraphInfo,
@@ -9374,23 +9781,154 @@ impl TrtxConverter {
 
         let window = Self::pool2d_window_from_graph_input(graph, input_id, operation, opts)?;
 
-        let layer = network
-            .add_pooling(input, pool_type, &window)
+        let output_ids = operation.output_operands_slice();
+        let output_id = output_ids[0];
+
+        let layout = match opts.layout.as_str() {
+            "" => "nchw",
+            s => s,
+        };
+
+        // TensorRT pooling is NCHW; WebNN NHWC must be transposed first (same as conv2d).
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(input)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d NHWC->NCHW shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("pool2d NHWC shuffle output: {e}"),
+                    })?,
+            )
+        } else {
+            None
+        };
+        let pool_nchw_in = nhwc_to_nchw.as_ref().unwrap_or(input);
+
+        let dh = opts.dilations.get(0).copied().unwrap_or(1);
+        let dw = opts.dilations.get(1).copied().unwrap_or(1);
+        if dh != 1 || dw != 1 {
+            if pool_type != PoolingType::kMAX {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason:
+                        "TRTX: pooling with dilations other than 1 is only supported for maxPool2d"
+                            .to_string(),
+                });
+            }
+
+            let input_dtype = graph
+                .operand(input_id)
+                .map(|o| o.descriptor.data_type)
+                .unwrap_or(DataType::Float32);
+
+            let half_to_float: Option<trtx::Tensor<'a>> =
+                if input_dtype == DataType::Float16 {
+                    let cast_layer = network
+                        .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("maxPool2d dilated Half->Float: {e}"),
+                        })?;
+                    Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("maxPool2d dilated cast output: {e}"),
+                        }
+                    })?)
+                } else {
+                    None
+                };
+            let dilated_input = half_to_float.as_ref().unwrap_or(pool_nchw_in);
+
+            let out_nchw = Self::add_max_pool2d_dilated_via_slices(
+                graph,
+                network,
+                dilated_input,
+                operation,
+                opts,
+                window,
+            )?;
+
+            let output = if layout == "nhwc" {
+                let mut shuffle = network
+                    .add_shuffle(&out_nchw)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("maxPool2d dilated NCHW->NHWC shuffle: {e}"),
+                    })?;
+                shuffle
+                    .set_first_transpose(network, &[0, 2, 3, 1])
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("maxPool2d dilated NCHW->NHWC transpose: {e}"),
+                    })?;
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("maxPool2d dilated NCHW shuffle output: {e}"),
+                    })?
+            } else {
+                out_nchw
+            };
+
+            tensor_map.insert(output_id, output);
+            return Ok(());
+        }
+
+        let round_up = Self::trtx_pool_padding_round_up(graph, operation, opts)?;
+
+        let mut layer = network
+            .add_pooling(pool_nchw_in, pool_type, &window)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add pooling: {}", e),
             })?;
 
-        // Extract output tensor from layer
-        let output = layer
+        Self::trtx_apply_pool2d_options(&mut layer, network, opts, round_up);
+
+        let pooled_nchw = layer
             .get_output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
             })?;
 
-        let output_ids = operation.output_operands_slice();
-        let output_id = output_ids[0];
+        let output = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(&pooled_nchw)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d NCHW->NHWC shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d set_first_transpose NCHW: {e}"),
+                })?;
+            shuffle
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d NCHW shuffle output: {e}"),
+                })?
+        } else {
+            pooled_nchw
+        };
+
         tensor_map.insert(output_id, output);
         Ok(())
     }
@@ -9994,22 +10532,92 @@ impl TrtxConverter {
         // Step 2: Apply average pooling (same window resolution as averagePool2d / ONNX)
         let default_pool = MLPool2dOptions::default();
         let opts = opts_ref.unwrap_or(&default_pool);
+
+        let dh = opts.dilations.get(0).copied().unwrap_or(1);
+        let dw = opts.dilations.get(1).copied().unwrap_or(1);
+        if dh != 1 || dw != 1 {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason:
+                    "TRTX: l2Pool2d with dilations other than 1 is not supported (TensorRT pooling has no dilation)"
+                        .to_string(),
+            });
+        }
+
         let window = Self::pool2d_window_from_graph_input(graph, input_id, operation, opts)?;
 
-        let pool_layer = network
-            .add_pooling(&squared, PoolingType::kAVERAGE, &window)
+        let layout = match opts.layout.as_str() {
+            "" => "nchw",
+            s => s,
+        };
+
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(&squared)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d NHWC->NCHW shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .get_output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d NHWC shuffle output: {e}"),
+                    })?,
+            )
+        } else {
+            None
+        };
+        let pool_in = nhwc_to_nchw.as_ref().unwrap_or(&squared);
+
+        let round_up = Self::trtx_pool_padding_round_up(graph, operation, opts)?;
+
+        let mut pool_layer = network
+            .add_pooling(pool_in, PoolingType::kAVERAGE, &window)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create pooling layer for l2Pool2d: {}", e),
             })?;
 
-        let pooled =
+        Self::trtx_apply_pool2d_options(&mut pool_layer, network, opts, round_up);
+
+        let pooled_nchw =
             pool_layer
                 .get_output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get pooled output: {}", e),
                 })?;
+
+        let pooled = if layout == "nhwc" {
+            let mut shuffle = network
+                .add_shuffle(&pooled_nchw)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d NCHW->NHWC shuffle: {e}"),
+                })?;
+            shuffle
+                .set_first_transpose(network, &[0, 2, 3, 1])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d set_first_transpose NCHW: {e}"),
+                })?;
+            shuffle
+                .get_output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d NCHW shuffle output: {e}"),
+                })?
+        } else {
+            pooled_nchw
+        };
 
         // Step 3: Take square root
         let sqrt_layer = network

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -10984,9 +10984,38 @@ impl TrtxConverter {
                     reason: format!("Failed to get ABS output: {}", e),
                 })?;
 
-        let inf_bytes = f32::INFINITY.to_le_bytes();
+        // Infinity constant must match `abs` tensor rank. `[1]` is rank-1; 0D scalars use `abs` rank 0
+        // and TRT rejects elementwise `[]` vs `[1]` (no broadcast between those ranks).
+        let abs_rank = abs_output
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("isInfinite: abs output dimensions: {e}"),
+            })?
+            .len();
+        let inf_dims: Vec<i64> = vec![1i64; abs_rank];
+        let abs_trt_type = abs_output.get_type(&*network);
+        let (inf_bytes, inf_trt_dtype) = match abs_trt_type {
+            TrtDataType::kHALF => (
+                f16::from_f32(f32::INFINITY)
+                    .to_bits()
+                    .to_le_bytes()
+                    .to_vec(),
+                TrtDataType::kHALF,
+            ),
+            TrtDataType::kFLOAT => (f32::INFINITY.to_le_bytes().to_vec(), TrtDataType::kFLOAT),
+            _ => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "isInfinite: expected float16 or float32 abs tensor, got TRT dtype id {:?}",
+                        abs_trt_type
+                    ),
+                });
+            }
+        };
         let inf_constant = network
-            .add_small_constant_copied(&[1], inf_bytes.as_slice(), TrtDataType::kFLOAT)
+            .add_small_constant_copied(&inf_dims, inf_bytes.as_slice(), inf_trt_dtype)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to create infinity constant: {}", e),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -83,6 +83,36 @@ impl TrtxConverter {
         }
     }
 
+    /// `[1; rank]` for scalar weights in elementwise ops. Prefer TRT tensor rank when the operand
+    /// descriptor has no shape (webnn-graph-json subgraphs often omit intermediate shapes).
+    fn trtx_broadcast_ones_for_elementwise_scalar<'a>(
+        input: &trtx::Tensor<'a>,
+        network: &trtx::NetworkDefinition<'a>,
+        descriptor_rank: usize,
+        op_label: &'static str,
+    ) -> Result<Vec<i64>, GraphError> {
+        let rank_from_tensor = input
+            .dimensions(network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label}: input dimensions: {e}"),
+            })?
+            .len();
+        let num_dims = if rank_from_tensor > 0 {
+            rank_from_tensor
+        } else if descriptor_rank > 0 {
+            descriptor_rank
+        } else {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!(
+                    "{op_label}: could not determine input tensor rank (empty dims and shape)"
+                ),
+            });
+        };
+        Ok(vec![1i64; num_dims])
+    }
+
     /// Get constant data as bytes
     fn get_constant_data(graph: &GraphInfo, operand_id: u32) -> Result<&[u8], GraphError> {
         graph
@@ -1536,8 +1566,12 @@ impl TrtxConverter {
             return Self::add_activation_op(network, tensor_map, operation, ActivationType::kELU);
         }
 
-        let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
+        let broadcast_shape = Self::trtx_broadcast_ones_for_elementwise_scalar(
+            input,
+            &*network,
+            input_operand.descriptor.shape.len(),
+            "elu",
+        )?;
         let (trt_dtype, one_bytes, zero_bytes, alpha_bytes) = match input_dtype {
             DataType::Float16 => {
                 let one: Vec<u8> = f16::from_f32(1.0).to_bits().to_le_bytes().to_vec();
@@ -1764,8 +1798,12 @@ impl TrtxConverter {
                     operation.input_operands()[0]
                 ),
             })?;
-        let num_dims = input_operand.descriptor.shape.len();
-        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
+        let broadcast_shape = Self::trtx_broadcast_ones_for_elementwise_scalar(
+            input,
+            &*network,
+            input_operand.descriptor.shape.len(),
+            "leakyRelu",
+        )?;
 
         let (alpha_bytes, alpha_dtype) = match input_operand.descriptor.data_type {
             DataType::Float16 => (
@@ -7187,10 +7225,13 @@ impl TrtxConverter {
                     operation.input_operands()[0]
                 ),
             })?;
-        let num_dims = input_operand.descriptor.shape.len();
         let input_dtype = input_operand.descriptor.data_type;
-        // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
+        let broadcast_shape = Self::trtx_broadcast_ones_for_elementwise_scalar(
+            input,
+            &*network,
+            input_operand.descriptor.shape.len(),
+            "clamp",
+        )?;
 
         // Get min and max values from attributes (handle "Infinity"/"-Infinity"/"NaN" strings from WPT).
         let parse_clamp_bound_f32 = |v: &serde_json::Value| -> Option<f32> {
@@ -7498,9 +7539,12 @@ impl TrtxConverter {
                     operation.input_operands()[0]
                 ),
             })?;
-        let num_dims = input_operand.descriptor.shape.len();
-        // Create broadcast shape: [1, 1, ..., 1] with same number of dimensions as input
-        let broadcast_shape: Vec<i64> = vec![1i64; num_dims];
+        let broadcast_shape = Self::trtx_broadcast_ones_for_elementwise_scalar(
+            input,
+            &*network,
+            input_operand.descriptor.shape.len(),
+            "linear",
+        )?;
 
         let attrs = operation.attributes();
         let linear_opts = attrs.as_linear();
@@ -11586,6 +11630,10 @@ impl GraphConverter for TrtxConverter {
 
         // Set workspace size (1 GB)
         config.set_memory_pool_limit(trtx::builder::MemoryPoolType::kWORKSPACE, 1 << 30);
+
+        // WPT / rustnnpt often compare TRT to strict IEEE fp32 (ulpTol=0). TF32 matmul/conv rounds to
+        // 10-bit mantissa on supported GPUs and can differ by many ULP from CPU reference.
+        config.clear_flag(trtx::builder::BuilderFlag::kTF32);
 
         // Build and serialize the engine
         let engine_data = builder

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -212,10 +212,10 @@ fn execute_trtx_engine(
 ) -> Result<Vec<TrtxOutputWithData>, trtx::Error> {
     // Create logger and runtime
     let logger = create_trtx_logger().map_err(|e| trtx::Error::Runtime(e.to_string()))?;
-    let runtime = trtx::Runtime::new(&logger)?;
+    let mut runtime = trtx::Runtime::new(&logger)?;
 
     // Deserialize engine
-    let engine = runtime.deserialize_cuda_engine(engine_bytes)?;
+    let mut engine = runtime.deserialize_cuda_engine(engine_bytes)?;
     let mut context = engine.create_execution_context()?;
 
     // Get tensor information

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -141,6 +141,9 @@ fn is_onnx_format(bytes: &[u8]) -> bool {
 /// Run ONNX model or TensorRT engine with zero-filled inputs
 /// This is useful for validation and testing graph structure
 ///
+/// For native WebNN [`crate::converters::TrtxConverter`] engines (not ONNX), input tensor names
+/// must be [`TrtxConverter::engine_binding_name`] for each graph input operand id.
+///
 /// If model_bytes appears to be ONNX format, it will be parsed as ONNX and built into an engine.
 /// Otherwise, it will be treated as a pre-serialized TensorRT engine.
 pub fn run_trtx_zeroed(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use clap::Parser;
+#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
+use rustnn::converters::TrtxConverter;
 #[cfg(any(
     feature = "onnx-runtime",
     feature = "trtx-runtime-mock",
@@ -18,11 +20,7 @@ use rustnn::graph::get_static_or_max_size;
     feature = "trtx-runtime-mock",
     feature = "trtx-runtime"
 ))]
-use rustnn::{
-    ContextProperties, GraphError, GraphValidator, graph_to_dot, load_graph_from_path,
-};
-#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
-use rustnn::converters::TrtxConverter;
+use rustnn::{ContextProperties, GraphError, GraphValidator, graph_to_dot, load_graph_from_path};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Validate WebNN graph descriptions", long_about = None)]
@@ -223,12 +221,13 @@ fn run() -> Result<(), GraphError> {
             let inputs: Vec<rustnn::TrtxInput> = if converted.format == "trtx" {
                 let mut v = Vec::with_capacity(graph.input_operands.len());
                 for &op_id in &graph.input_operands {
-                    let logical = graph.operand(op_id).and_then(|o| o.name.as_deref()).ok_or_else(
-                        || GraphError::ConversionFailed {
+                    let logical = graph
+                        .operand(op_id)
+                        .and_then(|o| o.name.as_deref())
+                        .ok_or_else(|| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("input operand {op_id} has no name"),
-                        },
-                    )?;
+                        })?;
                     let desc = artifacts
                         .input_names_to_descriptors
                         .get(logical)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,11 @@ use rustnn::graph::get_static_or_max_size;
     feature = "trtx-runtime-mock",
     feature = "trtx-runtime"
 ))]
-use rustnn::{ContextProperties, GraphError, GraphValidator, graph_to_dot, load_graph_from_path};
+use rustnn::{
+    ContextProperties, GraphError, GraphValidator, graph_to_dot, load_graph_from_path,
+};
+#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
+use rustnn::converters::TrtxConverter;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Validate WebNN graph descriptions", long_about = None)]
@@ -213,11 +217,25 @@ fn run() -> Result<(), GraphError> {
                     format: converted.format.to_string(),
                 });
             }
-            // Build zeroed byte inputs (size from descriptor dtype and shape)
-            let inputs: Vec<rustnn::TrtxInput> = artifacts
-                .input_names_to_descriptors
-                .iter()
-                .map(|(name, desc)| {
+            // Native WebNN->TRT engines use `TrtxConverter::engine_binding_name(operand_id)` so TRT's
+            // QDQ optimizer does not match user names (e.g. WPT `quantizeLinearZeroPoint`). ONNX models
+            // keep protobuf I/O names from `artifacts`.
+            let inputs: Vec<rustnn::TrtxInput> = if converted.format == "trtx" {
+                let mut v = Vec::with_capacity(graph.input_operands.len());
+                for &op_id in &graph.input_operands {
+                    let logical = graph.operand(op_id).and_then(|o| o.name.as_deref()).ok_or_else(
+                        || GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("input operand {op_id} has no name"),
+                        },
+                    )?;
+                    let desc = artifacts
+                        .input_names_to_descriptors
+                        .get(logical)
+                        .ok_or_else(|| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("missing descriptor for input `{logical}`"),
+                        })?;
                     let total: usize = desc
                         .shape
                         .iter()
@@ -225,12 +243,31 @@ fn run() -> Result<(), GraphError> {
                         .product::<usize>()
                         .max(1);
                     let byte_len = total * desc.data_type.bytes_per_element();
-                    rustnn::TrtxInput {
-                        name: name.clone(),
+                    v.push(rustnn::TrtxInput {
+                        name: TrtxConverter::engine_binding_name(op_id),
                         data: vec![0u8; byte_len],
-                    }
-                })
-                .collect();
+                    });
+                }
+                v
+            } else {
+                artifacts
+                    .input_names_to_descriptors
+                    .iter()
+                    .map(|(name, desc)| {
+                        let total: usize = desc
+                            .shape
+                            .iter()
+                            .map(|dim| get_static_or_max_size(dim) as usize)
+                            .product::<usize>()
+                            .max(1);
+                        let byte_len = total * desc.data_type.bytes_per_element();
+                        rustnn::TrtxInput {
+                            name: name.clone(),
+                            data: vec![0u8; byte_len],
+                        }
+                    })
+                    .collect()
+            };
 
             let outputs = rustnn::run_trtx_with_inputs(&converted.data, inputs)?;
 

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -130,10 +130,10 @@ impl OperationExtras {
             }
             "expand" => {
                 let _ = obj.remove("axes");
-                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
-                        out.expand_new_shape = parsed;
-                    }
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape"))
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s)
+                {
+                    out.expand_new_shape = parsed;
                 }
             }
             "cumulativeSum" => {
@@ -180,10 +180,10 @@ impl OperationExtras {
             }
             "slice" => {
                 out.starts = remove_u32_vec(obj, "starts");
-                if let Some(s) = obj.remove("sizes") {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
-                        out.sizes = parsed;
-                    }
+                if let Some(s) = obj.remove("sizes")
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s)
+                {
+                    out.sizes = parsed;
                 }
             }
             "split" => {
@@ -205,10 +205,10 @@ impl OperationExtras {
                 out.repetitions = remove_u32_vec(obj, "repetitions");
             }
             "reshape" => {
-                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape")) {
-                    if let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s) {
-                        out.reshape_new_shape = parsed;
-                    }
+                if let Some(s) = obj.remove("newShape").or_else(|| obj.remove("new_shape"))
+                    && let Ok(parsed) = serde_json::from_value::<Vec<MLDimension>>(s)
+                {
+                    out.reshape_new_shape = parsed;
                 }
             }
             _ => {}

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1303,10 +1303,8 @@ impl Operation {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
             Operation::Expand { new_shape, .. } => {
-                if !new_shape.is_empty() {
-                    if let Ok(v) = serde_json::to_value(new_shape) {
-                        obj.insert("newShape".to_string(), v);
-                    }
+                if !new_shape.is_empty() && let Ok(v) = serde_json::to_value(new_shape) {
+                    obj.insert("newShape".to_string(), v);
                 }
             }
             Operation::Gather {
@@ -1366,10 +1364,8 @@ impl Operation {
                 }
             }
             Operation::Reshape { new_shape, .. } => {
-                if !new_shape.is_empty() {
-                    if let Ok(val) = serde_json::to_value(new_shape) {
-                        obj.insert("newShape".to_string(), val);
-                    }
+                if !new_shape.is_empty() && let Ok(val) = serde_json::to_value(new_shape) {
+                    obj.insert("newShape".to_string(), val);
                 }
             }
             _ => {}

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1303,7 +1303,9 @@ impl Operation {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
             Operation::Expand { new_shape, .. } => {
-                if !new_shape.is_empty() && let Ok(v) = serde_json::to_value(new_shape) {
+                if !new_shape.is_empty()
+                    && let Ok(v) = serde_json::to_value(new_shape)
+                {
                     obj.insert("newShape".to_string(), v);
                 }
             }
@@ -1364,7 +1366,9 @@ impl Operation {
                 }
             }
             Operation::Reshape { new_shape, .. } => {
-                if !new_shape.is_empty() && let Ok(val) = serde_json::to_value(new_shape) {
+                if !new_shape.is_empty()
+                    && let Ok(val) = serde_json::to_value(new_shape)
+                {
                     obj.insert("newShape".to_string(), val);
                 }
             }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -2309,18 +2309,44 @@ impl Operation {
                 options: attributes.as_constant().cloned(),
                 outputs: outputs.to_vec(),
             }),
-            "conv2d" if input_operands.len() >= 2 => Some(Operation::Conv2d {
-                input: at(input_operands, 0)?,
-                filter: at(input_operands, 1)?,
-                options: attributes.as_conv2d().cloned(),
-                outputs: outputs.to_vec(),
-            }),
-            "convTranspose2d" if input_operands.len() >= 2 => Some(Operation::ConvTranspose2d {
-                input: at(input_operands, 0)?,
-                filter: at(input_operands, 1)?,
-                options: attributes.as_conv_transpose2d().cloned(),
-                outputs: outputs.to_vec(),
-            }),
+            "conv2d" if input_operands.len() >= 2 => {
+                let parsed = attributes.as_conv2d().cloned();
+                let mut opts = parsed.clone().unwrap_or_default();
+                if opts.bias.is_none()
+                    && let Some(b) = at(input_operands, 2)
+                {
+                    opts.bias = Some(b);
+                }
+                let options = match parsed {
+                    None if opts == MLConv2dOptions::default() => None,
+                    _ => Some(opts),
+                };
+                Some(Operation::Conv2d {
+                    input: at(input_operands, 0)?,
+                    filter: at(input_operands, 1)?,
+                    options,
+                    outputs: outputs.to_vec(),
+                })
+            }
+            "convTranspose2d" if input_operands.len() >= 2 => {
+                let parsed = attributes.as_conv_transpose2d().cloned();
+                let mut opts = parsed.clone().unwrap_or_default();
+                if opts.bias.is_none()
+                    && let Some(b) = at(input_operands, 2)
+                {
+                    opts.bias = Some(b);
+                }
+                let options = match parsed {
+                    None if opts == MLConvTranspose2dOptions::default() => None,
+                    _ => Some(opts),
+                };
+                Some(Operation::ConvTranspose2d {
+                    input: at(input_operands, 0)?,
+                    filter: at(input_operands, 1)?,
+                    options,
+                    outputs: outputs.to_vec(),
+                })
+            }
             "concat" => Some(Operation::Concat {
                 inputs: input_operands.to_vec(),
                 axis: extras.axis.unwrap_or(0),

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -1,6 +1,6 @@
 /// Shape inference and validation for WebNN operations
 use crate::error::GraphError;
-use crate::graph::{Dimension, DynamicDimension, get_static_or_max_size};
+use crate::graph::{Dimension, DynamicDimension, get_static_or_max_size, to_dimension_vector};
 
 /// Compute the broadcasted shape for two operands following NumPy broadcasting rules
 ///
@@ -644,13 +644,17 @@ pub fn infer_conv_transpose2d_shape(
     Ok(output_shape)
 }
 
-/// Parameters for pool2d shape inference
+/// Parameters for pool2d shape inference.
+///
+/// `pads` is WebNN order: `[beginning_height, ending_height, beginning_width, ending_width]`.
 pub struct Pool2dOptions {
     pub window_dimensions: Vec<u32>,
     pub strides: Vec<u32>,
     pub dilations: Vec<u32>,
     pub pads: Vec<u32>,
     pub layout: Conv2dInputLayout,
+    /// When true, match WebNN `outputShapeRounding` `"ceil"` / ONNX `ceil_mode` (round spatial span up).
+    pub ceil_output_spatial: bool,
 }
 
 /// Infer output shape for 2D pooling operations (average, max)
@@ -744,9 +748,10 @@ pub fn infer_pool2d_shape(
             reason: format!("Pool2d pads must have 4 elements, got {:?}", options.pads),
         });
     }
+    // WebNN: [beginning_height, ending_height, beginning_width, ending_width]
     let pad_begin_h = options.pads[0];
-    let pad_begin_w = options.pads[1];
-    let pad_end_h = options.pads[2];
+    let pad_end_h = options.pads[1];
+    let pad_begin_w = options.pads[2];
     let pad_end_w = options.pads[3];
 
     // Compute effective window size with dilation
@@ -767,8 +772,18 @@ pub fn infer_pool2d_shape(
         });
     }
 
-    let output_h = (padded_h - effective_window_h) / stride_h + 1;
-    let output_w = (padded_w - effective_window_w) / stride_w + 1;
+    let span_h = padded_h - effective_window_h;
+    let span_w = padded_w - effective_window_w;
+    let output_h = if options.ceil_output_spatial {
+        (span_h + stride_h - 1) / stride_h + 1
+    } else {
+        span_h / stride_h + 1
+    };
+    let output_w = if options.ceil_output_spatial {
+        (span_w + stride_w - 1) / stride_w + 1
+    } else {
+        span_w / stride_w + 1
+    };
 
     // Build output shape based on layout (channels remain unchanged)
     let output_shape = match options.layout {
@@ -777,6 +792,109 @@ pub fn infer_pool2d_shape(
     };
 
     Ok(output_shape)
+}
+
+/// Infer pool2d output shape as [`Dimension`] values (WebNN `MLPool2dOptions` defaults applied).
+///
+/// When `output_sizes` has at least two entries, spatial dimensions are taken from it and
+/// `outputShapeRounding` is ignored (WebNN).
+pub fn infer_pool2d_shape_dimensions(
+    input_shape: &[Dimension],
+    layout: &str,
+    window_dimensions: Option<&[u32]>,
+    strides: &[u32],
+    dilations: &[u32],
+    padding: &[u32],
+    output_sizes: Option<&[u32]>,
+    ceil_output_spatial: bool,
+) -> Result<Vec<Dimension>, GraphError> {
+    if input_shape.len() != 4 {
+        return Err(GraphError::ShapeInferenceFailed {
+            reason: format!(
+                "Pool2d input must be 4D, got {} dimensions",
+                input_shape.len()
+            ),
+        });
+    }
+
+    let layout_enum = if layout.eq_ignore_ascii_case("nhwc") {
+        Conv2dInputLayout::Nhwc
+    } else {
+        Conv2dInputLayout::Nchw
+    };
+
+    if let Some(sizes) = output_sizes {
+        if sizes.len() >= 2 {
+            let oh = sizes[0];
+            let ow = sizes[1];
+            let output_shape = match layout_enum {
+                Conv2dInputLayout::Nchw => vec![
+                    input_shape[0].clone(),
+                    input_shape[1].clone(),
+                    Dimension::Static(oh),
+                    Dimension::Static(ow),
+                ],
+                Conv2dInputLayout::Nhwc => vec![
+                    input_shape[0].clone(),
+                    Dimension::Static(oh),
+                    Dimension::Static(ow),
+                    input_shape[3].clone(),
+                ],
+            };
+            return Ok(output_shape);
+        }
+    }
+
+    let (in_h, in_w) = match layout_enum {
+        Conv2dInputLayout::Nchw => (
+            get_static_or_max_size(&input_shape[2]),
+            get_static_or_max_size(&input_shape[3]),
+        ),
+        Conv2dInputLayout::Nhwc => (
+            get_static_or_max_size(&input_shape[1]),
+            get_static_or_max_size(&input_shape[2]),
+        ),
+    };
+
+    let window_dims: Vec<u32> = if let Some(w) = window_dimensions {
+        if w.len() >= 2 {
+            vec![w[0], w[1]]
+        } else {
+            vec![in_h, in_w]
+        }
+    } else {
+        vec![in_h, in_w]
+    };
+
+    let strides_v: Vec<u32> = if strides.len() >= 2 {
+        vec![strides[0], strides[1]]
+    } else {
+        vec![1, 1]
+    };
+
+    let dilations_v: Vec<u32> = if dilations.len() >= 2 {
+        vec![dilations[0], dilations[1]]
+    } else {
+        vec![1, 1]
+    };
+
+    let pads_v: Vec<u32> = if padding.len() >= 4 {
+        vec![padding[0], padding[1], padding[2], padding[3]]
+    } else {
+        vec![0, 0, 0, 0]
+    };
+
+    let input_u32: Vec<u32> = input_shape.iter().map(get_static_or_max_size).collect();
+    let pool_opts = Pool2dOptions {
+        window_dimensions: window_dims,
+        strides: strides_v,
+        dilations: dilations_v,
+        pads: pads_v,
+        layout: layout_enum,
+        ceil_output_spatial,
+    };
+    let out = infer_pool2d_shape(&input_u32, &pool_opts)?;
+    Ok(to_dimension_vector(&out))
 }
 
 /// Options for global pooling operations
@@ -2581,6 +2699,7 @@ mod tests {
             dilations: vec![1, 1],
             pads: vec![0, 0, 0, 0],
             layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: false,
         };
         // Input: [1, 64, 32, 32], Window: [2, 2], Stride: [2, 2]
         // Output: (32 - 2) / 2 + 1 = 16
@@ -2596,6 +2715,7 @@ mod tests {
             dilations: vec![1, 1],
             pads: vec![1, 1, 1, 1],
             layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: false,
         };
         // Input: [1, 64, 32, 32], Window: [3, 3], Padding: 1
         // Output: (32 + 1 + 1 - 3) / 1 + 1 = 32
@@ -2611,6 +2731,7 @@ mod tests {
             dilations: vec![1, 1],
             pads: vec![0, 0, 0, 0],
             layout: Conv2dInputLayout::Nhwc,
+            ceil_output_spatial: false,
         };
         // Input: [1, 32, 32, 64] (NHWC)
         // Output: [1, 16, 16, 64] (NHWC)
@@ -2626,6 +2747,7 @@ mod tests {
             dilations: vec![1, 1],
             pads: vec![0, 0, 0, 0],
             layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: false,
         };
         // Input: [1, 64, 28, 28], Window: [3, 3], Stride: [2, 2]
         // Output: (28 - 3) / 2 + 1 = 13
@@ -2641,9 +2763,40 @@ mod tests {
             dilations: vec![1, 1],
             pads: vec![0, 0, 0, 0],
             layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: false,
         };
         // Input must be 4D
         assert!(infer_pool2d_shape(&[64, 32, 32], &options).is_err());
+    }
+
+    #[test]
+    fn test_pool2d_ceil_rounding_matches_wpt() {
+        let pads = vec![1, 0, 0, 1];
+        let input = [1u32, 2, 5, 5];
+        let floor_opts = Pool2dOptions {
+            window_dimensions: vec![3, 3],
+            strides: vec![2, 2],
+            dilations: vec![1, 1],
+            pads: pads.clone(),
+            layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: false,
+        };
+        assert_eq!(
+            infer_pool2d_shape(&input, &floor_opts).unwrap(),
+            vec![1, 2, 2, 2]
+        );
+        let ceil_opts = Pool2dOptions {
+            window_dimensions: vec![3, 3],
+            strides: vec![2, 2],
+            dilations: vec![1, 1],
+            pads: pads.clone(),
+            layout: Conv2dInputLayout::Nchw,
+            ceil_output_spatial: true,
+        };
+        assert_eq!(
+            infer_pool2d_shape(&input, &ceil_opts).unwrap(),
+            vec![1, 2, 3, 3]
+        );
     }
 
     // Global pooling tests

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -2116,6 +2116,10 @@ pub fn infer_scatter_nd_shape(
 /// Infer output shape for tile operation
 /// Output shape = input shape * repetitions
 pub fn infer_tile_shape(input_shape: &[u32], repetitions: &[u32]) -> Result<Vec<u32>, GraphError> {
+    // Rank-0 input: repetitions must be `[]` (no axes to repeat); output stays scalar.
+    if input_shape.is_empty() && repetitions.is_empty() {
+        return Ok(Vec::new());
+    }
     if input_shape.len() != repetitions.len() {
         return Err(GraphError::ShapeInferenceFailed {
             reason: format!(
@@ -3593,6 +3597,12 @@ mod tests {
         // Repetitions length mismatch
         assert!(infer_tile_shape(&[2, 3], &[2]).is_err());
         assert!(infer_tile_shape(&[2, 3], &[2, 3, 1]).is_err());
+    }
+
+    #[test]
+    fn test_tile_scalar_empty_repetitions() {
+        assert_eq!(infer_tile_shape(&[], &[]).unwrap(), Vec::<u32>::new());
+        assert!(infer_tile_shape(&[1], &[]).is_err());
     }
 
     // Triangular tests

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -775,9 +775,10 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     if let Some(input_shape) = input_shapes.first() {
                         match &op {
                             Operation::Slice { starts, sizes, .. } => {
-                                if starts.is_empty() || sizes.is_empty() {
-                                    None
-                                } else if starts.len() != sizes.len() {
+                                if starts.is_empty()
+                                    || sizes.is_empty()
+                                    || starts.len() != sizes.len()
+                                {
                                     None
                                 } else {
                                     let mut output = input_shape.clone();

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -880,6 +880,22 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     _ => Some(Vec::new()),
                 },
 
+                "tile" => {
+                    if let (Some(input_shape), Operation::Tile { repetitions, .. }) =
+                        (input_shapes.first(), op)
+                    {
+                        let input_u32: Vec<u32> = input_shape
+                            .iter()
+                            .map(crate::graph::get_static_or_max_size)
+                            .collect();
+                        infer_tile_shape(&input_u32, repetitions)
+                            .ok()
+                            .map(|v| to_dimension_vector(&v))
+                    } else {
+                        None
+                    }
+                },
+
                 // For other operations, leave shape empty (will be handled later or is dynamic)
                 _ => None,
             };

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -806,6 +806,66 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     }
                 }
 
+                // Pool2d (WebNN defaults for window / strides / dilations / padding)
+                "averagepool2d" | "maxpool2d" | "l2pool2d" => {
+                    if let Some(input_shape) = input_shapes.first() {
+                        let default_pool = crate::operator_options::MLPool2dOptions::default();
+                        let o = match &op {
+                            Operation::AveragePool2d { options, .. }
+                            | Operation::MaxPool2d { options, .. }
+                            | Operation::L2Pool2d { options, .. } => {
+                                options.as_ref().unwrap_or(&default_pool)
+                            }
+                            _ => &default_pool,
+                        };
+                        infer_pool2d_shape_dimensions(
+                            input_shape,
+                            &o.layout,
+                            o.window_dimensions.as_deref(),
+                            &o.strides,
+                            &o.dilations,
+                            &o.padding,
+                            o.output_sizes.as_deref(),
+                            o.output_shape_rounding.eq_ignore_ascii_case("ceil"),
+                        )
+                        .ok()
+                    } else {
+                        None
+                    }
+                }
+
+                "globalaveragepool" | "globalmaxpool" => {
+                    if let Some(input_shape) = input_shapes.first() {
+                        let default_pool = crate::operator_options::MLPool2dOptions::default();
+                        let o = match &op {
+                            Operation::GlobalAveragePool { options, .. }
+                            | Operation::GlobalMaxPool { options, .. } => {
+                                options.as_ref().unwrap_or(&default_pool)
+                            }
+                            _ => &default_pool,
+                        };
+                        let layout_enum = if o.layout.eq_ignore_ascii_case("nhwc") {
+                            Conv2dInputLayout::Nhwc
+                        } else {
+                            Conv2dInputLayout::Nchw
+                        };
+                        let input_u32: Vec<u32> = input_shape
+                            .iter()
+                            .map(crate::graph::get_static_or_max_size)
+                            .collect();
+                        infer_global_pool_shape(
+                            &input_u32,
+                            &GlobalPoolOptions {
+                                layout: layout_enum,
+                            },
+                        )
+                        .ok()
+                        .map(|v| to_dimension_vector(&v))
+                    } else {
+                        None
+                    }
+                }
+
                 // Constant: shape from operator options
                 "constant" => match &op {
                     Operation::Constant { options, .. } => options

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -894,7 +894,7 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     } else {
                         None
                     }
-                },
+                }
 
                 // For other operations, leave shape empty (will be handled later or is dynamic)
                 _ => None,

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -10,7 +10,8 @@
 mod tests {
     use rustnn::converters::{GraphConverter, TrtxConverter};
     use rustnn::graph::{
-        ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
+        get_static_or_max_size, to_dimension_vector, ConstantData, DataType, GraphInfo, Operand,
+        OperandDescriptor, OperandKind,
     };
     use rustnn::operator_options::MLConv2dOptions;
     use rustnn::operators::Operation;
@@ -57,7 +58,7 @@ mod tests {
     fn create_unary_graph(op_type: &str, input_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -101,13 +102,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -144,7 +145,7 @@ mod tests {
     fn create_binary_graph(op_type: &str, input_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -215,7 +216,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers
@@ -298,7 +299,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers
@@ -385,7 +386,7 @@ mod tests {
             .descriptor
             .shape
             .iter()
-            .map(|&d| d as usize)
+            .map(|d| get_static_or_max_size(d) as usize)
             .product();
 
         // Allocate device buffers for all inputs
@@ -836,13 +837,13 @@ mod tests {
     fn create_matmul_graph(a_shape: Vec<u32>, b_shape: Vec<u32>, data_type: DataType) -> GraphInfo {
         let a_desc = OperandDescriptor {
             data_type,
-            shape: a_shape.clone(),
+            shape: to_dimension_vector(&a_shape),
             pending_permutation: Vec::new(),
         };
 
         let b_desc = OperandDescriptor {
             data_type,
-            shape: b_shape.clone(),
+            shape: to_dimension_vector(&b_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -855,7 +856,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -927,7 +928,8 @@ mod tests {
             let a_shape = &graph.operands[0].descriptor.shape;
             let b_shape = &graph.operands[1].descriptor.shape;
             if a_shape.len() == 2 && b_shape.len() == 2 {
-                (a_shape[0] * b_shape[1]) as usize * std::mem::size_of::<f32>()
+                (get_static_or_max_size(&a_shape[0]) * get_static_or_max_size(&b_shape[1])) as usize
+                    * std::mem::size_of::<f32>()
             } else {
                 input_a_size // Fallback
             }
@@ -1048,19 +1050,19 @@ mod tests {
     ) -> GraphInfo {
         let a_desc = OperandDescriptor {
             data_type,
-            shape: a_shape.clone(),
+            shape: to_dimension_vector(&a_shape),
             pending_permutation: Vec::new(),
         };
 
         let b_desc = OperandDescriptor {
             data_type,
-            shape: b_shape.clone(),
+            shape: to_dimension_vector(&b_shape),
             pending_permutation: Vec::new(),
         };
 
         let c_desc = OperandDescriptor {
             data_type,
-            shape: c_shape.clone(),
+            shape: to_dimension_vector(&c_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1299,13 +1301,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let filter_desc = OperandDescriptor {
             data_type,
-            shape: filter_shape.clone(),
+            shape: to_dimension_vector(&filter_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1317,7 +1319,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -1351,7 +1353,7 @@ mod tests {
         if let Some(bias) = bias_data {
             let bias_desc = OperandDescriptor {
                 data_type,
-                shape: vec![filter_shape[0]], // bias shape = [out_channels]
+                shape: to_dimension_vector(&[filter_shape[0]]), // bias shape = [out_channels]
                 pending_permutation: Vec::new(),
             };
 
@@ -1500,13 +1502,13 @@ mod tests {
         // Create graph with slope constant
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![4],
+            shape: to_dimension_vector(&[4]),
             pending_permutation: Vec::new(),
         };
 
         let slope_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1],
+            shape: to_dimension_vector(&[1]),
             pending_permutation: Vec::new(),
         };
 
@@ -1628,13 +1630,13 @@ mod tests {
 
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Output: [1, 2, 1, 1]
+            shape: to_dimension_vector(&[1, 2, 1, 1]), // Output: [1, 2, 1, 1]
             pending_permutation: Vec::new(),
         };
 
@@ -1683,13 +1685,13 @@ mod tests {
 
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Output: [1, 2, 1, 1]
+            shape: to_dimension_vector(&[1, 2, 1, 1]), // Output: [1, 2, 1, 1]
             pending_permutation: Vec::new(),
         };
 
@@ -1745,13 +1747,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2066,19 +2068,19 @@ mod tests {
         // So we use [1, 2, 1, 1] instead of [2]
         let input_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 2],
+            shape: to_dimension_vector(&[1, 2, 1, 2]),
             pending_permutation: Vec::new(),
         };
 
         let stats_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 1], // Reshaped for broadcasting
+            shape: to_dimension_vector(&[1, 2, 1, 1]), // Reshaped for broadcasting
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: vec![1, 2, 1, 2],
+            shape: to_dimension_vector(&[1, 2, 1, 2]),
             pending_permutation: Vec::new(),
         };
 
@@ -2145,13 +2147,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2230,13 +2232,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2310,13 +2312,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2431,13 +2433,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2492,13 +2494,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2560,13 +2562,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2638,13 +2640,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2848,19 +2850,19 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let indices_desc = OperandDescriptor {
             data_type: DataType::Int32,
-            shape: indices_shape,
+            shape: to_dimension_vector(&indices_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -2930,13 +2932,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape,
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let output_desc = OperandDescriptor {
             data_type: DataType::Int32,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -3038,7 +3040,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![8],
+                        shape: to_dimension_vector(&[8]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3047,7 +3049,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![8],
+                        shape: to_dimension_vector(&[8]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3095,7 +3097,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]), // 4D tensor
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3104,7 +3106,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]), // 4D tensor
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3146,7 +3148,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("condition".to_string()),
@@ -3155,7 +3157,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("true_value".to_string()),
@@ -3164,7 +3166,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("false_value".to_string()),
@@ -3173,7 +3175,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3221,7 +3223,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3230,7 +3232,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3276,7 +3278,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3285,7 +3287,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3329,7 +3331,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3338,7 +3340,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3379,7 +3381,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3388,7 +3390,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3435,7 +3437,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]), // 4D tensor
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3444,7 +3446,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 2, 2, 2], // 4D tensor
+                        shape: to_dimension_vector(&[1, 2, 2, 2]), // 4D tensor
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3496,7 +3498,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3505,7 +3507,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![7],
+                        shape: to_dimension_vector(&[7]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3547,7 +3549,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3556,7 +3558,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3565,7 +3567,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3620,7 +3622,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3629,7 +3631,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 4, 4],
+                        shape: to_dimension_vector(&[1, 1, 4, 4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3722,7 +3724,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3731,7 +3733,7 @@ mod tests {
                     kind: OperandKind::Constant,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("kernel".to_string()),
@@ -3740,7 +3742,7 @@ mod tests {
                     kind: OperandKind::Constant,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("bias".to_string()),
@@ -3749,7 +3751,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 3, 3],
+                        shape: to_dimension_vector(&[1, 1, 3, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3802,7 +3804,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3811,7 +3813,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3820,7 +3822,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("updates".to_string()),
@@ -3829,7 +3831,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3875,7 +3877,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -3884,7 +3886,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -3893,7 +3895,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("updates".to_string()),
@@ -3902,7 +3904,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 3],
+                        shape: to_dimension_vector(&[2, 3]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -3965,7 +3967,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -3974,7 +3976,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("quant_scale".to_string()),
@@ -3983,7 +3985,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int8,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("quantized".to_string()),
@@ -3992,7 +3994,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("dequant_scale".to_string()),
@@ -4001,7 +4003,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("dequantized".to_string()),
@@ -4010,7 +4012,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1],
+                        shape: to_dimension_vector(&[1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("add_constant".to_string()),
@@ -4019,7 +4021,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4064,7 +4066,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4073,7 +4075,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4113,7 +4115,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4122,7 +4124,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4161,7 +4163,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4170,7 +4172,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4217,7 +4219,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("data".to_string()),
@@ -4226,7 +4228,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Int32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("indices".to_string()),
@@ -4235,7 +4237,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4280,7 +4282,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 2, 2],
+                        shape: to_dimension_vector(&[1, 1, 2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4289,7 +4291,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![1, 1, 1, 1],
+                        shape: to_dimension_vector(&[1, 1, 1, 1]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4331,7 +4333,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4340,7 +4342,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4383,7 +4385,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4392,7 +4394,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![4],
+                        shape: to_dimension_vector(&[4]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4433,7 +4435,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4442,7 +4444,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2, 2],
+                        shape: to_dimension_vector(&[2, 2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4490,7 +4492,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![2],
+                        shape: to_dimension_vector(&[2]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("input".to_string()),
@@ -4499,7 +4501,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![6],
+                        shape: to_dimension_vector(&[6]),
                         pending_permutation: Vec::new(),
                     },
                     name: Some("output".to_string()),
@@ -4539,13 +4541,13 @@ mod tests {
     ) -> GraphInfo {
         let input_desc = OperandDescriptor {
             data_type,
-            shape: input_shape.clone(),
+            shape: to_dimension_vector(&input_shape),
             pending_permutation: Vec::new(),
         };
 
         let filter_desc = OperandDescriptor {
             data_type,
-            shape: filter_shape.clone(),
+            shape: to_dimension_vector(&filter_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -4569,7 +4571,7 @@ mod tests {
 
         let output_desc = OperandDescriptor {
             data_type,
-            shape: output_shape,
+            shape: to_dimension_vector(&output_shape),
             pending_permutation: Vec::new(),
         };
 
@@ -4603,7 +4605,7 @@ mod tests {
         if let Some(bias) = bias_data {
             let bias_desc = OperandDescriptor {
                 data_type,
-                shape: vec![filter_shape[0]], // bias shape = [out_channels]
+                shape: to_dimension_vector(&[filter_shape[0]]), // bias shape = [out_channels]
                 pending_permutation: Vec::new(),
             };
 
@@ -4857,7 +4859,7 @@ mod tests {
         // Operand layout: [0]=input, [1]=filter, [2]=output (no bias)
         assert_eq!(
             graph_same.operands[2].descriptor.shape,
-            vec![1, 1, 218, 218]
+            to_dimension_vector(&[1, 1, 218, 218])
         );
 
         // Branch 2: Valid padding shrinks by 2 per dimension
@@ -4875,7 +4877,7 @@ mod tests {
         // Operand layout: [0]=input, [1]=filter, [2]=output (no bias)
         assert_eq!(
             graph_valid.operands[2].descriptor.shape,
-            vec![1, 1, 216, 216]
+            to_dimension_vector(&[1, 1, 216, 216])
         );
 
         // This test documents the root cause of MobileNetV2 dimension mismatch:

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -10,8 +10,8 @@
 mod tests {
     use rustnn::converters::{GraphConverter, TrtxConverter};
     use rustnn::graph::{
-        get_static_or_max_size, to_dimension_vector, ConstantData, DataType, GraphInfo, Operand,
-        OperandDescriptor, OperandKind,
+        ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
+        get_static_or_max_size, to_dimension_vector,
     };
     use rustnn::operator_options::MLConv2dOptions;
     use rustnn::operators::Operation;

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -197,8 +197,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -281,8 +281,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -354,8 +354,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -906,8 +906,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
@@ -1126,8 +1126,8 @@ mod tests {
 
         // Create TensorRT runtime
         let logger = Logger::stderr()?;
-        let runtime = Runtime::new(&logger)?;
-        let engine = runtime.deserialize_cuda_engine(&converted.data)?;
+        let mut runtime = Runtime::new(&logger)?;
+        let mut engine = runtime.deserialize_cuda_engine(&converted.data)?;
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info

--- a/tests/wpt_conformance/mod.rs
+++ b/tests/wpt_conformance/mod.rs
@@ -507,17 +507,19 @@ pub fn run_one_test_case_trtx(
             .iter()
             .copied()
             .find(|&id| {
-                graph_info
-                    .operand(id)
-                    .and_then(|o| o.name.as_deref())
-                    == Some(out_name.as_str())
+                graph_info.operand(id).and_then(|o| o.name.as_deref()) == Some(out_name.as_str())
             })
             .ok_or_else(|| format!("output operand '{}' not in graph_info", out_name))?;
         let trt_out_name = TrtxConverter::engine_binding_name(out_op_id);
         let actual = outputs
             .iter()
             .find(|o| o.name == trt_out_name)
-            .ok_or_else(|| format!("output '{}' (TRT {}) not found in results", out_name, trt_out_name))?;
+            .ok_or_else(|| {
+                format!(
+                    "output '{}' (TRT {}) not found in results",
+                    out_name, trt_out_name
+                )
+            })?;
 
         let (pass, msg, expected_str, actual_str) = match expected_spec.data_type() {
             "int64" => {

--- a/tests/wpt_conformance/mod.rs
+++ b/tests/wpt_conformance/mod.rs
@@ -489,7 +489,7 @@ pub fn run_one_test_case_trtx(
 ) -> Result<(), String> {
     let graph = &test_case.graph;
     let (graph_info, input_names) = wpt_graph_to_graph_info(graph)?;
-    let inputs = wpt_graph_to_trtx_inputs(graph, &input_names)?;
+    let inputs = wpt_graph_to_trtx_inputs(graph, &graph_info)?;
 
     let converter = TrtxConverter;
     let converted = converter
@@ -502,10 +502,22 @@ pub fn run_one_test_case_trtx(
         get_operation_tolerance(operation, test_case.tolerance.as_ref());
 
     for (out_name, expected_spec) in &graph.expected_outputs {
+        let out_op_id = graph_info
+            .output_operands
+            .iter()
+            .copied()
+            .find(|&id| {
+                graph_info
+                    .operand(id)
+                    .and_then(|o| o.name.as_deref())
+                    == Some(out_name.as_str())
+            })
+            .ok_or_else(|| format!("output operand '{}' not in graph_info", out_name))?;
+        let trt_out_name = TrtxConverter::engine_binding_name(out_op_id);
         let actual = outputs
             .iter()
-            .find(|o| o.name == *out_name)
-            .ok_or_else(|| format!("output '{}' not found in results", out_name))?;
+            .find(|o| o.name == trt_out_name)
+            .ok_or_else(|| format!("output '{}' (TRT {}) not found in results", out_name, trt_out_name))?;
 
         let (pass, msg, expected_str, actual_str) = match expected_spec.data_type() {
             "int64" => {

--- a/tests/wpt_conformance/wpt_to_graph.rs
+++ b/tests/wpt_conformance/wpt_to_graph.rs
@@ -20,13 +20,13 @@
 //! Operations are built with [`rustnn::operators::Operation::from_json_attributes`]: one JSON attributes
 //! object per op (WebNN camelCase names) plus operand wiring.
 
+#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
+use rustnn::converters::TrtxConverter;
 use rustnn::graph::{
     ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
     get_static_or_max_size, to_dimension_vector,
 };
 use rustnn::operators::Operation;
-#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
-use rustnn::converters::TrtxConverter;
 #[cfg(feature = "onnx-runtime")]
 use rustnn::{OnnxInput, TensorData};
 use std::collections::HashMap;

--- a/tests/wpt_conformance/wpt_to_graph.rs
+++ b/tests/wpt_conformance/wpt_to_graph.rs
@@ -25,6 +25,8 @@ use rustnn::graph::{
     get_static_or_max_size, to_dimension_vector,
 };
 use rustnn::operators::Operation;
+#[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
+use rustnn::converters::TrtxConverter;
 #[cfg(feature = "onnx-runtime")]
 use rustnn::{OnnxInput, TensorData};
 use std::collections::HashMap;
@@ -1186,18 +1188,23 @@ fn parse_int_for_tensor(v: &serde_json::Value) -> Option<i64> {
         .or_else(|| v.as_u64().map(|u| u as i64))
 }
 
-/// Build TensorRT input list from WPT graph. Caller encodes values as bytes per dtype (float32, float16, int8, int32, etc.).
+/// Build TensorRT input list from WPT graph. Tensor names match [`TrtxConverter::engine_binding_name`]
+/// (operand index), not WebNN/WPT logical names, so TensorRT QDQ rewrite does not misfire on names like `...ZeroPoint`.
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 pub fn wpt_graph_to_trtx_inputs(
     graph: &WptGraph,
-    input_names: &[String],
+    graph_info: &GraphInfo,
 ) -> Result<Vec<rustnn::TrtxInput>, String> {
     let mut inputs = Vec::new();
-    for name in input_names {
+    for &op_id in &graph_info.input_operands {
+        let name = graph_info
+            .operand(op_id)
+            .and_then(|o| o.name.as_deref())
+            .ok_or_else(|| format!("input operand {op_id} has no name"))?;
         let spec = graph
             .inputs
             .get(name)
-            .ok_or_else(|| format!("input {} not found", name))?;
+            .ok_or_else(|| format!("input {name} not found"))?;
         let dtype = spec.data_type();
         let shape: Vec<usize> = spec.shape().iter().map(|&d| d as usize).collect();
         let n: usize = shape.iter().product();
@@ -1326,7 +1333,7 @@ pub fn wpt_graph_to_trtx_inputs(
         };
 
         inputs.push(rustnn::TrtxInput {
-            name: name.clone(),
+            name: TrtxConverter::engine_binding_name(op_id),
             data,
         });
     }


### PR DESCRIPTION
## Summary

* Update trtx backend to new Operation/OperatorOptions changes.
* Fix a series of trtx converter operations. The operations still failing are related to (u)int* and lstm/gru and quantization / dequantization.

## Validation

- [x] `make test 
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

