### PR TITLE
fix: update `converters::trtx` for #93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run cargo check (onnx-runtime without dynamic-inputs)
         run: cargo check --no-default-features --features onnx-runtime
 
+      - name: Run cargo check (TensorRT)
+        run: cargo check -F trtx-runtime
+
       - name: Run cargo test (library only)
         run: cargo test --lib
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -33,9 +33,7 @@ use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
-use crate::shape_inference::{
-    Conv2dInputLayout, infer_arg_reduce_shape, infer_pool2d_shape, infer_where_shape,
-};
+use crate::shape_inference::{infer_arg_reduce_shape, infer_pool2d_shape, infer_where_shape};
 use trtx::network::PoolingLayer;
 use trtx::{
     ActivationType, Axes, DataType as TrtDataType, ElementWiseOperation, MatrixOperation,


### PR DESCRIPTION


## Summary

- [x] Describe the user-visible and code-level changes.

#93 broke the TensorRT build:
- add minimal CI for TensorRT
- Update TensorRT converter for changes in #93 

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

