### PR TITLE
Update Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Is Cargo.lock consistent with Cargo.toml?
+        run: cargo fetch --locked
+
       - name: Run cargo check
         run: cargo check
 


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Late commit updated `trtx` in Cargo.toml, but didn't update `Cargo.lock`. Each cargo build will therefore change `Cargo.lock`.

This adds a simple check to CI and updates Cargo.lock

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

