### PR TITLE
feat: make onnx-converter optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ exclude = [
 ]
 
 [features]
-default = []
+default = ["onnx-converter"]
 dynamic-inputs = []
 coreml-runtime = ["objc"]
-onnx-runtime = ["ort", "ndarray", "tokenizers"]
+onnx-converter = ["webnn-onnx-utils"]
+onnx-runtime = ["ort", "ndarray", "tokenizers", "onnx-converter"]
 trtx-runtime = ["trtx"]
 trtx-runtime-mock = ["trtx/mock"]
 
@@ -38,13 +39,17 @@ bytes = "1.6"
 bytemuck = { version = "1.15", features = ["extern_crate_std"] }
 ndarray = { version = "0.17", optional = true }
 objc = { version = "0.2", optional = true }
-ort = { version = "2.0.0-rc.11", optional = true, features = ["ndarray", "half", "load-dynamic"] }
+ort = { version = "2.0.0-rc.11", optional = true, features = [
+    "ndarray",
+    "half",
+    "load-dynamic",
+] }
 tokenizers = { version = "0.22", optional = true }
 half = "2.4"
 trtx = { version = "0.4.0", optional = true }
 regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
-webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }
+webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main", optional = true }
 
 [build-dependencies]
 prost-build = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,11 @@ exclude = [
 [features]
 default = ["onnx-converter"]
 dynamic-inputs = []
-coreml-runtime = ["objc"]
+
 onnx-converter = ["webnn-onnx-utils"]
+coreml-converter = []
+
+coreml-runtime = ["coreml-converter", "objc"]
 onnx-runtime = ["ort", "ndarray", "tokenizers", "onnx-converter"]
 trtx-runtime = ["trtx"]
 trtx-runtime-mock = ["trtx/mock"]

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     coreml_files.sort();
 
     // Only compile CoreML protos - ONNX protos come from webnn-onnx-utils
+    #[cfg(feature = "coreml-converter")]
     config.compile_protos(&coreml_files, &[coreml_dir])?;
 
     println!("cargo:rerun-if-changed=protos");

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -4,6 +4,7 @@ use crate::error::GraphError;
 use crate::graph::GraphInfo;
 
 mod coreml_mlprogram;
+#[cfg(feature = "onnx-converter")]
 pub mod onnx;
 mod pool2d_shared;
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
@@ -11,6 +12,7 @@ mod trtx;
 mod weight_file_builder;
 
 pub use coreml_mlprogram::CoremlMlProgramConverter;
+#[cfg(feature = "onnx-converter")]
 pub use onnx::OnnxConverter;
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 pub use trtx::TrtxConverter;
@@ -50,6 +52,7 @@ impl ConverterRegistry {
         let mut registry = Self {
             converters: HashMap::new(),
         };
+        #[cfg(feature = "onnx-converter")]
         registry.register(Box::new(OnnxConverter));
         registry.register(Box::new(CoremlMlProgramConverter));
         #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -3,19 +3,24 @@ use std::collections::HashMap;
 use crate::error::GraphError;
 use crate::graph::GraphInfo;
 
+#[cfg(feature = "coreml-converter")]
 mod coreml_mlprogram;
 #[cfg(feature = "onnx-converter")]
 pub mod onnx;
 mod pool2d_shared;
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 mod trtx;
+#[cfg(feature = "coreml-converter")]
 mod weight_file_builder;
 
+#[cfg(feature = "coreml-converter")]
 pub use coreml_mlprogram::CoremlMlProgramConverter;
 #[cfg(feature = "onnx-converter")]
 pub use onnx::OnnxConverter;
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 pub use trtx::TrtxConverter;
+
+#[cfg(feature = "coreml-converter")]
 pub(crate) use weight_file_builder::WeightFileBuilder;
 
 /// Get operand name for an operand ID, or generate a default name
@@ -54,6 +59,7 @@ impl ConverterRegistry {
         };
         #[cfg(feature = "onnx-converter")]
         registry.register(Box::new(OnnxConverter));
+        #[cfg(feature = "coreml-converter")]
         registry.register(Box::new(CoremlMlProgramConverter));
         #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
         registry.register(Box::new(TrtxConverter::new()));

--- a/src/converters/pool2d_shared.rs
+++ b/src/converters/pool2d_shared.rs
@@ -7,6 +7,7 @@ use crate::operators::Operation;
 /// / TensorRT round-up: `0` = floor spatial shape, `1` = ceil spatial shape.
 ///
 /// Returns [`None`] when `output_sizes` is absent, not length-2, or does not match either implicit shape.
+#[cfg(feature = "onnx-converter")]
 pub(crate) fn infer_pool2d_ceil_mode_from_output_sizes(
     op: &Operation,
     graph: &GraphInfo,

--- a/src/protos.rs
+++ b/src/protos.rs
@@ -26,6 +26,7 @@ pub mod coreml {
 }
 
 // Re-export ONNX protos from webnn-onnx-utils to ensure type compatibility
+#[cfg(feature = "onnx-converter")]
 pub mod onnx {
     pub use webnn_onnx_utils::protos::onnx::*;
 }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

I want to use only the TensorRT converter in trtexec-rs and I don't need ONNX or `protoc`.

E.g. this CI fails due to missing `protoc`. I could install it, but actually I don't really the onnxconverter when we don't use the onnx-runtime.
https://github.com/rustnn/trtx-rs/actions/runs/24238058234/job/70765521955

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

