### PR TITLE
refactor: use MLOperandDataType

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -28,6 +28,7 @@
 use crate::converters::operand_name;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension as GraphDimension, GraphInfo};
+use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::MLDimension;
 use crate::operators::Operation;
 use crate::protos::coreml::mil_spec::{
@@ -2158,30 +2159,28 @@ impl CoremlMlProgramConverter {
                 // Note: outputDataType is handled by the output tensor's data type
             }
 
-            Operation::Cast { to, .. } => {
+            Operation::Cast { data_type: to, .. } => {
                 // cast: x, dtype
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
                 // Add dtype parameter (required)
-                if !to.is_empty() {
-                    let to_type = to;
-                    let dtype_string = match to_type.as_str() {
-                        "float32" => "fp32",
-                        "float16" => "fp16",
-                        "int32" => "int32",
-                        "uint32" => "uint32",
-                        "int8" => "int8",
-                        "uint8" => "uint8",
-                        "int64" => "int64",
-                        _ => "fp32", // default
-                    };
-                    inputs.insert(
-                        "dtype".to_string(),
-                        Self::create_immediate_string(dtype_string),
-                    );
-                }
+                let to_type = to;
+                let dtype_string = match to_type {
+                    MLOperandDataType::Float32 => "fp32",
+                    MLOperandDataType::Float16 => "fp16",
+                    MLOperandDataType::Int32 => "int32",
+                    MLOperandDataType::Uint32 => "uint32",
+                    MLOperandDataType::Int8 => "int8",
+                    MLOperandDataType::Uint8 => "int8",
+                    MLOperandDataType::Int64 => "int64",
+                    MLOperandDataType::Uint64 => "uint64",
+                };
+                inputs.insert(
+                    "dtype".to_string(),
+                    Self::create_immediate_string(dtype_string),
+                );
             }
 
             Operation::ScatterElements { options, .. } => {

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -20,6 +20,7 @@ use crate::converters::{ConvertedGraph, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
+use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
 use crate::operators::Operation;
 use crate::protos::onnx::{
@@ -1695,19 +1696,15 @@ impl OnnxConverter {
     /// Create ONNX attributes for cast operation
     fn create_cast_attributes(op: &Operation) -> Vec<AttributeProto> {
         let mut attributes = Vec::new();
-        if let Operation::Cast { to, .. } = &op
-            && !to.is_empty()
-        {
-            let to_type = to.to_ascii_lowercase();
-            let type_code = match to_type.as_str() {
-                "float32" => ProtoDataType::Float as i64,
-                "float16" => ProtoDataType::Float16 as i64,
-                "int32" => ProtoDataType::Int32 as i64,
-                "uint32" => ProtoDataType::Uint32 as i64,
-                "int8" => ProtoDataType::Int8 as i64,
-                "uint8" => ProtoDataType::Uint8 as i64,
-                "int64" => ProtoDataType::Int64 as i64,
-                "int4" | "uint4" => ProtoDataType::Undefined as i64,
+        if let Operation::Cast { data_type: to, .. } = &op {
+            let type_code = match to {
+                MLOperandDataType::Float32 => ProtoDataType::Float as i64,
+                MLOperandDataType::Float16 => ProtoDataType::Float16 as i64,
+                MLOperandDataType::Int32 => ProtoDataType::Int32 as i64,
+                MLOperandDataType::Uint32 => ProtoDataType::Uint32 as i64,
+                MLOperandDataType::Int8 => ProtoDataType::Int8 as i64,
+                MLOperandDataType::Uint8 => ProtoDataType::Uint8 as i64,
+                MLOperandDataType::Int64 => ProtoDataType::Int64 as i64,
                 _ => ProtoDataType::Undefined as i64,
             };
             attributes.push(AttributeProto {
@@ -9295,22 +9292,16 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         let output_id = op
                             .output_operand()
                             .expect("Single-output operation expected");
-                        let type_code: i64 = match match &op {
-                            Operation::Cast { to, .. } => {
-                                let t = to.to_ascii_lowercase();
-                                if t.is_empty() { None } else { Some(t) }
-                            }
-                            _ => None,
-                        } {
-                            Some(s) => match s.as_str() {
-                                "float32" => ProtoDataType::Float as i64,
-                                "float16" => ProtoDataType::Float16 as i64,
-                                "int32" => ProtoDataType::Int32 as i64,
-                                "uint32" => ProtoDataType::Uint32 as i64,
-                                "int8" => ProtoDataType::Int8 as i64,
-                                "uint8" => ProtoDataType::Uint8 as i64,
-                                "int64" => ProtoDataType::Int64 as i64,
-                                _ => {
+                        let type_code: i64 = match &op {
+                            Operation::Cast { data_type: to, .. } => match to {
+                                MLOperandDataType::Float32 => ProtoDataType::Float as i64,
+                                MLOperandDataType::Float16 => ProtoDataType::Float16 as i64,
+                                MLOperandDataType::Int32 => ProtoDataType::Int32 as i64,
+                                MLOperandDataType::Uint32 => ProtoDataType::Uint32 as i64,
+                                MLOperandDataType::Int8 => ProtoDataType::Int8 as i64,
+                                MLOperandDataType::Uint8 => ProtoDataType::Uint8 as i64,
+                                MLOperandDataType::Int64 => ProtoDataType::Int64 as i64,
+                                MLOperandDataType::Uint64 => {
                                     let output_dtype = graph
                                         .operand(output_id)
                                         .map(|o| o.descriptor.data_type)
@@ -9318,13 +9309,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                                     Self::data_type_code(output_dtype) as i64
                                 }
                             },
-                            None => {
-                                let output_dtype = graph
-                                    .operand(output_id)
-                                    .map(|o| o.descriptor.data_type)
-                                    .unwrap_or(DataType::Float32);
-                                Self::data_type_code(output_dtype) as i64
-                            }
+                            _ => unreachable!("Cast-only branch"),
                         };
                         vec![AttributeProto {
                             name: "to".to_string(),
@@ -10031,7 +10016,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_operation_with_int4_target() {
+    fn test_cast_operation_to_int32() {
         let mut operands = Vec::new();
         let mut operations = Vec::new();
 
@@ -10048,7 +10033,7 @@ mod tests {
         operands.push(Operand {
             kind: OperandKind::Output,
             descriptor: OperandDescriptor {
-                data_type: DataType::Int4,
+                data_type: DataType::Int32,
                 shape: s(&[10, 10]),
                 pending_permutation: vec![],
             },
@@ -10057,7 +10042,7 @@ mod tests {
 
         let operator = Operation::Cast {
             input: 0,
-            to: "int4".to_string(),
+            data_type: MLOperandDataType::Int32,
             options: None,
             outputs: vec![1],
         };

--- a/src/operator_enums.rs
+++ b/src/operator_enums.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum MlOperandDataType {
+pub enum MLOperandDataType {
     #[default]
     Float32,
     Float16,
@@ -103,6 +103,21 @@ pub enum MLPaddingMode {
 // ---------------------------------------------------------------------------
 // Stable WebNN JSON / IDL string forms (kebab-case / lowercase) for converters
 // ---------------------------------------------------------------------------
+
+impl MLOperandDataType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MLOperandDataType::Float32 => "float32",
+            MLOperandDataType::Float16 => "float16",
+            MLOperandDataType::Int32 => "int32",
+            MLOperandDataType::Uint32 => "uint32",
+            MLOperandDataType::Int64 => "int64",
+            MLOperandDataType::Uint64 => "uint64",
+            MLOperandDataType::Int8 => "int8",
+            MLOperandDataType::Uint8 => "uint8",
+        }
+    }
+}
 
 impl MLRoundingType {
     pub fn as_str(self) -> &'static str {

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -23,6 +23,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::operator_enums::MLOperandDataType;
+
 /// Operand reference (graph operand index). Used in option structs for MLOperand fields.
 pub type OperandIndex = u32;
 
@@ -68,7 +70,7 @@ pub fn mldimensions_static_or_max(dims: &[MLDimension]) -> Vec<u32> {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct OperationExtras {
     pub axis: Option<u32>,
-    pub to_data_type: Option<String>,
+    pub to_data_type: Option<MLOperandDataType>,
     pub batch_dimensions: Option<u32>,
     pub steps: Option<u32>,
     pub hidden_size: Option<u32>,
@@ -113,16 +115,10 @@ impl OperationExtras {
                 out.axis = remove_u32(obj, "axis");
             }
             "cast" => {
-                if let Some(s) = obj
-                    .remove("to")
-                    .and_then(|x| x.as_str().map(|s| s.to_string()))
+                if let Some(v) = obj.remove("to").or_else(|| obj.remove("dataType"))
+                    && let Ok(dt) = serde_json::from_value::<MLOperandDataType>(v)
                 {
-                    out.to_data_type = Some(s);
-                } else if let Some(s) = obj
-                    .remove("dataType")
-                    .and_then(|x| x.as_str().map(|s| s.to_string()))
-                {
-                    out.to_data_type = Some(s);
+                    out.to_data_type = Some(dt);
                 }
             }
             "concat" => {
@@ -246,7 +242,7 @@ pub struct MLArgMinMaxOptions {
     #[serde(default)]
     pub keep_dimensions: bool,
     #[serde(default)]
-    pub output_data_type: String, // MLOperandDataType, e.g. "int32", "int64"
+    pub output_data_type: MLOperandDataType,
 }
 
 fn default_batch_norm_axis() -> u32 {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -40,15 +40,18 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::operator_options::{
-    MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
-    MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions, MLDimension, MLEluOptions,
-    MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions,
-    MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
-    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
-    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions, MLScatterOptions,
-    MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions, MLTriangularOptions,
-    MLUnsqueezeOptions, OperandIndex, OperationExtras, OperatorOptions,
+use crate::{
+    operator_enums::MLOperandDataType,
+    operator_options::{
+        MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
+        MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions, MLDimension,
+        MLEluOptions, MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions,
+        MLHardSigmoidOptions, MLInstanceNormalizationOptions, MLLayerNormalizationOptions,
+        MLLeakyReluOptions, MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions,
+        MLPadOptions, MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions,
+        MLScatterOptions, MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions,
+        MLTriangularOptions, MLUnsqueezeOptions, OperandIndex, OperationExtras, OperatorOptions,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -334,7 +337,7 @@ pub enum Operation {
     /// [cast()](https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cast)
     Cast {
         input: OperandIndex,
-        to: String,
+        data_type: MLOperandDataType,
         options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -1291,8 +1294,10 @@ impl Operation {
             Operation::ArgMin { axis, .. } | Operation::ArgMax { axis, .. } => {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
             }
-            Operation::Cast { to, .. } if !to.is_empty() => {
-                obj.insert("to".to_string(), serde_json::Value::String(to.clone()));
+            Operation::Cast { data_type: to, .. } => {
+                if let Ok(v) = serde_json::to_value(to) {
+                    obj.insert("to".to_string(), v);
+                }
             }
             Operation::CumulativeSum { axis, .. } => {
                 obj.insert("axis".to_string(), serde_json::json!(axis));
@@ -2292,7 +2297,7 @@ impl Operation {
             }
             "cast" if !input_operands.is_empty() => Some(Operation::Cast {
                 input: at(input_operands, 0)?,
-                to: extras.to_data_type.unwrap_or_default(),
+                data_type: extras.to_data_type.unwrap_or_default(),
                 options: attributes.as_operator().cloned(),
                 outputs: outputs.to_vec(),
             }),

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -22,6 +22,7 @@ use crate::graph::{
     ConstantData, DataType, Dimension, DynamicDimension, GraphInfo, Operand, OperandDescriptor,
     OperandKind, to_dimension_vector,
 };
+use crate::operator_enums::MLOperandDataType;
 use crate::operators::Operation;
 use std::collections::{BTreeMap, HashMap};
 use webnn_graph::ast::{ConstDecl, ConstInit, GraphJson, Node, OperandDesc};
@@ -435,6 +436,19 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             "int4" => Some(DataType::Int4),
             "uint4" => Some(DataType::Uint4),
             _ => None,
+        }
+    }
+
+    fn data_type_from_ml_operand_dtype(dt: MLOperandDataType) -> DataType {
+        match dt {
+            MLOperandDataType::Float32 => DataType::Float32,
+            MLOperandDataType::Float16 => DataType::Float16,
+            MLOperandDataType::Int32 => DataType::Int32,
+            MLOperandDataType::Uint32 => DataType::Uint32,
+            MLOperandDataType::Int64 => DataType::Int64,
+            MLOperandDataType::Uint64 => DataType::Uint64,
+            MLOperandDataType::Int8 => DataType::Int8,
+            MLOperandDataType::Uint8 => DataType::Uint8,
         }
     }
 
@@ -910,12 +924,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         _ => None,
                     },
                     "cast" => match &op {
-                        Operation::Cast { to, .. } => {
-                            if to.is_empty() {
-                                None
-                            } else {
-                                parse_dtype(&serde_json::Value::String(to.clone()))
-                            }
+                        Operation::Cast { data_type: to, .. } => {
+                            Some(data_type_from_ml_operand_dtype(*to))
                         }
                         _ => None,
                     },
@@ -923,14 +933,12 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     "quantizelinear" => input_types.get(2).cloned().or(Some(DataType::Uint8)),
                     "argmax" | "argmin" => match &op {
                         Operation::ArgMax { options, .. } | Operation::ArgMin { options, .. } => {
-                            options
-                                .as_ref()
-                                .and_then(|o| {
-                                    parse_dtype(&serde_json::Value::String(
-                                        o.output_data_type.clone(),
-                                    ))
-                                })
-                                .or(Some(DataType::Int32))
+                            Some(
+                                options
+                                    .as_ref()
+                                    .map(|o| data_type_from_ml_operand_dtype(o.output_data_type))
+                                    .unwrap_or(DataType::Int32),
+                            )
                         }
                         _ => Some(DataType::Int32),
                     },


### PR DESCRIPTION
I grepped the generated API and it seems to be only used for MLArgMinMaxOptions and as an argument to cast. Of course, it is also used in the general high-level API (MLTensor) where we currently mostly use rustnn::DataType

## Summary

- [x] Describe the user-visible and code-level changes.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

