### PR TITLE
Add draft for MLContext API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,15 +57,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aquamarine"
@@ -115,7 +115,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -154,7 +154,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -164,9 +164,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16fa879472d80dc40ca826a59347772b3f15e69a7a74df41c4935942f62cf30"
 dependencies = [
  "autocxx-engine",
- "env_logger",
+ "env_logger 0.9.3",
  "indexmap 1.9.3",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ dependencies = [
  "regex_static",
  "rustversion",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.117",
  "tempfile",
  "thiserror 1.0.69",
  "version_check",
@@ -209,7 +209,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
@@ -265,14 +265,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d250916401487680ed13b8b675660281dcfc3ab0121fe44c94bcab9eae2fb"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -343,9 +343,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -388,21 +388,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -438,13 +438,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.2",
  "windows-sys",
 ]
@@ -544,7 +543,7 @@ dependencies = [
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash",
+ "foldhash 0.2.0",
  "link-cplusplus",
 ]
 
@@ -556,11 +555,11 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -570,10 +569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "035b6c61a944483e8a4b2ad4fb8b13830d63491bd004943716ad16d85dcc64bc"
 dependencies = [
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -584,10 +583,10 @@ checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -602,10 +601,10 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -620,12 +619,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -639,21 +638,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -664,34 +662,34 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -699,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -725,7 +723,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -735,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -780,6 +778,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -827,6 +838,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -850,6 +867,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,8 +908,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -896,16 +950,31 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -921,6 +990,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -981,6 +1056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,12 +1080,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1027,6 +1108,17 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1054,6 +1146,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1072,25 +1173,33 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1123,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1200,7 +1309,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1228,7 +1337,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1299,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1332,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1344,9 +1453,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -1356,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1366,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1387,7 +1496,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1398,9 +1507,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -1410,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "half",
  "libloading 0.9.0",
@@ -1425,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -1442,9 +1551,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1485,7 +1594,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1505,20 +1614,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1528,9 +1637,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1551,13 +1660,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger 0.10.2",
+ "log",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1611,7 +1730,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -1620,7 +1739,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -1631,10 +1750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1648,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1662,10 +1781,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1687,7 +1812,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1698,9 +1823,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1744,7 +1869,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1756,7 +1881,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1767,7 +1892,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1778,9 +1903,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regex_static"
@@ -1818,15 +1943,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1837,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -1854,9 +1979,11 @@ dependencies = [
  "clap",
  "cudarc 0.19.4",
  "half",
+ "log",
  "ndarray",
  "objc",
  "ort",
+ "pretty_env_logger",
  "prost",
  "prost-build",
  "prost-types",
@@ -1898,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys",
 ]
@@ -1937,9 +2064,9 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1950,13 +2077,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1985,7 +2118,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2003,15 +2136,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2022,14 +2155,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2048,6 +2181,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2103,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2114,12 +2253,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2160,7 +2299,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2171,7 +2310,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2217,7 +2356,7 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.3.4",
  "indicatif",
  "itertools 0.14.0",
  "log",
@@ -2229,7 +2368,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -2290,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -2317,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2332,6 +2471,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -2347,9 +2492,9 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "der",
@@ -2359,15 +2504,15 @@ dependencies = [
  "rustls-pki-types",
  "socks",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-root-certs",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -2376,10 +2521,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -2401,18 +2546,27 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2423,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2433,24 +2587,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -2499,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2558,7 +2746,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2569,7 +2757,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2610,25 +2798,113 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cudarc"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+dependencies = [
+ "libloading 0.9.0",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1852,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "clap",
+ "cudarc 0.19.4",
  "half",
  "ndarray",
  "objc",
@@ -2255,7 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33e2037d309568bc023bb161c9ea23168ac0e345d398c912061d63dc3fb8415"
 dependencies = [
  "autocxx",
- "cudarc",
+ "cudarc 0.11.9",
  "cxx",
  "libc",
  "libloading 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }
 cudarc = { version = "0.19", features = ["cuda-13020"], optional = true}
 log = "0.4.29"
+pretty_env_logger = "0.5.0"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ default = []
 dynamic-inputs = []
 coreml-runtime = ["objc"]
 onnx-runtime = ["ort", "ndarray", "tokenizers", "dep:tempfile"]
-trtx-runtime = ["trtx"]
-trtx-runtime-mock = ["trtx/mock"]
+trtx-runtime = ["trtx", "cudarc"]
+trtx-runtime-mock = ["trtx/mock", "cudarc"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
@@ -46,6 +46,7 @@ trtx = { version = "0.4.0", optional = true }
 regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }
+cudarc = { version = "0.19", features = ["cuda-13020"], optional = true}
 
 [build-dependencies]
 prost-build = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ bytes = "1.6"
 bytemuck = { version = "1.15", features = ["extern_crate_std"] }
 ndarray = { version = "0.17", optional = true }
 objc = { version = "0.2", optional = true }
-ort = { version = "2.0.0-rc.11", optional = true, features = ["ndarray", "half", "load-dynamic"] }
 tempfile = { version = "3.8", optional = true }
+ort = { version = "2.0.0-rc.12", optional = true, features = ["ndarray", "half", "load-dynamic", "api-22"] }
 tokenizers = { version = "0.22", optional = true }
 half = "2.4"
 trtx = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }
 cudarc = { version = "0.19", features = ["cuda-13020"], optional = true}
+log = "0.4.29"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::Result,
-    mlcontext::{GpuDevice, MLContextOptions, MLPowerPreference},
+    executors::trtx::TrtxContext,
+    mlcontext::{GpuDevice, ListDevices, MLContextOptions, MLPowerPreference},
 };
 
 // this is a concept of pywebnn
@@ -14,6 +15,7 @@ pub(crate) enum DeviceType {
 /// we currently only consider internal backends,
 /// might allow to register external backends in future
 /// like with converter registry
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub(crate) enum BackendDevice {
     OnnxRuntime {
         //ep_device_idx: u64,
@@ -34,7 +36,8 @@ pub(crate) enum BackendDevice {
 // autoselection
 pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice> {
     let have_trtx = cfg!(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"));
-    let want_trtx = false;
+    let want_trtx = true;
+    let trtx_devices = TrtxContext::list_devices();
 
     let have_onnx = cfg!(feature = "onnx-runtime");
     let want_onnx = true;
@@ -58,9 +61,12 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
     Ok(match (options.power_preference, options.accelerated) {
         // Trtx
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
-            if have_trtx && want_trtx =>
+            if have_trtx
+                && want_trtx
+                && !trtx_devices.is_empty()
+                && trtx::dynamically_load_tensorrt(None::<String>).is_ok() =>
         {
-            BackendDevice::TrtxRuntime { cuda_device_idx: 0 }
+            *trtx_devices.first().unwrap()
         }
 
         // CoreML

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -16,20 +16,31 @@ pub(crate) enum DeviceType {
 /// might allow to register external backends in future
 /// like with converter registry
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[allow(dead_code)]
 pub(crate) enum BackendDevice {
-    OnnxRuntime {
+    OnnxDevice {
         //ep_device_idx: u64,
         device_type: DeviceType,
     },
-    TrtxRuntime {
+    TrtxDevice {
         cuda_device_idx: u32,
     },
-    CoremlRuntime {
+    CoremlDevice {
         //device_idx: u64,
         device_type: DeviceType,
     },
     WebNN,
     ExternalBackend,
+}
+
+impl BackendDevice {
+    pub(crate) fn as_trtx_device(&self) -> Option<&u32> {
+        if let Self::TrtxDevice { cuda_device_idx } = self {
+            Some(cuda_device_idx)
+        } else {
+            None
+        }
+    }
 }
 
 // TODO: pywebnn has device_type, and we could have backend preference for user to overwrite
@@ -63,42 +74,42 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_trtx
                 && want_trtx
-                && !trtx_devices.is_empty()
+                && let [first, ..] = trtx_devices.as_slice()
                 && trtx::dynamically_load_tensorrt(None::<String>).is_ok() =>
         {
-            *trtx_devices.first().unwrap()
+            *first
         }
 
         // CoreML
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_coreml && want_coreml =>
         {
-            BackendDevice::CoremlRuntime {
+            BackendDevice::CoremlDevice {
                 device_type: DeviceType::Gpu,
             }
         }
         (MLPowerPreference::LowPower, true) if have_coreml && want_coreml => {
-            BackendDevice::CoremlRuntime {
+            BackendDevice::CoremlDevice {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_coreml && want_coreml => BackendDevice::CoremlRuntime {
+        (_, false) if have_coreml && want_coreml => BackendDevice::CoremlDevice {
             device_type: DeviceType::Cpu,
         },
         // ORT
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_onnx && want_onnx =>
         {
-            BackendDevice::CoremlRuntime {
+            BackendDevice::CoremlDevice {
                 device_type: DeviceType::Gpu,
             }
         }
         (MLPowerPreference::LowPower, true) if have_onnx && want_onnx => {
-            BackendDevice::CoremlRuntime {
+            BackendDevice::CoremlDevice {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_onnx && want_onnx => BackendDevice::CoremlRuntime {
+        (_, false) if have_onnx && want_onnx => BackendDevice::CoremlDevice {
             device_type: DeviceType::Cpu,
         },
         // WebNN
@@ -107,6 +118,6 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
     })
 }
 
-pub(crate) fn select_backend_by_gpu(gpu_device: &GpuDevice) -> Result<BackendDevice> {
+pub(crate) fn select_backend_by_gpu(_gpu_device: &GpuDevice) -> Result<BackendDevice> {
     todo!()
 }

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -152,10 +152,7 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
             if have_onnx
                 && want_onnx
                 && ensure_ort_initialized().is_ok()
-                && let Some(first) = OrtContext::list_devices()
-                    .iter()
-                    .filter(|d| d.is_gpu())
-                    .next() =>
+                && let Some(first) = OrtContext::list_devices().iter().find(|d| d.is_gpu()) =>
         {
             *first
         }
@@ -163,10 +160,7 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
             if have_onnx
                 && want_onnx
                 && ensure_ort_initialized().is_ok()
-                && let Some(first) = OrtContext::list_devices()
-                    .iter()
-                    .filter(|d| d.is_npu())
-                    .next() =>
+                && let Some(first) = OrtContext::list_devices().iter().find(|d| d.is_npu()) =>
         {
             *first
         }
@@ -176,10 +170,7 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
             if have_onnx
                 && want_onnx
                 && ensure_ort_initialized().is_ok()
-                && let Some(first) = OrtContext::list_devices()
-                    .iter()
-                    .filter(|d| d.is_cpu())
-                    .next() =>
+                && let Some(first) = OrtContext::list_devices().iter().find(|d| d.is_cpu()) =>
         {
             *first
         }

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -1,8 +1,12 @@
 use crate::{
+    backends::ort::OrtContext,
     error::Result,
-    executors::{onnx::ensure_ort_initialized, trtx::TrtxContext},
+    executors::onnx::ensure_ort_initialized,
     mlcontext::{GpuDevice, ListDevices, MLContextOptions, MLPowerPreference},
 };
+
+#[cfg(feature = "trtx-runtime")]
+use crate::executors::trtx::TrtxContext;
 
 // this is a concept of pywebnn
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
@@ -10,6 +14,16 @@ pub(crate) enum DeviceType {
     Cpu,
     Gpu,
     Npu,
+}
+
+impl From<ort::memory::DeviceType> for DeviceType {
+    fn from(value: ort::memory::DeviceType) -> Self {
+        match value {
+            ort::memory::DeviceType::CPU => Self::Cpu,
+            ort::memory::DeviceType::GPU => Self::Gpu,
+            ort::memory::DeviceType::NPU => Self::Gpu,
+        }
+    }
 }
 
 /// we currently only consider internal backends,
@@ -34,6 +48,37 @@ pub(crate) enum BackendDevice {
 }
 
 impl BackendDevice {
+    fn is_npu(&self) -> bool {
+        match self {
+            BackendDevice::OnnxDevice { device_type }
+            | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Npu,
+            BackendDevice::TrtxDevice { .. } => false,
+            BackendDevice::WebNN => todo!(),
+            BackendDevice::ExternalBackend => todo!(),
+        }
+    }
+
+    fn is_gpu(&self) -> bool {
+        match self {
+            BackendDevice::OnnxDevice { device_type }
+            | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Gpu,
+            BackendDevice::TrtxDevice { .. } => true,
+            BackendDevice::WebNN => todo!(),
+            BackendDevice::ExternalBackend => todo!(),
+        }
+    }
+
+    fn is_cpu(&self) -> bool {
+        match self {
+            BackendDevice::OnnxDevice { device_type }
+            | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Cpu,
+            BackendDevice::TrtxDevice { .. } => false,
+            BackendDevice::WebNN => todo!(),
+            BackendDevice::ExternalBackend => todo!(),
+        }
+    }
+
+    #[cfg(feature = "trtx-runtime")]
     #[allow(dead_code)]
     pub(crate) fn as_trtx_device(&self) -> Option<&u32> {
         if let Self::TrtxDevice { cuda_device_idx } = self {
@@ -47,12 +92,15 @@ impl BackendDevice {
 // TODO: pywebnn has device_type, and we could have backend preference for user to overwrite
 // autoselection
 pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice> {
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let have_trtx = cfg!(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"));
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let want_trtx = true;
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let trtx_devices = TrtxContext::list_devices();
 
     let have_onnx = cfg!(feature = "onnx-runtime");
-    let want_onnx = true;
+    let want_onnx = true; // onnxruntime stuck in loading
 
     let have_coreml = cfg!(all(target_os = "macos", feature = "coreml-runtime"));
     let want_coreml = false;
@@ -72,6 +120,7 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
 
     Ok(match (options.power_preference, options.accelerated) {
         // Trtx
+        #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_trtx
                 && want_trtx
@@ -99,21 +148,33 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
         },
         // ORT
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
-            if have_onnx && want_onnx && ensure_ort_initialized().is_ok() =>
+            if have_onnx
+                && want_onnx
+                && ensure_ort_initialized().is_ok()
+                && OrtContext::list_devices()
+                    .iter()
+                    .find(|d| d.is_gpu())
+                    .is_some() =>
         {
             BackendDevice::OnnxDevice {
                 device_type: DeviceType::Gpu,
             }
         }
-        (MLPowerPreference::LowPower, true)
-            if have_onnx && want_onnx && ensure_ort_initialized().is_ok() =>
+        (MLPowerPreference::Default | MLPowerPreference::LowPower, true)
+            if have_onnx
+                && want_onnx
+                && ensure_ort_initialized().is_ok()
+                && OrtContext::list_devices()
+                    .iter()
+                    .find(|d| d.is_npu())
+                    .is_some() =>
         {
             BackendDevice::OnnxDevice {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_onnx && want_onnx && ensure_ort_initialized().is_ok() => {
-            BackendDevice::CoremlDevice {
+        (_, _) if have_onnx && want_onnx && ensure_ort_initialized().is_ok() => {
+            BackendDevice::OnnxDevice {
                 device_type: DeviceType::Cpu,
             }
         }

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -33,7 +33,7 @@ impl From<ort::memory::DeviceType> for DeviceType {
 #[allow(dead_code)]
 pub(crate) enum BackendDevice {
     OnnxDevice {
-        //ep_device_idx: u64,
+        ep_device_idx: usize,
         device_type: DeviceType,
     },
     TrtxDevice {
@@ -50,7 +50,7 @@ pub(crate) enum BackendDevice {
 impl BackendDevice {
     fn is_npu(&self) -> bool {
         match self {
-            BackendDevice::OnnxDevice { device_type }
+            BackendDevice::OnnxDevice { device_type, .. }
             | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Npu,
             BackendDevice::TrtxDevice { .. } => false,
             BackendDevice::WebNN => todo!(),
@@ -60,7 +60,7 @@ impl BackendDevice {
 
     fn is_gpu(&self) -> bool {
         match self {
-            BackendDevice::OnnxDevice { device_type }
+            BackendDevice::OnnxDevice { device_type, .. }
             | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Gpu,
             BackendDevice::TrtxDevice { .. } => true,
             BackendDevice::WebNN => todo!(),
@@ -71,7 +71,7 @@ impl BackendDevice {
     #[allow(dead_code)]
     fn is_cpu(&self) -> bool {
         match self {
-            BackendDevice::OnnxDevice { device_type }
+            BackendDevice::OnnxDevice { device_type, .. }
             | BackendDevice::CoremlDevice { device_type } => *device_type == DeviceType::Cpu,
             BackendDevice::TrtxDevice { .. } => false,
             BackendDevice::WebNN => todo!(),
@@ -152,33 +152,38 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
             if have_onnx
                 && want_onnx
                 && ensure_ort_initialized().is_ok()
-                && OrtContext::list_devices()
+                && let Some(first) = OrtContext::list_devices()
                     .iter()
-                    .find(|d| d.is_gpu())
-                    .is_some() =>
+                    .filter(|d| d.is_gpu())
+                    .next() =>
         {
-            BackendDevice::OnnxDevice {
-                device_type: DeviceType::Gpu,
-            }
+            *first
         }
         (MLPowerPreference::Default | MLPowerPreference::LowPower, true)
             if have_onnx
                 && want_onnx
                 && ensure_ort_initialized().is_ok()
-                && OrtContext::list_devices()
+                && let Some(first) = OrtContext::list_devices()
                     .iter()
-                    .find(|d| d.is_npu())
-                    .is_some() =>
+                    .filter(|d| d.is_npu())
+                    .next() =>
         {
-            BackendDevice::OnnxDevice {
-                device_type: DeviceType::Npu,
-            }
+            *first
         }
-        (_, _) if have_onnx && want_onnx && ensure_ort_initialized().is_ok() => {
-            BackendDevice::OnnxDevice {
-                device_type: DeviceType::Cpu,
-            }
+        // TODO: confirm whether we are allowed to return CPU, if user wanted accelerated (IRC
+        // chrome did have this behavior in browser)
+        (_, _)
+            if have_onnx
+                && want_onnx
+                && ensure_ort_initialized().is_ok()
+                && let Some(first) = OrtContext::list_devices()
+                    .iter()
+                    .filter(|d| d.is_cpu())
+                    .next() =>
+        {
+            *first
         }
+
         // WebNN
         (_, _) if have_webnn && want_webnn => BackendDevice::WebNN,
         _ => return Err(crate::error::Error::NoBackendAvialable),

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -20,7 +20,7 @@ pub(crate) enum BackendDesc {
         device_type: DeviceType,
     },
     TrtxRuntime {
-        cuda_device_idx: u64,
+        cuda_device_idx: u32,
     },
     CoremlRuntime {
         //device_idx: u64,

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -68,6 +68,7 @@ impl BackendDevice {
         }
     }
 
+    #[allow(dead_code)]
     fn is_cpu(&self) -> bool {
         match self {
             BackendDevice::OnnxDevice { device_type }

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -1,0 +1,106 @@
+use crate::{
+    error::Result,
+    mlcontext::{GpuDevice, MLContextOptions, MLPowerPreference},
+};
+
+// this is a concept of pywebnn
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub(crate) enum DeviceType {
+    Cpu,
+    Gpu,
+    Npu,
+}
+
+/// we currently only consider internal backends,
+/// might allow to register external backends in future
+/// like with converter registry
+pub(crate) enum BackendDesc {
+    OnnxRuntime {
+        //ep_device_idx: u64,
+        device_type: DeviceType,
+    },
+    TrtxRuntime {
+        cuda_device_idx: u64,
+    },
+    CoremlRuntime {
+        //device_idx: u64,
+        device_type: DeviceType,
+    },
+    WebNN,
+    ExternalBackend,
+}
+
+// TODO: pywebnn has device_type, and we could have backend preference for user to overwrite
+// autoselection
+pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDesc> {
+    let have_trtx = cfg!(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"));
+    let want_trtx = false;
+
+    let have_onnx = cfg!(feature = "onnx-runtime");
+    let want_onnx = true;
+
+    let have_coreml = cfg!(all(target_os = "macos", feature = "coreml-runtime"));
+    let want_coreml = false;
+
+    // not merged yet
+    //let have_webnn = cfg!(all(feature = "web", target_arch = "wasm32"));
+    let have_webnn = false;
+    let want_webnn = true;
+
+    // TODO: also check whether WebNN is available
+    //#[cfg(target_arch = "wasm32")]
+    //{
+    //let window = window().expect("no global `window` exists");
+    //let navigator = window.navigator();
+    //let ml = navigator.ml();
+    //}
+
+    Ok(match (options.power_preference, options.accelerated) {
+        // Trtx
+        (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
+            if have_trtx && want_trtx =>
+        {
+            BackendDesc::TrtxRuntime { cuda_device_idx: 0 }
+        }
+
+        // CoreML
+        (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
+            if have_coreml && want_coreml =>
+        {
+            BackendDesc::CoremlRuntime {
+                device_type: DeviceType::Gpu,
+            }
+        }
+        (MLPowerPreference::LowPower, true) if have_coreml && want_coreml => {
+            BackendDesc::CoremlRuntime {
+                device_type: DeviceType::Npu,
+            }
+        }
+        (_, false) if have_coreml && want_coreml => BackendDesc::CoremlRuntime {
+            device_type: DeviceType::Cpu,
+        },
+        // ORT
+        (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
+            if have_onnx && want_onnx =>
+        {
+            BackendDesc::CoremlRuntime {
+                device_type: DeviceType::Gpu,
+            }
+        }
+        (MLPowerPreference::LowPower, true) if have_onnx && want_onnx => {
+            BackendDesc::CoremlRuntime {
+                device_type: DeviceType::Npu,
+            }
+        }
+        (_, false) if have_onnx && want_onnx => BackendDesc::CoremlRuntime {
+            device_type: DeviceType::Cpu,
+        },
+        // WebNN
+        (_, _) if have_webnn && want_webnn => BackendDesc::WebNN,
+        _ => return Err(crate::error::Error::NoBackendAvialable),
+    })
+}
+
+pub(crate) fn select_backend_by_gpu(gpu_device: &GpuDevice) -> Result<BackendDesc> {
+    todo!()
+}

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -14,7 +14,7 @@ pub(crate) enum DeviceType {
 /// we currently only consider internal backends,
 /// might allow to register external backends in future
 /// like with converter registry
-pub(crate) enum BackendDesc {
+pub(crate) enum BackendDevice {
     OnnxRuntime {
         //ep_device_idx: u64,
         device_type: DeviceType,
@@ -32,7 +32,7 @@ pub(crate) enum BackendDesc {
 
 // TODO: pywebnn has device_type, and we could have backend preference for user to overwrite
 // autoselection
-pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDesc> {
+pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice> {
     let have_trtx = cfg!(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"));
     let want_trtx = false;
 
@@ -60,47 +60,47 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDesc> 
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_trtx && want_trtx =>
         {
-            BackendDesc::TrtxRuntime { cuda_device_idx: 0 }
+            BackendDevice::TrtxRuntime { cuda_device_idx: 0 }
         }
 
         // CoreML
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_coreml && want_coreml =>
         {
-            BackendDesc::CoremlRuntime {
+            BackendDevice::CoremlRuntime {
                 device_type: DeviceType::Gpu,
             }
         }
         (MLPowerPreference::LowPower, true) if have_coreml && want_coreml => {
-            BackendDesc::CoremlRuntime {
+            BackendDevice::CoremlRuntime {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_coreml && want_coreml => BackendDesc::CoremlRuntime {
+        (_, false) if have_coreml && want_coreml => BackendDevice::CoremlRuntime {
             device_type: DeviceType::Cpu,
         },
         // ORT
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_onnx && want_onnx =>
         {
-            BackendDesc::CoremlRuntime {
+            BackendDevice::CoremlRuntime {
                 device_type: DeviceType::Gpu,
             }
         }
         (MLPowerPreference::LowPower, true) if have_onnx && want_onnx => {
-            BackendDesc::CoremlRuntime {
+            BackendDevice::CoremlRuntime {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_onnx && want_onnx => BackendDesc::CoremlRuntime {
+        (_, false) if have_onnx && want_onnx => BackendDevice::CoremlRuntime {
             device_type: DeviceType::Cpu,
         },
         // WebNN
-        (_, _) if have_webnn && want_webnn => BackendDesc::WebNN,
+        (_, _) if have_webnn && want_webnn => BackendDevice::WebNN,
         _ => return Err(crate::error::Error::NoBackendAvialable),
     })
 }
 
-pub(crate) fn select_backend_by_gpu(gpu_device: &GpuDevice) -> Result<BackendDesc> {
+pub(crate) fn select_backend_by_gpu(gpu_device: &GpuDevice) -> Result<BackendDevice> {
     todo!()
 }

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -34,6 +34,7 @@ pub(crate) enum BackendDevice {
 }
 
 impl BackendDevice {
+    #[allow(dead_code)]
     pub(crate) fn as_trtx_device(&self) -> Option<&u32> {
         if let Self::TrtxDevice { cuda_device_idx } = self {
             Some(cuda_device_idx)

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Result,
-    executors::trtx::TrtxContext,
+    executors::{onnx::ensure_ort_initialized, trtx::TrtxContext},
     mlcontext::{GpuDevice, ListDevices, MLContextOptions, MLPowerPreference},
 };
 
@@ -99,20 +99,24 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
         },
         // ORT
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
-            if have_onnx && want_onnx =>
+            if have_onnx && want_onnx && ensure_ort_initialized().is_ok() =>
         {
             BackendDevice::OnnxDevice {
                 device_type: DeviceType::Gpu,
             }
         }
-        (MLPowerPreference::LowPower, true) if have_onnx && want_onnx => {
+        (MLPowerPreference::LowPower, true)
+            if have_onnx && want_onnx && ensure_ort_initialized().is_ok() =>
+        {
             BackendDevice::OnnxDevice {
                 device_type: DeviceType::Npu,
             }
         }
-        (_, false) if have_onnx && want_onnx => BackendDevice::CoremlDevice {
-            device_type: DeviceType::Cpu,
-        },
+        (_, false) if have_onnx && want_onnx && ensure_ort_initialized().is_ok() => {
+            BackendDevice::CoremlDevice {
+                device_type: DeviceType::Cpu,
+            }
+        }
         // WebNN
         (_, _) if have_webnn && want_webnn => BackendDevice::WebNN,
         _ => return Err(crate::error::Error::NoBackendAvialable),

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -101,12 +101,12 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
         (MLPowerPreference::Default | MLPowerPreference::HighPerformance, true)
             if have_onnx && want_onnx =>
         {
-            BackendDevice::CoremlDevice {
+            BackendDevice::OnnxDevice {
                 device_type: DeviceType::Gpu,
             }
         }
         (MLPowerPreference::LowPower, true) if have_onnx && want_onnx => {
-            BackendDevice::CoremlDevice {
+            BackendDevice::OnnxDevice {
                 device_type: DeviceType::Npu,
             }
         }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,0 +1,2 @@
+pub mod ort;
+

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,2 +1,1 @@
 pub mod ort;
-

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -323,7 +323,7 @@ fn copy_dyn_value_to_buffer(
 
 fn write_outputs_from_session<'s>(
     session_outputs: &SessionOutputs<'s>,
-    outputs: &HashMap<&str, MLTensor>,
+    outputs: &HashMap<&str, &MLTensor>,
     tensors: &mut [OrtTensor],
 ) -> crate::error::Result<()> {
     for (&name, ml_tensor) in outputs.iter() {
@@ -355,6 +355,8 @@ impl OrtContext {
             tensors: Vec::new(),
         })
     }
+
+    #[allow(dead_code)]
     pub(crate) fn new_from_ty(
         device_type: crate::backend_selection::DeviceType,
     ) -> crate::error::Result<Self> {
@@ -503,8 +505,8 @@ impl<'context> MLBackendContext<'context> for OrtContext {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, MLTensor>,
-        outputs: &HashMap<&str, MLTensor>,
+        inputs: &HashMap<&str, &MLTensor>,
+        outputs: &HashMap<&str, &MLTensor>,
     ) -> crate::error::Result<()> {
         let ort_graph =
             graph

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -1,28 +1,356 @@
+use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use log::debug;
-use ort::{device::Device, environment::Environment, memory::DeviceType, sys::OrtHardwareDevice};
+use ndarray::{ArrayD, IxDyn};
+use ort::environment::Environment;
+use ort::memory::DeviceType;
+use ort::session::SessionInputValue;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::{Session, SessionOutputs};
+use ort::value::{DynValue, Outlet, TensorElementType, Value, ValueType};
 
-use crate::{
-    backend_selection::BackendDevice,
-    error::Error,
-    executors::onnx::ensure_ort_initialized,
-    mlcontext::{ListDevices, MLBackendContext},
+use crate::GraphInfo;
+use crate::backend_selection::BackendDevice;
+use crate::converters::{GraphConverter, OnnxConverter};
+use crate::error::Error;
+use crate::executors::onnx::ensure_ort_initialized;
+use crate::mlcontext::{
+    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLOperand, MLTensor,
+    MLTensorDescriptor,
 };
+
+trait ToDispatchResult<T> {
+    fn to_dispatch_result(self) -> crate::error::Result<T>;
+}
+
+impl<T> ToDispatchResult<T> for ort::Result<T> {
+    fn to_dispatch_result(self) -> crate::error::Result<T> {
+        self.map_err(|e| Error::GraphDispatchError { source: e.into() })
+    }
+}
+
+fn tensor_byte_len(descriptor: &MLTensorDescriptor) -> crate::error::Result<usize> {
+    let bits = descriptor.data_type().element_size_bits();
+    let elements: usize = descriptor
+        .shape()
+        .iter()
+        .try_fold(1u64, |acc, &d| acc.checked_mul(d))
+        .ok_or_else(|| Error::GraphDispatchError {
+            source: "tensor element count overflow".into(),
+        })? as usize;
+    Ok(bits * elements / 8)
+}
+
+fn ort_tensor_element_size(ty: TensorElementType) -> Option<usize> {
+    match ty {
+        TensorElementType::Float32 => Some(4),
+        TensorElementType::Float16 => Some(2),
+        TensorElementType::Int8 | TensorElementType::Uint8 | TensorElementType::Bool => Some(1),
+        TensorElementType::Int16 | TensorElementType::Uint16 => Some(2),
+        TensorElementType::Int32 | TensorElementType::Uint32 => Some(4),
+        TensorElementType::Int64 | TensorElementType::Uint64 => Some(8),
+        _ => None,
+    }
+}
+
+/// Host tensor storage for the ONNX Runtime backend (mirrors device buffers in TRTX).
+#[derive(Debug)]
+pub(crate) struct OrtTensor {
+    memory: Vec<u8>,
+}
+
+/// Compiled ONNX model held by [`MLGraph`] (mirrors [`crate::executors::trtx::TrtxGraph`]).
+pub(crate) struct OrtGraph {
+    pub(crate) session: Session,
+}
+
+impl fmt::Debug for OrtGraph {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OrtGraph")
+            .field("num_inputs", &self.session.inputs().len())
+            .field("num_outputs", &self.session.outputs().len())
+            .finish()
+    }
+}
+
+pub(crate) struct OrtBuilder<'a> {
+    graph: Option<&'a GraphInfo>,
+}
+
+impl fmt::Debug for OrtBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OrtBuilder")
+            .field("has_graph", &self.graph.is_some())
+            .finish()
+    }
+}
+
+impl<'context> MLBackendBuilder<'context> for OrtBuilder<'context> {
+    fn build(
+        &mut self,
+        _outputs: &HashMap<&str, MLOperand>,
+    ) -> crate::error::Result<MLGraph<'context>> {
+        let graph_info = self.graph.ok_or_else(|| Error::GraphBuildError {
+            source: "build called before load_graph".into(),
+        })?;
+        let converted = OnnxConverter.convert(graph_info)?;
+        ensure_ort_initialized().map_err(|e| Error::GraphBuildError { source: e.into() })?;
+        let session = Session::builder()
+            .map_err(|e| Error::GraphBuildError { source: e.into() })?
+            .with_optimization_level(GraphOptimizationLevel::Disable)
+            .map_err(|e| Error::GraphBuildError { source: e.into() })?
+            .commit_from_memory(&converted.data)
+            .map_err(|e| Error::GraphBuildError { source: e.into() })?;
+        Ok(MLGraph {
+            backend: crate::mlcontext::MLBackendGraph::OnnxSession(
+                OrtGraph { session },
+                std::marker::PhantomData,
+            ),
+        })
+    }
+
+    fn load_graph(&mut self, graph: &'context GraphInfo) -> crate::error::Result<()> {
+        self.graph = Some(graph);
+        Ok(())
+    }
+}
+
+fn session_input_from_host(
+    input_info: &Outlet,
+    shape: &[u64],
+    bytes: &[u8],
+) -> crate::error::Result<SessionInputValue<'static>> {
+    let ValueType::Tensor { ty, .. } = input_info.dtype() else {
+        return Err(Error::GraphDispatchError {
+            source: format!("input '{}' is not a tensor", input_info.name()).into(),
+        });
+    };
+    let shape_usize: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+    let Some(elem_sz) = ort_tensor_element_size(*ty) else {
+        return Err(Error::GraphDispatchError {
+            source: format!(
+                "input '{}': unsupported ONNX element type for WebNN I/O: {:?}",
+                input_info.name(),
+                ty
+            )
+            .into(),
+        });
+    };
+    let elements: usize = shape_usize.iter().product();
+    let expected = elements.saturating_mul(elem_sz).max(elem_sz);
+    if bytes.len() != expected {
+        return Err(Error::GraphDispatchError {
+            source: format!(
+                "input '{}': byte length mismatch (expected {}, got {})",
+                input_info.name(),
+                expected,
+                bytes.len()
+            )
+            .into(),
+        });
+    }
+
+    let shape_i64: Vec<i64> = shape.iter().map(|&d| d as i64).collect();
+    let dyn_val: DynValue = match ty {
+        TensorElementType::Float32 => {
+            let v = if shape_usize.contains(&0) {
+                let data: Vec<f32> = bytemuck::cast_slice(bytes).to_vec();
+                let array = ArrayD::from_shape_vec(IxDyn(&shape_usize), data).map_err(|e| {
+                    Error::GraphDispatchError {
+                        source: format!("ndarray input {}: {e}", input_info.name()).into(),
+                    }
+                })?;
+                Value::from_array(array)
+                    .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+            } else {
+                Value::from_array((
+                    shape_i64.as_slice(),
+                    bytemuck::cast_slice::<u8, f32>(bytes).to_vec(),
+                ))
+                .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+            };
+            v.into_dyn()
+        }
+        TensorElementType::Float16 => {
+            let u16s: Vec<u16> = bytemuck::cast_slice(bytes).to_vec();
+            let f16_data: Vec<half::f16> = u16s.iter().map(|&b| half::f16::from_bits(b)).collect();
+            Value::from_array((shape_i64.as_slice(), f16_data))
+                .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+                .into_dyn()
+        }
+        TensorElementType::Int8 => Value::from_array((
+            shape_i64.clone(),
+            bytemuck::cast_slice::<u8, i8>(bytes).to_vec(),
+        ))
+        .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+        .into_dyn(),
+        TensorElementType::Uint8 => Value::from_array((shape_i64.clone(), bytes.to_vec()))
+            .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+            .into_dyn(),
+        TensorElementType::Int32 => Value::from_array((
+            shape_i64.clone(),
+            bytemuck::cast_slice::<u8, i32>(bytes).to_vec(),
+        ))
+        .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+        .into_dyn(),
+        TensorElementType::Uint32 => Value::from_array((
+            shape_i64.clone(),
+            bytemuck::cast_slice::<u8, u32>(bytes).to_vec(),
+        ))
+        .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+        .into_dyn(),
+        TensorElementType::Int64 => Value::from_array((
+            shape_i64.clone(),
+            bytemuck::cast_slice::<u8, i64>(bytes).to_vec(),
+        ))
+        .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+        .into_dyn(),
+        TensorElementType::Uint64 => Value::from_array((
+            shape_i64.clone(),
+            bytemuck::cast_slice::<u8, u64>(bytes).to_vec(),
+        ))
+        .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+        .into_dyn(),
+        _ => {
+            return Err(Error::GraphDispatchError {
+                source: format!(
+                    "input '{}': unsupported element type {:?}",
+                    input_info.name(),
+                    ty
+                )
+                .into(),
+            });
+        }
+    };
+    Ok(SessionInputValue::from(dyn_val))
+}
+
+fn copy_dyn_value_to_buffer(
+    name: &str,
+    value: &ort::value::DynValue,
+    descriptor: &MLTensorDescriptor,
+    buf: &mut [u8],
+) -> crate::error::Result<()> {
+    let expected = tensor_byte_len(descriptor)?;
+    if buf.len() != expected {
+        return Err(Error::GraphDispatchError {
+            source: format!(
+                "output '{name}': buffer length {} does not match descriptor ({expected} bytes)",
+                buf.len()
+            )
+            .into(),
+        });
+    }
+    match descriptor.data_type() {
+        crate::operator_enums::MLOperandDataType::Float32 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<f32>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Float16 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<half::f16>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            let u16s: Vec<u16> = sl.iter().map(|h| h.to_bits()).collect();
+            buf.copy_from_slice(bytemuck::cast_slice(&u16s));
+        }
+        crate::operator_enums::MLOperandDataType::Int32 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<i32>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Uint32 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<u32>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Int64 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<i64>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Uint64 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<u64>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Int8 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<i8>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(bytemuck::cast_slice(sl));
+        }
+        crate::operator_enums::MLOperandDataType::Uint8 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<u8>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            buf.copy_from_slice(sl);
+        }
+    }
+    Ok(())
+}
+
+fn write_outputs_from_session<'s>(
+    session_outputs: &SessionOutputs<'s>,
+    outputs: &HashMap<&str, MLTensor>,
+    tensors: &mut [OrtTensor],
+) -> crate::error::Result<()> {
+    for (&name, ml_tensor) in outputs.iter() {
+        let Some(value) = session_outputs.get(name) else {
+            return Err(Error::GraphDispatchError {
+                source: format!("model did not produce output '{name}'").into(),
+            });
+        };
+        let buf = &mut tensors[ml_tensor.id].memory;
+        copy_dyn_value_to_buffer(name, value, &ml_tensor.descriptor, buf)?;
+    }
+    Ok(())
+}
 
 pub(crate) struct OrtContext {
     env: Arc<Environment>,
     device_idx: usize,
+    tensors: Vec<OrtTensor>,
 }
 
 impl OrtContext {
     pub(crate) fn new_from_ty(
         device_type: crate::backend_selection::DeviceType,
     ) -> crate::error::Result<Self> {
+        ensure_ort_initialized().map_err(|e| Error::ContextCreationError { source: e.into() })?;
         let env =
             Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })?;
-        //env.devices() has wrong lifetimes, the device should have the lifetime from env, but not hold on
-        //the borrow
 
         let selected = env
             .devices()
@@ -38,12 +366,13 @@ impl OrtContext {
         Ok(Self {
             env,
             device_idx: selected,
+            tensors: Vec::new(),
         })
     }
 }
 
-impl std::fmt::Debug for OrtContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for OrtContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let device = self.env.devices().nth(self.device_idx).unwrap();
         f.debug_struct("OrtContext")
             .field(
@@ -55,8 +384,7 @@ impl std::fmt::Debug for OrtContext {
                     &device.ty(),
                 ),
             )
-            //.field("ep_device", &self.ep_device)
-            //.field("hw_device", &self.hw_device)
+            .field("tensor_count", &self.tensors.len())
             .finish()
     }
 }
@@ -88,9 +416,6 @@ impl ListDevices for OrtContext {
     }
 }
 
-//let env = Environment::current()?;
-//let _ = env.register_ep_library("CUDA", "/path/to/onnxruntime_providers_cuda.dll");
-
 impl<'context> MLBackendContext<'context> for OrtContext {
     fn accelerated(&self) -> bool {
         let device = self.env.devices().nth(self.device_idx).unwrap();
@@ -99,48 +424,102 @@ impl<'context> MLBackendContext<'context> for OrtContext {
 
     fn create_builder(
         &mut self,
-    ) -> crate::error::Result<Box<dyn crate::mlcontext::MLBackendBuilder<'context> + 'context>>
-    {
-        todo!()
+    ) -> crate::error::Result<Box<dyn MLBackendBuilder<'context> + 'context>> {
+        Ok(Box::new(OrtBuilder { graph: None }))
     }
 
-    fn create_tensor(
-        &mut self,
-        descriptor: &crate::mlcontext::MLTensorDescriptor,
-    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
-        todo!()
+    fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> crate::error::Result<MLTensor> {
+        let n = tensor_byte_len(descriptor)?;
+        let memory = vec![0u8; n.max(1)];
+        self.tensors.push(OrtTensor { memory });
+        Ok(MLTensor {
+            id: self.tensors.len() - 1,
+            constant: false,
+            descriptor: descriptor.clone(),
+        })
     }
 
     fn create_constant_tensor(
         &mut self,
-        descriptor: &crate::mlcontext::MLTensorDescriptor,
+        descriptor: &MLTensorDescriptor,
         input_data: &[u8],
-    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
-        todo!()
+    ) -> crate::error::Result<MLTensor> {
+        let mut tensor = self.create_tensor(descriptor)?;
+        tensor.constant = true;
+        self.write_tensor(&tensor, input_data)
+            .map_err(|e| Error::TensorCreationError {
+                source: e.into(),
+                descriptor: descriptor.clone(),
+            })?;
+        Ok(tensor)
     }
 
-    fn read_tensor(
-        &mut self,
-        tensor: &crate::mlcontext::MLTensor,
-        array: &mut [u8],
-    ) -> crate::error::Result<()> {
-        todo!()
+    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> crate::error::Result<()> {
+        let host = &self.tensors[tensor.id].memory;
+        if array.len() < host.len() {
+            return Err(Error::TensorReadError {
+                source: format!(
+                    "buffer too small: need {} bytes, got {}",
+                    host.len(),
+                    array.len()
+                )
+                .into(),
+                tensor: tensor.clone(),
+            });
+        }
+        array[..host.len()].copy_from_slice(host);
+        Ok(())
     }
 
-    fn write_tensor(
-        &mut self,
-        tensor: &crate::mlcontext::MLTensor,
-        array: &[u8],
-    ) -> crate::error::Result<()> {
-        todo!()
+    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> crate::error::Result<()> {
+        let host = &mut self.tensors[tensor.id].memory;
+        if array.len() > host.len() {
+            return Err(Error::TensorWriteError {
+                source: format!(
+                    "write exceeds tensor storage: {} bytes > {}",
+                    array.len(),
+                    host.len()
+                )
+                .into(),
+                tensor: tensor.clone(),
+            });
+        }
+        let n = array.len();
+        host[..n].copy_from_slice(array);
+        Ok(())
     }
 
     fn dispatch(
         &mut self,
-        graph: &mut crate::mlcontext::MLGraph,
-        inputs: &std::collections::HashMap<&str, crate::mlcontext::MLTensor>,
-        outputs: &std::collections::HashMap<&str, crate::mlcontext::MLTensor>,
+        graph: &mut MLGraph,
+        inputs: &HashMap<&str, MLTensor>,
+        outputs: &HashMap<&str, MLTensor>,
     ) -> crate::error::Result<()> {
-        todo!()
+        let ort_graph =
+            graph
+                .backend
+                .as_onnx_session_mut()
+                .ok_or_else(|| Error::GraphDispatchError {
+                    source: "MLGraph is not an ONNX Runtime session graph".into(),
+                })?;
+
+        let mut input_session_values: Vec<SessionInputValue> = Vec::new();
+        for input_info in ort_graph.session.inputs().iter() {
+            let name = input_info.name();
+            let tensor = inputs.get(name).ok_or_else(|| Error::GraphDispatchError {
+                source: format!("missing input '{name}' for ONNX dispatch").into(),
+            })?;
+            let bytes = &self.tensors[tensor.id].memory;
+            let v = session_input_from_host(input_info, tensor.shape(), bytes)?;
+            input_session_values.push(v);
+        }
+
+        let session_outputs = ort_graph
+            .session
+            .run(input_session_values.as_slice())
+            .to_dispatch_result()?;
+
+        write_outputs_from_session(&session_outputs, outputs, &mut self.tensors)?;
+        Ok(())
     }
 }

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -345,6 +345,16 @@ pub(crate) struct OrtContext {
 }
 
 impl OrtContext {
+    pub(crate) fn new_from_ep_idx(device_idx: usize) -> crate::error::Result<Self> {
+        ensure_ort_initialized().map_err(|e| Error::ContextCreationError { source: e.into() })?;
+        let env =
+            Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })?;
+        Ok(Self {
+            env,
+            device_idx,
+            tensors: Vec::new(),
+        })
+    }
     pub(crate) fn new_from_ty(
         device_type: crate::backend_selection::DeviceType,
     ) -> crate::error::Result<Self> {
@@ -402,13 +412,14 @@ impl ListDevices for OrtContext {
         };
 
         let mut rtn = vec![];
-        for d in env.devices() {
+        for (idx, d) in env.devices().enumerate() {
             debug!(
                 "Saw ONNX device {:?}",
                 &(&d.vendor(), &d.ep_vendor(), &d.id(), &d.ty(),)
             );
             rtn.push(BackendDevice::OnnxDevice {
                 device_type: d.ty().into(),
+                ep_device_idx: idx,
             })
         }
 

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use log::debug;
+use ort::{device::Device, environment::Environment, memory::DeviceType, sys::OrtHardwareDevice};
+
+use crate::{
+    backend_selection::BackendDevice,
+    error::Error,
+    executors::onnx::ensure_ort_initialized,
+    mlcontext::{ListDevices, MLBackendContext},
+};
+
+pub(crate) struct OrtContext {
+    env: Arc<Environment>,
+    device_idx: usize,
+}
+
+impl OrtContext {
+    pub(crate) fn new_from_ty(
+        device_type: crate::backend_selection::DeviceType,
+    ) -> crate::error::Result<Self> {
+        let env =
+            Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })?;
+        //env.devices() has wrong lifetimes, the device should have the lifetime from env, but not hold on
+        //the borrow
+
+        let selected = env
+            .devices()
+            .inspect(|d| {
+                debug!(
+                    "Saw ONNX device {:?}",
+                    &(&d.vendor(), &d.ep_vendor(), &d.id(), &d.ty(),)
+                )
+            })
+            .position(|d| device_type == d.ty().into())
+            .ok_or(Error::NoDeviceAvailable)?;
+
+        Ok(Self {
+            env,
+            device_idx: selected,
+        })
+    }
+}
+
+impl std::fmt::Debug for OrtContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let device = self.env.devices().nth(self.device_idx).unwrap();
+        f.debug_struct("OrtContext")
+            .field(
+                "device",
+                &(
+                    &device.vendor(),
+                    &device.ep_vendor(),
+                    &device.id(),
+                    &device.ty(),
+                ),
+            )
+            //.field("ep_device", &self.ep_device)
+            //.field("hw_device", &self.hw_device)
+            .finish()
+    }
+}
+
+impl ListDevices for OrtContext {
+    fn list_devices() -> Vec<crate::backend_selection::BackendDevice> {
+        if ensure_ort_initialized().is_err() {
+            return vec![];
+        }
+
+        let Ok(env) =
+            Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })
+        else {
+            return vec![];
+        };
+
+        let mut rtn = vec![];
+        for d in env.devices() {
+            debug!(
+                "Saw ONNX device {:?}",
+                &(&d.vendor(), &d.ep_vendor(), &d.id(), &d.ty(),)
+            );
+            rtn.push(BackendDevice::OnnxDevice {
+                device_type: d.ty().into(),
+            })
+        }
+
+        rtn
+    }
+}
+
+//let env = Environment::current()?;
+//let _ = env.register_ep_library("CUDA", "/path/to/onnxruntime_providers_cuda.dll");
+
+impl<'context> MLBackendContext<'context> for OrtContext {
+    fn accelerated(&self) -> bool {
+        let device = self.env.devices().nth(self.device_idx).unwrap();
+        device.ty() != DeviceType::CPU
+    }
+
+    fn create_builder(
+        &mut self,
+    ) -> crate::error::Result<Box<dyn crate::mlcontext::MLBackendBuilder<'context> + 'context>>
+    {
+        todo!()
+    }
+
+    fn create_tensor(
+        &mut self,
+        descriptor: &crate::mlcontext::MLTensorDescriptor,
+    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
+        todo!()
+    }
+
+    fn create_constant_tensor(
+        &mut self,
+        descriptor: &crate::mlcontext::MLTensorDescriptor,
+        input_data: &[u8],
+    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
+        todo!()
+    }
+
+    fn read_tensor(
+        &mut self,
+        tensor: &crate::mlcontext::MLTensor,
+        array: &mut [u8],
+    ) -> crate::error::Result<()> {
+        todo!()
+    }
+
+    fn write_tensor(
+        &mut self,
+        tensor: &crate::mlcontext::MLTensor,
+        array: &[u8],
+    ) -> crate::error::Result<()> {
+        todo!()
+    }
+
+    fn dispatch(
+        &mut self,
+        graph: &mut crate::mlcontext::MLGraph,
+        inputs: &std::collections::HashMap<&str, crate::mlcontext::MLTensor>,
+        outputs: &std::collections::HashMap<&str, crate::mlcontext::MLTensor>,
+    ) -> crate::error::Result<()> {
+        todo!()
+    }
+}

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -51,12 +51,54 @@ impl TrtxConverter {
         TrtxConverter
     }
 
-    /// TensorRT engine I/O tensor name for operand index `operand_id` (`GraphInfo::operands` index).
-    ///
-    /// WebNN/WPT names are intentionally not used as TRT binding names: TensorRT's QDQ rewrite
-    /// matches ONNX-style tokens (e.g. `ZeroPoint`) and can fail engine build for unrelated native graphs.
+    /// Stable fallback TensorRT tensor name when [`Operand::name`] is missing or empty.
     pub fn engine_binding_name(operand_id: u32) -> String {
         format!("webnn_operand_{operand_id}")
+    }
+
+    /// Tensor names for graph inputs and outputs as used by [`Self::build_network`].
+    ///
+    /// Uses each operand's `name` when present and non-empty. If the same name is used for more
+    /// than one input/output operand, disambiguates with `_{operand_id}`. Falls back to
+    /// [`Self::engine_binding_name`] when unnamed.
+    pub fn engine_io_binding_names(graph: &GraphInfo) -> HashMap<u32, String> {
+        let mut specs: Vec<(u32, Option<String>)> = Vec::new();
+        for (i, op) in graph.operands.iter().enumerate() {
+            if matches!(op.kind, OperandKind::Input | OperandKind::Output) {
+                let trimmed = op
+                    .name
+                    .as_ref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
+                specs.push((i as u32, trimmed));
+            }
+        }
+        let mut count_by_pref: HashMap<String, usize> = HashMap::new();
+        for (_, pref) in &specs {
+            if let Some(n) = pref {
+                *count_by_pref.entry(n.clone()).or_insert(0) += 1;
+            }
+        }
+        let mut m = HashMap::new();
+        for (id, pref) in specs {
+            let name = match pref {
+                Some(n) if count_by_pref.get(&n).copied().unwrap_or(0) > 1 => format!("{n}_{id}"),
+                Some(n) => n,
+                None => Self::engine_binding_name(id),
+            };
+            m.insert(id, name);
+        }
+        m
+    }
+
+    /// TensorRT engine I/O name for `operand_id` after [`Self::build_network`] (same rules as
+    /// [`Self::engine_io_binding_names`]).
+    pub fn engine_io_tensor_name(graph: &GraphInfo, operand_id: u32) -> String {
+        Self::engine_io_binding_names(graph)
+            .get(&operand_id)
+            .cloned()
+            .unwrap_or_else(|| Self::engine_binding_name(operand_id))
     }
 
     #[allow(dead_code)]
@@ -397,6 +439,7 @@ impl TrtxConverter {
         let mut tensor_map: HashMap<u32, trtx::Tensor<'a>> = HashMap::new();
         let promoted_constants: HashSet<u32> = HashSet::new();
         let constants_stored_flat: HashSet<u32> = HashSet::new();
+        let io_binding_names = Self::engine_io_binding_names(graph);
 
         // Step 1: Add inputs
         for (operand_id, operand) in graph.operands.iter().enumerate() {
@@ -408,7 +451,10 @@ impl TrtxConverter {
                     .iter()
                     .map(|d| get_static_or_max_size(d) as i64)
                     .collect();
-                let trt_io_name = Self::engine_binding_name(operand_id as u32);
+                let trt_io_name = io_binding_names
+                    .get(&(operand_id as u32))
+                    .cloned()
+                    .unwrap_or_else(|| Self::engine_binding_name(operand_id as u32));
 
                 let tensor = network.add_input(&trt_io_name, dtype, &dims).map_err(|e| {
                     GraphError::ConversionFailed {
@@ -539,7 +585,10 @@ impl TrtxConverter {
                     }
                 })?;
 
-                let trt_io_name = Self::engine_binding_name(operand_id as u32);
+                let trt_io_name = io_binding_names
+                    .get(&(operand_id as u32))
+                    .cloned()
+                    .unwrap_or_else(|| Self::engine_binding_name(operand_id as u32));
                 let _ = tensor.set_name(network, &trt_io_name);
 
                 network.mark_output(tensor);
@@ -12658,6 +12707,79 @@ mod tests {
             TrtxConverter::engine_binding_name(42).as_str(),
             "webnn_operand_42"
         );
+    }
+
+    #[test]
+    fn test_engine_io_binding_names_use_operand_names() {
+        use crate::graph::{Operand, OperandDescriptor, OperandKind};
+        use crate::graph::to_dimension_vector;
+        let desc = OperandDescriptor {
+            data_type: DataType::Float32,
+            shape: to_dimension_vector(&[1, 1]),
+            pending_permutation: vec![],
+        };
+        let graph = GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: desc.clone(),
+                    name: Some("lhs".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Constant,
+                    descriptor: desc.clone(),
+                    name: Some("c".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: desc,
+                    name: Some("sum".to_string()),
+                },
+            ],
+            input_operands: vec![0],
+            output_operands: vec![2],
+            operations: vec![],
+            constant_operand_ids_to_handles: Default::default(),
+            id_to_constant_tensor_operand_map: Default::default(),
+            quantized: false,
+        };
+        let m = TrtxConverter::engine_io_binding_names(&graph);
+        assert_eq!(m.get(&0).map(String::as_str), Some("lhs"));
+        assert_eq!(m.get(&2).map(String::as_str), Some("sum"));
+    }
+
+    #[test]
+    fn test_engine_io_binding_names_duplicate_disambiguation() {
+        use crate::graph::{Operand, OperandDescriptor, OperandKind};
+        use crate::graph::to_dimension_vector;
+        let desc = OperandDescriptor {
+            data_type: DataType::Float32,
+            shape: to_dimension_vector(&[1]),
+            pending_permutation: vec![],
+        };
+        let graph = GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: desc.clone(),
+                    name: Some("x".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: desc,
+                    name: Some("x".to_string()),
+                },
+            ],
+            input_operands: vec![0, 1],
+            output_operands: vec![],
+            operations: vec![],
+            constant_operand_ids_to_handles: Default::default(),
+            id_to_constant_tensor_operand_map: Default::default(),
+            quantized: false,
+        };
+        let m = TrtxConverter::engine_io_binding_names(&graph);
+        assert_eq!(m.get(&0).map(String::as_str), Some("x_0"));
+        assert_eq!(m.get(&1).map(String::as_str), Some("x_1"));
     }
 
     /// HWIO -> OIHW transpose: perm (3,2,0,1) => output[o,i,h,w] = input[h,w,i,o].

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,13 @@ use crate::graph::DataType;
 use serde_json::Error as JsonError;
 use thiserror::Error;
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("No backend is avaialbel for context creation")]
+    NoBackendAvialable,
+
     #[error("Lost MLContext: {0}")]
     MLContextLost(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     NoBackendAvialable,
 
     #[error("Lost MLContext: {0}")]
-    MLContextLost(String),
+    ContextLost(String),
 
     // TODO: this error can at moment also occur in other situations than conversion. We should make
     // GraphError more specific to graph conversion
@@ -24,7 +24,16 @@ pub enum Error {
 
     #[error("Failed to run inference: {source}")]
     InferenceError {
-        #[from]
+        source: Box<dyn std::error::Error>,
+    },
+
+    #[error("Failed to create context: {source}")]
+    ContextCreationError {
+        source: Box<dyn std::error::Error>,
+    },
+
+    #[error("Failed to create builder: {source}")]
+    BuilderCreationError {
         source: Box<dyn std::error::Error>,
     },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,9 +20,15 @@ pub enum Error {
     // TODO: this error can at moment also occur in other situations than conversion. We should make
     // GraphError more specific to graph conversion
     #[error("Failed to convert graph: {source}")]
-    GraphBuildError {
+    GraphConversionError {
         #[from]
         source: GraphError,
+    },
+
+    #[error("Failed to convert graph: {source}")]
+    GraphBuildError {
+        #[from]
+        source: Box<dyn std::error::Error>,
     },
 
     #[error("Failed to run inference: {source}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use crate::graph::DataType;
+use crate::{
+    graph::DataType,
+    mlcontext::{MLTensor, MLTensorDescriptor},
+};
 use serde_json::Error as JsonError;
 use thiserror::Error;
 
@@ -23,18 +26,30 @@ pub enum Error {
     },
 
     #[error("Failed to run inference: {source}")]
-    InferenceError {
-        source: Box<dyn std::error::Error>,
-    },
+    InferenceError { source: Box<dyn std::error::Error> },
 
     #[error("Failed to create context: {source}")]
-    ContextCreationError {
-        source: Box<dyn std::error::Error>,
-    },
+    ContextCreationError { source: Box<dyn std::error::Error> },
 
     #[error("Failed to create builder: {source}")]
-    BuilderCreationError {
+    BuilderCreationError { source: Box<dyn std::error::Error> },
+
+    #[error("Failed to tensor: {source}")]
+    TensorCreationError {
         source: Box<dyn std::error::Error>,
+        descriptor: MLTensorDescriptor,
+    },
+
+    #[error("Failed to write tensor: {source}")]
+    TensorWriteError {
+        source: Box<dyn std::error::Error>,
+        tensor: MLTensor,
+    },
+
+    #[error("Failed to read tensor: {source}")]
+    TensorReadError {
+        source: Box<dyn std::error::Error>,
+        tensor: MLTensor,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     // TODO: this error can at moment also occur in other situations than conversion. We should make
     // GraphError more specific to graph conversion
     #[error("Failed to convert graph: {source}")]
-    GraphError {
+    GraphBuildError {
         #[from]
         source: GraphError,
     },
@@ -50,6 +50,11 @@ pub enum Error {
     TensorReadError {
         source: Box<dyn std::error::Error>,
         tensor: MLTensor,
+    },
+
+    #[error("Failed to dispatch graph: {source}")]
+    GraphDispatchError {
+        source: Box<dyn std::error::Error>,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,26 @@ use serde_json::Error as JsonError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+pub enum Error {
+    #[error("Lost MLContext: {0}")]
+    MLContextLost(String),
+
+    // TODO: this error can at moment also occur in other situations than conversion. We should make
+    // GraphError more specific to graph conversion
+    #[error("Failed to convert graph: {source}")]
+    GraphError {
+        #[from]
+        source: GraphError,
+    },
+
+    #[error("Failed to run inference: {source}")]
+    InferenceError {
+        #[from]
+        source: Box<dyn std::error::Error>,
+    },
+}
+
+#[derive(Debug, Error)]
 pub enum GraphError {
     #[error("graph file {path} could not be read: {source}")]
     Io {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     #[error("No backend is avaialbel for context creation")]
     NoBackendAvialable,
 
+    #[error("No device of selected type available")]
+    NoDeviceAvailable,
+
     #[error("Lost MLContext: {0}")]
     ContextLost(String),
 
@@ -59,9 +62,7 @@ pub enum Error {
     },
 
     #[error("Failed to dispatch graph: {source}")]
-    GraphDispatchError {
-        source: Box<dyn std::error::Error>,
-    },
+    GraphDispatchError { source: Box<dyn std::error::Error> },
 }
 
 #[derive(Debug, Error)]

--- a/src/executors/onnx.rs
+++ b/src/executors/onnx.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Once;
 
+use log::{error, info};
 use ndarray::{ArrayD, IxDyn};
 use ort::session::SessionInputValue;
 
@@ -19,9 +20,10 @@ use crate::runtime_checks::{RuntimeShapeState, TensorKind, validate_shape_data_l
 
 static INIT: Once = Once::new();
 
-fn ensure_ort_initialized() -> Result<(), GraphError> {
+pub(crate) fn ensure_ort_initialized() -> Result<(), GraphError> {
     let mut result = Ok(());
     INIT.call_once(|| {
+        info!("Loading onnxruntime");
         let success = ort::init()
             .with_name("rustnn")
             .with_execution_providers([
@@ -30,6 +32,7 @@ fn ensure_ort_initialized() -> Result<(), GraphError> {
             .commit();
 
         if !success {
+            error!("Failed to load onnxruntime");
             result = Err(GraphError::OnnxRuntimeFailed {
                 reason: "ort init failed - unable to initialize ONNX Runtime".to_string(),
             });

--- a/src/executors/onnx.rs
+++ b/src/executors/onnx.rs
@@ -6,6 +6,7 @@ use std::sync::Once;
 
 use log::{error, info};
 use ndarray::{ArrayD, IxDyn};
+use ort::environment::Environment;
 use ort::session::SessionInputValue;
 
 use half;
@@ -27,7 +28,9 @@ pub(crate) fn ensure_ort_initialized() -> Result<(), GraphError> {
         let success = ort::init()
             .with_name("rustnn")
             .with_execution_providers([
-                ort::execution_providers::CPUExecutionProvider::default().build()
+                ort::ep::CPUExecutionProvider::default().build(),
+                //ort::ep::NVRTXExecutionProvider::default().build(),
+                //ort::ep::CUDAExecutionProvider::default().build(),
             ])
             .commit();
 
@@ -37,6 +40,11 @@ pub(crate) fn ensure_ort_initialized() -> Result<(), GraphError> {
                 reason: "ort init failed - unable to initialize ONNX Runtime".to_string(),
             });
         }
+        let env = Environment::current();
+        if let Ok(env) = env {
+            env.set_log_level(ort::logging::LogLevel::Verbose);
+        }
+        info!("Loaded");
     });
     result
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -8,6 +8,7 @@ use std::sync::Once;
 
 use crate::error::{Error, GraphError};
 use crate::graph::{OperandDescriptor, get_static_or_max_size};
+use crate::mlcontext::ListDevices;
 use crate::mlcontext::MLBackendBuilder;
 use crate::mlcontext::MLBackendContext;
 
@@ -366,7 +367,8 @@ impl std::fmt::Debug for TrtxContext<'_> {
 }
 
 // TODO: should make logger static or remove from API. It is anyway a global for TRT
-static LOGGER: trtx::Logger = trtx::Logger::log_crate().unwrap();
+static LOGGER: std::sync::LazyLock<trtx::Logger> =
+    std::sync::LazyLock::new(|| trtx::Logger::log_crate().unwrap());
 
 impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
@@ -383,7 +385,7 @@ impl<'context> TrtxContext<'context> {
 }
 
 pub(crate) struct TrtxBuilder<'builder> {
-    builder: trtx::NetworkDefinition<'builder>,
+    network: trtx::NetworkDefinition<'builder>,
 }
 impl std::fmt::Debug for TrtxBuilder<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -398,21 +400,51 @@ impl MLBackendBuilder<'_> for TrtxBuilder<'_> {
     }
 }
 
-impl<'context> MLBackendContext for TrtxContext<'context> {
+impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     fn accelerated(&self) -> bool {
         true
     }
 
     fn create_builder(
         &'_ mut self,
-    ) -> crate::error::Result<Box<dyn crate::mlcontext::MLBackendBuilder<'context>>> {
-        let builder = self
+    ) -> crate::error::Result<Box<dyn crate::mlcontext::MLBackendBuilder<'context> + 'context>>
+    {
+        let network = self
             .builder
             .create_network(0)
             .map_err(|e| Error::BuilderCreationError {
                 source: Box::new(e),
             })?;
-        Ok(Box::new(TrtxBuilder { builder }))
+        //self.networks.push(network);
+        Ok(Box::new(TrtxBuilder { network }))
+    }
+}
+
+impl ListDevices for dyn MLBackendContext<'_> {
+    fn list_devices() -> Vec<crate::backend_selection::BackendDevice> {
+        let Ok(device_count) = CudaContext::device_count() else {
+            return Vec::new();
+        };
+
+        let mut devices = Vec::new();
+        for cuda_device_idx in 0..device_count {
+            let Ok(cuda_ctx) = CudaContext::new(cuda_device_idx as usize) else {
+                continue;
+            };
+
+            let Ok((major, minor)) = cuda_ctx.compute_capability() else {
+                continue;
+            };
+
+            // Accept Ampere+ devices only (compute capability >= 8.0).
+            if major > 8 || (major == 8 && minor >= 0) {
+                devices.push(crate::backend_selection::BackendDevice::TrtxRuntime {
+                    cuda_device_idx: cuda_device_idx as u32,
+                });
+            }
+        }
+
+        devices
     }
 }
 

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,10 +1,9 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
-use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError};
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError, result, sys};
 use log::info;
 use log::trace;
 use log::warn;
-use ort::logging::Logger;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Once;
@@ -427,24 +426,44 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
 impl ListDevices for TrtxContext<'_> {
     fn list_devices() -> Vec<crate::backend_selection::BackendDevice> {
         trace!("Enumerating Trtx devices");
-        let Ok(device_count) = CudaContext::device_count() else {
+        let Ok(()) = result::init() else {
             warn!("Could not enumerate CUDA devices for TensorRT RTX");
+            return Vec::new();
+        };
+        let Ok(device_count) = result::device::get_count() else {
+            warn!("Could not get CUDA device count for TensorRT RTX");
             return Vec::new();
         };
 
         let mut devices = Vec::new();
         for cuda_device_idx in 0..device_count {
-            let Ok(cuda_ctx) = CudaContext::new(cuda_device_idx as usize) else {
+            let Ok(device) = result::device::get(cuda_device_idx) else {
                 continue;
             };
 
-            let Ok((major, minor)) = cuda_ctx.compute_capability() else {
+            // SAFETY: `device` is returned by `result::device::get`, so it is a valid CUdevice.
+            let Ok(major) = (unsafe {
+                result::device::get_attribute(
+                    device,
+                    sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+                )
+            }) else {
+                continue;
+            };
+
+            // SAFETY: `device` is returned by `result::device::get`, so it is a valid CUdevice.
+            let Ok(minor) = (unsafe {
+                result::device::get_attribute(
+                    device,
+                    sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+                )
+            }) else {
                 continue;
             };
 
             // Accept Ampere+ devices only (compute capability >= 8.0).
             if major > 8 || (major == 8 && minor >= 0) {
-                devices.push(crate::backend_selection::BackendDevice::TrtxRuntime {
+                devices.push(crate::backend_selection::BackendDevice::TrtxDevice {
                     cuda_device_idx: cuda_device_idx as u32,
                 });
             }
@@ -468,7 +487,11 @@ mod tests {
     #[test]
     #[cfg(feature = "trtx-runtime")]
     fn test_context_creation() {
-        use crate::executors::trtx::TrtxContext;
-        TrtxContext::new(0).unwrap();
+        let _ = pretty_env_logger::try_init();
+        use crate::{executors::trtx::TrtxContext, mlcontext::ListDevices};
+        let devices = TrtxContext::list_devices();
+        if let [first, ..] = devices.as_slice() {
+            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap();
+        }
     }
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,12 +1,17 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError, result, sys};
+use cudarc::driver::{CudaEvent, DevicePtrMut};
+use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
 use std::collections::HashMap;
+use std::ffi::c_void;
 use std::sync::Arc;
 use std::sync::Once;
+use trtx::CudaEngine;
+use trtx::ExecutionContext;
 
 use crate::error::{Error, GraphError};
 use crate::graph::{OperandDescriptor, get_static_or_max_size};
@@ -32,6 +37,59 @@ pub enum TrtxError {
     },
 }
 pub type TrtxResult<T> = std::result::Result<T, TrtxError>;
+
+trait ToDispatchResult<T> {
+    fn to_dispatch_result(self) -> crate::error::Result<T>;
+}
+
+impl<T> ToDispatchResult<T> for trtx::Result<T> {
+    fn to_dispatch_result(self) -> crate::error::Result<T> {
+        self.map_err(|e| crate::error::Error::GraphDispatchError { source: e.into() })
+    }
+}
+impl<T> ToDispatchResult<T> for std::result::Result<T, DriverError> {
+    fn to_dispatch_result(self) -> crate::error::Result<T> {
+        self.map_err(|e| crate::error::Error::GraphDispatchError { source: e.into() })
+    }
+}
+
+trait ToReadTensorResult<T> {
+    fn to_read_tensor_result(
+        self,
+        get_tensor: impl FnOnce() -> MLTensor,
+    ) -> crate::error::Result<T>;
+}
+
+impl<T> ToReadTensorResult<T> for std::result::Result<T, DriverError> {
+    fn to_read_tensor_result(
+        self,
+        get_tensor: impl FnOnce() -> MLTensor,
+    ) -> crate::error::Result<T> {
+        self.map_err(|e| crate::error::Error::TensorReadError {
+            source: Box::new(e),
+            tensor: get_tensor(),
+        })
+    }
+}
+
+trait ToWriteTensorResult<T> {
+    fn to_write_tensor_result(
+        self,
+        get_tensor: impl FnOnce() -> MLTensor,
+    ) -> crate::error::Result<T>;
+}
+
+impl<T> ToWriteTensorResult<T> for std::result::Result<T, DriverError> {
+    fn to_write_tensor_result(
+        self,
+        get_tensor: impl FnOnce() -> MLTensor,
+    ) -> crate::error::Result<T> {
+        self.map_err(|e| crate::error::Error::TensorWriteError {
+            source: Box::new(e),
+            tensor: get_tensor(),
+        })
+    }
+}
 
 /// Bytes per element for TensorRT tensor data types (used for buffer sizing).
 fn trt_dtype_bytes_per_element(dtype: &trtx::DataType) -> usize {
@@ -344,6 +402,22 @@ pub fn run_trtx_with_inputs(
     })
 }
 
+pub(crate) struct TrtxGraph<'context> {
+    engine: CudaEngine<'context>,
+    exec: ExecutionContext<'context>,
+    cuda_stream: CudaStream,
+}
+
+impl std::fmt::Debug for TrtxGraph<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrtxGraph")
+            .field("engine", &"")
+            .field("exec", &self.exec.name())
+            .field("cuda_stream", &self.cuda_stream)
+            .finish()
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct TrtxTensor {
     // todo: make all allocs owned by backend, only have view here
@@ -353,6 +427,7 @@ pub(crate) struct TrtxTensor {
 
 impl TrtxTensor {
     fn new(cuda_ctx: &Arc<CudaContext>, size: usize) -> TrtxResult<Self> {
+        debug!("Allocating CUDA tensor of size {size}");
         let stream = cuda_ctx.new_stream()?;
         let memory = stream.alloc_zeros(size)?;
         Ok(Self { memory, stream })
@@ -362,6 +437,7 @@ impl TrtxTensor {
 pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
     tensors: Vec<TrtxTensor>,
+    events: Vec<CudaEvent>,
     runtime: trtx::Runtime<'context>,
     builder: trtx::Builder<'context>,
 }
@@ -387,9 +463,11 @@ impl<'context> TrtxContext<'context> {
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
         let builder = trtx::Builder::new(&LOGGER)?;
         let runtime = trtx::Runtime::new(&LOGGER)?;
+        debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
             tensors: vec![],
+            events: vec![],
             runtime,
             builder,
         })
@@ -406,9 +484,9 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
     }
 }
 
-impl MLBackendBuilder<'_> for TrtxBuilder<'_> {
+impl<'context> MLBackendBuilder<'context> for TrtxBuilder<'context> {
     /*async */
-    fn build(&self) -> crate::error::Result<crate::mlcontext::MLGraph> {
+    fn build(&self) -> crate::error::Result<crate::mlcontext::MLGraph<'context>> {
         todo!()
     }
 }
@@ -480,10 +558,10 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         let stream = &cuda_tensor.stream;
         stream
             .memcpy_dtoh(&cuda_tensor.memory, array)
-            .map_err(|e| crate::error::Error::TensorReadError {
-                source: e.into(),
-                tensor: tensor.clone(),
-            })?;
+            .to_read_tensor_result(|| tensor.clone())?;
+        stream
+            .synchronize()
+            .to_read_tensor_result(|| tensor.clone())?;
         Ok(())
     }
 
@@ -496,10 +574,65 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         let stream = &cuda_tensor.stream;
         stream
             .memcpy_htod(array, &mut cuda_tensor.memory)
-            .map_err(|e| crate::error::Error::TensorWriteError {
-                source: e.into(),
-                tensor: tensor.clone(),
-            })?;
+            .to_write_tensor_result(|| tensor.clone())?;
+        Ok(())
+    }
+
+    fn dispatch(
+        &mut self,
+        graph: &mut crate::mlcontext::MLGraph,
+        inputs: &HashMap<&str, MLTensor>,
+        outputs: &HashMap<&str, MLTensor>,
+    ) -> crate::error::Result<()> {
+        let graph = graph
+            .backend
+            .as_trtx_engine_mut()
+            .expect("Passed a graph that is not a Trtx engine to a TensorRT context");
+        // TODO: just create a u64 device value for cudastreamwaitvalue64?
+        let inference_stream = &graph.cuda_stream;
+
+        for (input, tensor) in inputs.iter() {
+            let cuda_tensor = &mut self.tensors[tensor.id];
+
+            let (ptr, _) = cuda_tensor.memory.device_ptr_mut(&cuda_tensor.stream);
+            unsafe {
+                graph
+                    .exec
+                    .set_input_tensor_address(input, ptr as *mut c_void)
+                    .to_dispatch_result()?
+            };
+            let event = cuda_tensor.stream.record_event(None).to_dispatch_result()?;
+            inference_stream.wait(&event).to_dispatch_result()?;
+            self.events.push(event);
+        }
+        for (output, tensor) in outputs.iter() {
+            let cuda_tensor = &mut self.tensors[tensor.id];
+
+            let (ptr, _) = cuda_tensor.memory.device_ptr_mut(&cuda_tensor.stream);
+            unsafe {
+                graph
+                    .exec
+                    .set_output_tensor_address(output, ptr as *mut c_void)
+                    .to_dispatch_result()?
+            };
+        }
+
+        unsafe {
+            graph
+                .exec
+                .enqueue_v3(inference_stream.cu_stream() as *mut c_void)
+                .to_dispatch_result()?
+        };
+        let inference_done = inference_stream.record_event(None).to_dispatch_result()?;
+        for (_output, tensor) in outputs.iter() {
+            let cuda_tensor = &mut self.tensors[tensor.id];
+            cuda_tensor
+                .stream
+                .wait(&inference_done)
+                .to_dispatch_result()?;
+        }
+        self.events.push(inference_done);
+
         Ok(())
     }
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,5 +1,6 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
+use clap::builder;
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError, result, sys};
 use cudarc::driver::{CudaEvent, DevicePtrMut};
 use log::debug;
@@ -8,17 +9,20 @@ use log::trace;
 use log::warn;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::sync::Arc;
+use std::rc::Rc;
 use std::sync::Once;
-use trtx::CudaEngine;
-use trtx::ExecutionContext;
+use std::sync::{Arc, Mutex};
+use trtx::{CudaEngine, Tensor, network};
+use trtx::{ExecutionContext, OnnxParser};
 
+use crate::GraphInfo;
+use crate::converters::TrtxConverter;
 use crate::error::{Error, GraphError};
 use crate::graph::{OperandDescriptor, get_static_or_max_size};
-use crate::mlcontext::ListDevices;
-use crate::mlcontext::MLBackendBuilder;
-use crate::mlcontext::MLBackendContext;
 use crate::mlcontext::MLTensor;
+use crate::mlcontext::{ListDevices, MLOperand};
+use crate::mlcontext::{MLBackendBuilder, MLGraph};
+use crate::mlcontext::{MLBackendContext, MLBackendGraph};
 
 // Reexport to allow downstream users (e.g. pywebnn) to set path to TensorRT RTX lib
 pub use trtx::dynamically_load_tensorrt;
@@ -38,6 +42,8 @@ pub enum TrtxError {
 }
 pub type TrtxResult<T> = std::result::Result<T, TrtxError>;
 
+// TODO: the mapping to GraphDispatchError/TensorReadError/TensorWriteError
+// should be done for all backends in mlcontext.rs
 trait ToDispatchResult<T> {
     fn to_dispatch_result(self) -> crate::error::Result<T>;
 }
@@ -405,7 +411,7 @@ pub fn run_trtx_with_inputs(
 pub(crate) struct TrtxGraph<'context> {
     engine: CudaEngine<'context>,
     exec: ExecutionContext<'context>,
-    cuda_stream: CudaStream,
+    cuda_stream: Arc<CudaStream>,
 }
 
 impl std::fmt::Debug for TrtxGraph<'_> {
@@ -438,8 +444,9 @@ pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
     tensors: Vec<TrtxTensor>,
     events: Vec<CudaEvent>,
-    runtime: trtx::Runtime<'context>,
-    builder: trtx::Builder<'context>,
+    runtime: Rc<Mutex<trtx::Runtime<'context>>>,
+    config: Rc<Mutex<trtx::BuilderConfig>>, // needs to be destroyed before builder
+    builder: Rc<Mutex<trtx::Builder<'context>>>,
 }
 
 impl std::fmt::Debug for TrtxContext<'_> {
@@ -461,15 +468,17 @@ impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
         // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
-        let builder = trtx::Builder::new(&LOGGER)?;
-        let runtime = trtx::Runtime::new(&LOGGER)?;
+        let mut builder = trtx::Builder::new(&LOGGER)?;
+        let config = Rc::new(builder.create_config()?.into());
+        let runtime = Rc::new(trtx::Runtime::new(&LOGGER)?.into());
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
             tensors: vec![],
             events: vec![],
             runtime,
-            builder,
+            builder: Rc::new(builder.into()),
+            config,
         })
     }
 }
@@ -477,6 +486,12 @@ impl<'context> TrtxContext<'context> {
 #[allow(dead_code)]
 pub(crate) struct TrtxBuilder<'builder> {
     network: trtx::NetworkDefinition<'builder>,
+    builder: Rc<Mutex<trtx::Builder<'builder>>>,
+    config: Rc<Mutex<trtx::BuilderConfig>>,
+    cuda_context: Arc<CudaContext>,
+    runtime: Rc<Mutex<trtx::Runtime<'builder>>>,
+    _tensors: Vec<Tensor<'builder>>,
+    //_parser: Option<OnnxParser<'builder>>,
 }
 impl std::fmt::Debug for TrtxBuilder<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -486,8 +501,51 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
 
 impl<'context> MLBackendBuilder<'context> for TrtxBuilder<'context> {
     /*async */
-    fn build(&self) -> crate::error::Result<crate::mlcontext::MLGraph<'context>> {
-        todo!()
+    fn build(
+        &mut self,
+        _outputs: &HashMap<&str, MLOperand>,
+    ) -> crate::error::Result<crate::mlcontext::MLGraph<'context>> {
+        // TODO: keep track of id->tensor during building via builder API and also get this mapping
+        // from converter API
+
+        //for (name, tensor) in outputs.iter() {
+        //let trt_tensor = self.network.get_te
+        // unset all outputs, then set outputs according to MLOperands
+        //}
+
+        let host_mem = self
+            .builder
+            .lock()
+            .unwrap()
+            .build_serialized_network(&mut self.network, &mut self.config.lock().unwrap())
+            .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+
+        let mut engine = self
+            .runtime
+            .lock()
+            .unwrap()
+            .deserialize_cuda_engine(&host_mem)
+            .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+
+        // make the right context current
+        let exec = engine
+            .create_execution_context()
+            .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+
+        Ok(MLGraph {
+            backend: MLBackendGraph::TrtxEngine(TrtxGraph {
+                engine,
+                exec,
+                cuda_stream: self
+                    .cuda_context
+                    .new_stream()
+                    .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?,
+            }),
+        })
+    }
+
+    fn load_graph(&mut self, graph: &'context GraphInfo) -> crate::error::Result<()> {
+        TrtxConverter::build_network(graph, &mut self.network).map_err(|e| e.into())
     }
 }
 
@@ -503,12 +561,21 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     {
         let network = self
             .builder
+            .lock()
+            .unwrap()
             .create_network(0)
             .map_err(|e| Error::BuilderCreationError {
                 source: Box::new(e),
             })?;
         //self.networks.push(network);
-        Ok(Box::new(TrtxBuilder { network }))
+        Ok(Box::new(TrtxBuilder {
+            network,
+            builder: Rc::clone(&self.builder),
+            config: Rc::clone(&self.config),
+            runtime: Rc::clone(&self.runtime),
+            cuda_context: Arc::clone(&self.cuda_ctx),
+            _tensors: vec![],
+        }))
     }
 
     fn create_tensor(

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -13,6 +13,7 @@ use crate::graph::{OperandDescriptor, get_static_or_max_size};
 use crate::mlcontext::ListDevices;
 use crate::mlcontext::MLBackendBuilder;
 use crate::mlcontext::MLBackendContext;
+use crate::mlcontext::MLTensor;
 
 // Reexport to allow downstream users (e.g. pywebnn) to set path to TensorRT RTX lib
 pub use trtx::dynamically_load_tensorrt;
@@ -347,7 +348,15 @@ pub fn run_trtx_with_inputs(
 pub(crate) struct TrtxTensor {
     // todo: make all allocs owned by backend, only have view here
     memory: CudaSlice<u8>,
-    stream: CudaStream,
+    stream: Arc<CudaStream>,
+}
+
+impl TrtxTensor {
+    fn new(cuda_ctx: &Arc<CudaContext>, size: usize) -> TrtxResult<Self> {
+        let stream = cuda_ctx.new_stream()?;
+        let memory = stream.alloc_zeros(size)?;
+        Ok(Self { memory, stream })
+    }
 }
 
 pub(crate) struct TrtxContext<'context> {
@@ -387,6 +396,7 @@ impl<'context> TrtxContext<'context> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct TrtxBuilder<'builder> {
     network: trtx::NetworkDefinition<'builder>,
 }
@@ -403,6 +413,7 @@ impl MLBackendBuilder<'_> for TrtxBuilder<'_> {
     }
 }
 
+#[allow(unused_variables)]
 impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     fn accelerated(&self) -> bool {
         true
@@ -420,6 +431,76 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             })?;
         //self.networks.push(network);
         Ok(Box::new(TrtxBuilder { network }))
+    }
+
+    fn create_tensor(
+        &mut self,
+        descriptor: &crate::mlcontext::MLTensorDescriptor,
+    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
+        let bits = descriptor.data_type().element_size_bits();
+        let elements = descriptor.shape().iter().copied().product::<u64>() as usize;
+        let size = bits * elements / 8;
+
+        let tensor = TrtxTensor::new(&self.cuda_ctx, size).map_err(|e| {
+            crate::error::Error::TensorCreationError {
+                source: e.into(),
+                descriptor: descriptor.clone(),
+            }
+        })?;
+        self.tensors.push(tensor);
+        Ok(MLTensor {
+            id: self.tensors.len() - 1,
+            constant: false,
+            descriptor: descriptor.clone(),
+        })
+    }
+
+    fn create_constant_tensor(
+        &mut self,
+        descriptor: &crate::mlcontext::MLTensorDescriptor,
+        input_data: &[u8],
+    ) -> crate::error::Result<crate::mlcontext::MLTensor> {
+        let mut tensor = self.create_tensor(descriptor)?;
+        tensor.constant = true;
+        self.write_tensor(&tensor, input_data).map_err(|e| {
+            crate::error::Error::TensorCreationError {
+                source: e.into(),
+                descriptor: descriptor.clone(),
+            }
+        })?; // need to free tensor in case of error
+        Ok(tensor)
+    }
+
+    fn read_tensor(
+        &mut self,
+        tensor: &crate::mlcontext::MLTensor,
+        array: &mut [u8],
+    ) -> crate::error::Result<()> {
+        let cuda_tensor = &self.tensors[tensor.id];
+        let stream = &cuda_tensor.stream;
+        stream
+            .memcpy_dtoh(&cuda_tensor.memory, array)
+            .map_err(|e| crate::error::Error::TensorReadError {
+                source: e.into(),
+                tensor: tensor.clone(),
+            })?;
+        Ok(())
+    }
+
+    fn write_tensor(
+        &mut self,
+        tensor: &crate::mlcontext::MLTensor,
+        array: &[u8],
+    ) -> crate::error::Result<()> {
+        let cuda_tensor = &mut self.tensors[tensor.id];
+        let stream = &cuda_tensor.stream;
+        stream
+            .memcpy_htod(array, &mut cuda_tensor.memory)
+            .map_err(|e| crate::error::Error::TensorWriteError {
+                source: e.into(),
+                tensor: tensor.clone(),
+            })?;
+        Ok(())
     }
 }
 
@@ -475,23 +556,87 @@ impl ListDevices for TrtxContext<'_> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "trtx-runtime")]
 mod tests {
-    #[test]
-    #[cfg(feature = "trtx-runtime-mock")]
-    fn test_trtx_executor_availability() {
-        // This test just verifies the module compiles in mock mode
-        // Real execution tests would require actual ONNX models
-        assert!(true, "TensorRT executor module compiled successfully");
-    }
+    use crate::mlcontext::{MLBackendContext, MLTensorDescriptor};
+    use crate::{executors::trtx::TrtxContext, mlcontext::ListDevices};
 
     #[test]
-    #[cfg(feature = "trtx-runtime")]
     fn test_context_creation() {
         let _ = pretty_env_logger::try_init();
         use crate::{executors::trtx::TrtxContext, mlcontext::ListDevices};
         let devices = TrtxContext::list_devices();
-        if let [first, ..] = devices.as_slice() {
-            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap();
-        }
+        let context = if let [first, ..] = devices.as_slice() {
+            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+        } else {
+            return;
+        };
+
+        assert!(context.accelerated());
+    }
+
+    #[test]
+    fn test_builder() {
+        let _ = pretty_env_logger::try_init();
+        let devices = TrtxContext::list_devices();
+        let mut context = if let [first, ..] = devices.as_slice() {
+            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+        } else {
+            return;
+        };
+
+        let _builder = context.create_builder().unwrap();
+    }
+
+    #[test]
+    fn test_create_tensors() {
+        let _ = pretty_env_logger::try_init();
+        let devices = TrtxContext::list_devices();
+        let mut context = if let [first, ..] = devices.as_slice() {
+            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+        } else {
+            return;
+        };
+
+        let mut desc = MLTensorDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+        desc.set_readable(true);
+        desc.set_writable(true);
+        let tensor = context.create_tensor(&desc).unwrap();
+
+        let upload = vec![1.0f32, 2., 3., 4.];
+        let mut download = vec![0.0f32; 4];
+        context
+            .write_tensor(&tensor, bytemuck::cast_slice(&upload))
+            .unwrap();
+        context
+            .read_tensor(&tensor, bytemuck::cast_slice_mut(&mut download))
+            .unwrap();
+        assert_eq!(&upload, &download);
+    }
+
+    #[test]
+    #[should_panic = "assertion failed: dst.len() >= src.len()"]
+    fn test_write_too_large_tensor() {
+        let _ = pretty_env_logger::try_init();
+        let devices = TrtxContext::list_devices();
+        let mut context = if let [first, ..] = devices.as_slice() {
+            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+        } else {
+            return;
+        };
+        let too_big = vec![0.0f32; 8];
+        let mut desc = MLTensorDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+        desc.set_readable(true);
+        desc.set_writable(true);
+        let tensor = context.create_tensor(&desc).unwrap();
+        context
+            .write_tensor(&tensor, bytemuck::cast_slice(&too_big))
+            .unwrap_err();
     }
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,6 +1,5 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
-use clap::builder;
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError, result, sys};
 use cudarc::driver::{CudaEvent, DevicePtrMut};
 use log::debug;

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -647,8 +647,8 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     fn dispatch(
         &mut self,
         graph: &mut crate::mlcontext::MLGraph,
-        inputs: &HashMap<&str, MLTensor>,
-        outputs: &HashMap<&str, MLTensor>,
+        inputs: &HashMap<&str, &MLTensor>,
+        outputs: &HashMap<&str, &MLTensor>,
     ) -> crate::error::Result<()> {
         let graph = graph
             .backend

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,13 +1,33 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError};
+use ort::logging::Logger;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::Once;
 
-use crate::error::GraphError;
+use crate::error::{Error, GraphError};
 use crate::graph::{OperandDescriptor, get_static_or_max_size};
+use crate::mlcontext::MLBackendBuilder;
+use crate::mlcontext::MLBackendContext;
 
 // Reexport to allow downstream users (e.g. pywebnn) to set path to TensorRT RTX lib
 pub use trtx::dynamically_load_tensorrt;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrtxError {
+    #[error("Cuda driver error: {source}")]
+    CudaError {
+        #[from]
+        source: DriverError,
+    },
+    #[error("TensorRT error: {source}")]
+    TrtxError {
+        #[from]
+        source: trtx::Error,
+    },
+}
+pub type TrtxResult<T> = std::result::Result<T, TrtxError>;
 
 /// Bytes per element for TensorRT tensor data types (used for buffer sizing).
 fn trt_dtype_bytes_per_element(dtype: &trtx::DataType) -> usize {
@@ -320,6 +340,82 @@ pub fn run_trtx_with_inputs(
     })
 }
 
+#[derive(Debug)]
+pub(crate) struct TrtxTensor {
+    // todo: make all allocs owned by backend, only have view here
+    memory: CudaSlice<u8>,
+    stream: CudaStream,
+}
+
+pub(crate) struct TrtxContext<'context> {
+    cuda_ctx: Arc<CudaContext>,
+    tensors: Vec<TrtxTensor>,
+    runtime: trtx::Runtime<'context>,
+    builder: trtx::Builder<'context>,
+}
+
+impl std::fmt::Debug for TrtxContext<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrtxContext")
+            .field("cuda_ctx", &self.cuda_ctx)
+            .field("tensors", &self.tensors)
+            //.field("logger", &self.logger)
+            //.field("runtime", &self.runtime)
+            .finish()
+    }
+}
+
+// TODO: should make logger static or remove from API. It is anyway a global for TRT
+static LOGGER: trtx::Logger = trtx::Logger::log_crate().unwrap();
+
+impl<'context> TrtxContext<'context> {
+    pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
+        let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
+        let builder = trtx::Builder::new(&LOGGER)?;
+        let runtime = trtx::Runtime::new(&LOGGER)?;
+        Ok(Self {
+            cuda_ctx,
+            tensors: vec![],
+            runtime,
+            builder,
+        })
+    }
+}
+
+pub(crate) struct TrtxBuilder<'builder> {
+    builder: trtx::NetworkDefinition<'builder>,
+}
+impl std::fmt::Debug for TrtxBuilder<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrtxBuilder").finish()
+    }
+}
+
+impl MLBackendBuilder<'_> for TrtxBuilder<'_> {
+    /*async */
+    fn build(&self) -> crate::error::Result<crate::mlcontext::MLGraph> {
+        todo!()
+    }
+}
+
+impl<'context> MLBackendContext for TrtxContext<'context> {
+    fn accelerated(&self) -> bool {
+        true
+    }
+
+    fn create_builder(
+        &'_ mut self,
+    ) -> crate::error::Result<Box<dyn crate::mlcontext::MLBackendBuilder<'context>>> {
+        let builder = self
+            .builder
+            .create_network(0)
+            .map_err(|e| Error::BuilderCreationError {
+                source: Box::new(e),
+            })?;
+        Ok(Box::new(TrtxBuilder { builder }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -328,5 +424,12 @@ mod tests {
         // This test just verifies the module compiles in mock mode
         // Real execution tests would require actual ONNX models
         assert!(true, "TensorRT executor module compiled successfully");
+    }
+
+    #[test]
+    #[cfg(feature = "trtx-runtime")]
+    fn test_context_creation() {
+        use crate::executors::trtx::TrtxContext;
+        TrtxContext::new(0).unwrap();
     }
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,6 +1,9 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DriverError};
+use log::info;
+use log::trace;
+use log::warn;
 use ort::logging::Logger;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -372,6 +375,7 @@ static LOGGER: std::sync::LazyLock<trtx::Logger> =
 
 impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
+        // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
         let builder = trtx::Builder::new(&LOGGER)?;
         let runtime = trtx::Runtime::new(&LOGGER)?;
@@ -420,9 +424,11 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     }
 }
 
-impl ListDevices for dyn MLBackendContext<'_> {
+impl ListDevices for TrtxContext<'_> {
     fn list_devices() -> Vec<crate::backend_selection::BackendDevice> {
+        trace!("Enumerating Trtx devices");
         let Ok(device_count) = CudaContext::device_count() else {
+            warn!("Could not enumerate CUDA devices for TensorRT RTX");
             return Vec::new();
         };
 
@@ -444,6 +450,7 @@ impl ListDevices for dyn MLBackendContext<'_> {
             }
         }
 
+        info!("Found Trtx devices {devices:?} from {device_count} CUDA devices");
         devices
     }
 }

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -11,8 +11,8 @@ use std::ffi::c_void;
 use std::rc::Rc;
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
-use trtx::{CudaEngine, Tensor, network};
-use trtx::{ExecutionContext, OnnxParser};
+use trtx::ExecutionContext;
+use trtx::{CudaEngine, Tensor};
 
 use crate::GraphInfo;
 use crate::converters::TrtxConverter;
@@ -408,7 +408,7 @@ pub fn run_trtx_with_inputs(
 }
 
 pub(crate) struct TrtxGraph<'context> {
-    engine: CudaEngine<'context>,
+    _engine: CudaEngine<'context>,
     exec: ExecutionContext<'context>,
     cuda_stream: Arc<CudaStream>,
 }
@@ -533,7 +533,7 @@ impl<'context> MLBackendBuilder<'context> for TrtxBuilder<'context> {
 
         Ok(MLGraph {
             backend: MLBackendGraph::TrtxEngine(TrtxGraph {
-                engine,
+                _engine: engine,
                 exec,
                 cuda_stream: self
                     .cuda_context

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -229,7 +229,7 @@ fn is_onnx_format(bytes: &[u8]) -> bool {
 /// This is useful for validation and testing graph structure
 ///
 /// For native WebNN [`crate::converters::TrtxConverter`] engines (not ONNX), input tensor names
-/// must be [`TrtxConverter::engine_binding_name`] for each graph input operand id.
+/// must match [`TrtxConverter::engine_io_tensor_name`] for each graph input operand id.
 ///
 /// If model_bytes appears to be ONNX format, it will be parsed as ONNX and built into an engine.
 /// Otherwise, it will be treated as a pre-serialized TensorRT engine.
@@ -408,8 +408,8 @@ pub fn run_trtx_with_inputs(
 }
 
 pub(crate) struct TrtxGraph<'context> {
-    _engine: CudaEngine<'context>,
     exec: ExecutionContext<'context>,
+    _engine: CudaEngine<'context>,
     cuda_stream: Arc<CudaStream>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod executors;
 pub mod graph;
 pub mod graphviz;
 pub mod loader;
+pub mod mlcontext;
 pub mod operator_enums;
 pub mod operator_options;
 pub mod operators;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backend_selection;
 pub mod converters;
 pub mod debug;
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod shape_inference;
 pub mod tensor;
 pub mod validator;
 pub mod webnn_json;
+pub mod backends;
 
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
 pub use executors::coreml;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend_selection;
+pub mod backends;
 pub mod converters;
 pub mod debug;
 pub mod error;
@@ -16,7 +17,6 @@ pub mod shape_inference;
 pub mod tensor;
 pub mod validator;
 pub mod webnn_json;
-pub mod backends;
 
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
 pub use executors::coreml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,9 +231,8 @@ fn run() -> Result<(), GraphError> {
                     format: converted.format.to_string(),
                 });
             }
-            // Native WebNN->TRT engines use `TrtxConverter::engine_binding_name(operand_id)` so TRT's
-            // QDQ optimizer does not match user names (e.g. WPT `quantizeLinearZeroPoint`). ONNX models
-            // keep protobuf I/O names from `artifacts`.
+            // Native WebNN->TRT engines use [`TrtxConverter::engine_io_tensor_name`] (operand names
+            // from the graph when set). ONNX models keep protobuf I/O names from `artifacts`.
             let inputs: Vec<rustnn::TrtxInput> = if converted.format == "trtx" {
                 let mut v = Vec::with_capacity(graph.input_operands.len());
                 for &op_id in &graph.input_operands {
@@ -259,7 +258,7 @@ fn run() -> Result<(), GraphError> {
                         .max(1);
                     let byte_len = total * desc.data_type.bytes_per_element();
                     v.push(rustnn::TrtxInput {
-                        name: TrtxConverter::engine_binding_name(op_id),
+                        name: TrtxConverter::engine_io_tensor_name(&graph, op_id),
                         data: vec![0u8; byte_len],
                     });
                 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -3,11 +3,12 @@
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
 use crate::executors::trtx::TrtxGraph;
 use crate::{
+    GraphInfo,
     backend_selection::BackendDevice,
     error::{Error, Result},
     executors::trtx::TrtxContext,
 };
-use std::{collections::HashMap, fmt::Display, io::Read};
+use std::{collections::HashMap, fmt::Display};
 
 use crate::{
     backend_selection::{select_backend, select_backend_by_gpu},
@@ -45,7 +46,8 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
 
 pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
     /*async*/
-    fn build(&self) -> Result<MLGraph<'context>>;
+    fn build(&mut self, outputs: &HashMap<&str, MLOperand>) -> Result<MLGraph<'context>>;
+    fn load_graph(&mut self, webnn: &'context GraphInfo) -> Result<()>;
 }
 
 // can be made a Box<dyn better_any::Tid<'context> + 'context> for dynamic dispatch
@@ -201,6 +203,11 @@ pub struct MLTensorDescriptor {
     writable: bool,
 }
 
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+pub struct MLOperand {
+    pub(crate) id: usize,
+}
+
 impl std::ops::Deref for MLTensorDescriptor {
     type Target = MLOperandDescriptor;
 
@@ -350,12 +357,13 @@ impl<'context> MLBuilder<'context> {
         Ok(Self { backend })
     }
 
-    fn load_webnn(webnn: impl Read) -> Result<()> {
-        Ok(())
+    fn load_graph(&mut self, graph: &'context GraphInfo) -> Result<()> {
+        self.backend.load_graph(graph)
     }
 
-    async fn build() -> Result<MLGraph<'context>> {
-        todo!()
+    /*async*/
+    fn build(&mut self, outputs: &HashMap<&str, MLOperand>) -> Result<MLGraph<'context>> {
+        self.backend.build(outputs)
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,4 +1,5 @@
 use crate::{
+    backend_selection::BackendDevice,
     error::{Error, Result},
     executors::trtx::TrtxContext,
 };
@@ -11,10 +12,13 @@ use crate::{
 
 // Backend traits
 
+pub(crate) trait ListDevices {
+    fn list_devices() -> Vec<BackendDevice>;
+}
 // could make public later if interface stabilized
-pub(crate) trait MLBackendContext: std::fmt::Debug {
+pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
     fn accelerated(&self) -> bool;
-    fn create_builder(&mut self) -> Result<Box<dyn MLBackendBuilder>>;
+    fn create_builder(&mut self) -> Result<Box<dyn MLBackendBuilder<'context> + 'context>>;
 }
 
 pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
@@ -186,23 +190,23 @@ impl MLTensorDescriptor {
 }
 
 #[derive(Debug)]
-pub struct MLContext {
-    backend: Box<dyn MLBackendContext>,
+pub struct MLContext<'context> {
+    backend: Box<dyn MLBackendContext<'context> + 'context>,
 }
 
-impl MLContext {
+impl<'context> MLContext<'context> {
     // those are methods on `create_context`
     pub async fn create(options: &MLContextOptions) -> Result<Self> {
         let desc = select_backend(options)?;
         let backend = match desc {
-            crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => Box::new(
+            crate::backend_selection::BackendDevice::OnnxRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::TrtxRuntime { cuda_device_idx } => Box::new(
                 TrtxContext::new(cuda_device_idx)
                     .map_err(|e| Error::ContextCreationError { source: e.into() })?,
             ),
-            crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDesc::WebNN => todo!(),
-            crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
+            crate::backend_selection::BackendDevice::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::WebNN => todo!(),
+            crate::backend_selection::BackendDevice::ExternalBackend => todo!(),
         };
         Ok(Self { backend })
     }
@@ -210,11 +214,11 @@ impl MLContext {
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
         let desc = select_backend_by_gpu(gpu_device)?;
         let backend = match desc {
-            crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => todo!(),
-            crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDesc::WebNN => todo!(),
-            crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
+            crate::backend_selection::BackendDevice::OnnxRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::TrtxRuntime { cuda_device_idx } => todo!(),
+            crate::backend_selection::BackendDevice::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::WebNN => todo!(),
+            crate::backend_selection::BackendDevice::ExternalBackend => todo!(),
         };
         Ok(Self { backend })
     }
@@ -256,22 +260,22 @@ impl MLContext {
         todo!()
     }
 
-    pub async fn read_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &mut [T]) {
+    pub async fn read_tensor<T>(&mut self, tensor: &MLTensor, array: &mut [T]) {
         todo!();
     }
 
-    pub async fn write_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &[T]) {
+    pub async fn write_tensor<T>(&mut self, tensor: &MLTensor, array: &[T]) {
         todo!();
     }
 }
 
 #[derive(Debug)]
 pub struct MLBuilder<'context> {
-    backend: Box<dyn MLBackendBuilder<'context>>,
+    backend: Box<dyn MLBackendBuilder<'context> + 'context>,
 }
 
 impl<'context> MLBuilder<'context> {
-    fn new(context: &'context mut MLContext) -> Result<Self> {
+    fn new(context: &'context mut MLContext<'context>) -> Result<Self> {
         let backend = context.backend.create_builder()?;
         Ok(Self { backend })
     }
@@ -308,6 +312,6 @@ mod test {
 
         let desc = MLTensorDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
         let op_desc = MLOperandDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
-        assert_eq!(desc.operand_descriptor(), op_desc);
+        assert_eq!(*desc.operand_descriptor(), op_desc);
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
+use log::info;
+
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
 use crate::executors::trtx::TrtxGraph;
 use crate::{
@@ -256,8 +258,10 @@ pub struct MLContext<'context> {
 
 impl<'context> MLContext<'context> {
     // those are methods on `create_context`
-    pub async fn create(options: &MLContextOptions) -> Result<Self> {
+    //pub async
+    pub fn create(options: &MLContextOptions) -> Result<Self> {
         let desc = select_backend(options)?;
+        info!("Backend selected: {desc:?}");
         let backend = match desc {
             crate::backend_selection::BackendDevice::OnnxDevice { device_type } => todo!(),
             crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => Box::new(
@@ -391,5 +395,16 @@ mod test {
         let desc = MLTensorDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
         let op_desc = MLOperandDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
         assert_eq!(*desc.operand_descriptor(), op_desc);
+    }
+
+    #[test]
+    fn test_create_context() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions {
+            power_preference: MLPowerPreference::Default,
+            accelerated: true,
+        })
+        .unwrap();
+        dbg!(&context);
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
+#[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+use crate::executors::trtx::TrtxGraph;
 use crate::{
     backend_selection::BackendDevice,
     error::{Error, Result},
@@ -33,11 +35,46 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
     fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<()>;
     /*async*/
     fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<()>;
+    fn dispatch(
+        &mut self,
+        graph: &mut MLGraph,
+        inputs: &HashMap<&str, MLTensor>,
+        outputs: &HashMap<&str, MLTensor>,
+    ) -> Result<()>;
 }
 
 pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
     /*async*/
-    fn build(&self) -> Result<MLGraph>;
+    fn build(&self) -> Result<MLGraph<'context>>;
+}
+
+// can be made a Box<dyn better_any::Tid<'context> + 'context> for dynamic dispatch
+// dyn Any does not work since Any requires 'static
+#[derive(Debug)]
+pub(crate) enum MLBackendGraph<'context> {
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+    TrtxEngine(TrtxGraph<'context>),
+    OnnxSession(),
+}
+
+impl<'context> MLBackendGraph<'context> {
+    pub(crate) fn as_trtx_engine(&self) -> Option<&TrtxGraph<'context>> {
+        if let Self::TrtxEngine(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'context> MLBackendGraph<'context> {
+    pub(crate) fn as_trtx_engine_mut(&mut self) -> Option<&mut TrtxGraph<'context>> {
+        if let Self::TrtxEngine(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 // types for MLContext
@@ -100,7 +137,9 @@ impl MLTensor {
 }
 
 #[derive(Debug)]
-pub struct MLGraph {}
+pub struct MLGraph<'context> {
+    pub(crate) backend: MLBackendGraph<'context>,
+}
 #[derive(Debug)]
 pub struct MLOpSupportLimits {}
 
@@ -315,7 +354,7 @@ impl<'context> MLBuilder<'context> {
         Ok(())
     }
 
-    async fn build() -> Result<MLGraph> {
+    async fn build() -> Result<MLGraph<'context>> {
         todo!()
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,5 +1,8 @@
-use crate::error::Result;
-use std::{collections::HashMap, fmt::Display};
+use crate::{
+    error::{Error, Result},
+    executors::trtx::TrtxContext,
+};
+use std::{collections::HashMap, fmt::Display, io::Read};
 
 use crate::{
     backend_selection::{select_backend, select_backend_by_gpu},
@@ -11,6 +14,12 @@ use crate::{
 // could make public later if interface stabilized
 pub(crate) trait MLBackendContext: std::fmt::Debug {
     fn accelerated(&self) -> bool;
+    fn create_builder(&mut self) -> Result<Box<dyn MLBackendBuilder>>;
+}
+
+pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
+    /*async*/
+    fn build(&self) -> Result<MLGraph>;
 }
 
 // types for MLContext
@@ -185,24 +194,29 @@ impl MLContext {
     // those are methods on `create_context`
     pub async fn create(options: &MLContextOptions) -> Result<Self> {
         let desc = select_backend(options)?;
-        match desc {
+        let backend = match desc {
             crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => todo!(),
+            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => Box::new(
+                TrtxContext::new(cuda_device_idx)
+                    .map_err(|e| Error::ContextCreationError { source: e.into() })?,
+            ),
             crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
             crate::backend_selection::BackendDesc::WebNN => todo!(),
             crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
-        }
+        };
+        Ok(Self { backend })
     }
 
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
         let desc = select_backend_by_gpu(gpu_device)?;
-        match desc {
+        let backend = match desc {
             crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
             crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => todo!(),
             crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
             crate::backend_selection::BackendDesc::WebNN => todo!(),
             crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
-        }
+        };
+        Ok(Self { backend })
     }
     pub fn accelerated(&self) -> bool {
         self.backend.accelerated()
@@ -248,6 +262,26 @@ impl MLContext {
 
     pub async fn write_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &[T]) {
         todo!();
+    }
+}
+
+#[derive(Debug)]
+pub struct MLBuilder<'context> {
+    backend: Box<dyn MLBackendBuilder<'context>>,
+}
+
+impl<'context> MLBuilder<'context> {
+    fn new(context: &'context mut MLContext) -> Result<Self> {
+        let backend = context.backend.create_builder()?;
+        Ok(Self { backend })
+    }
+
+    fn load_webnn(webnn: impl Read) -> Result<()> {
+        Ok(())
+    }
+
+    async fn build() -> Result<MLGraph> {
+        todo!()
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -2,10 +2,13 @@
 
 use log::info;
 
-#[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
-use crate::executors::trtx::{TrtxContext, TrtxGraph};
 use crate::{
     GraphInfo, backend_selection::BackendDevice, backends::ort::OrtContext, error::Result,
+};
+#[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+use crate::{
+    error::Error,
+    executors::trtx::{TrtxContext, TrtxGraph},
 };
 use std::{collections::HashMap, fmt::Display};
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -5,10 +5,7 @@ use log::info;
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
 use crate::executors::trtx::{TrtxContext, TrtxGraph};
 use crate::{
-    GraphInfo,
-    backend_selection::BackendDevice,
-    backends::ort::OrtContext,
-    error::{Error, Result},
+    GraphInfo, backend_selection::BackendDevice, backends::ort::OrtContext, error::Result,
 };
 use std::{collections::HashMap, fmt::Display};
 
@@ -58,7 +55,10 @@ pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
 pub(crate) enum MLBackendGraph<'context> {
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     TrtxEngine(TrtxGraph<'context>),
-    OnnxSession(crate::backends::ort::OrtGraph),
+    OnnxSession(
+        crate::backends::ort::OrtGraph,
+        std::marker::PhantomData<&'context ()>,
+    ),
 }
 
 impl<'context> MLBackendGraph<'context> {
@@ -72,10 +72,10 @@ impl<'context> MLBackendGraph<'context> {
     }
 
     pub(crate) fn as_onnx_session_mut(&mut self) -> Option<&mut crate::backends::ort::OrtGraph> {
-        if let Self::OnnxSession(g) = self {
-            Some(g)
-        } else {
-            None
+        match self {
+            #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+            Self::TrtxEngine(_) => None,
+            Self::OnnxSession(g, _) => Some(g),
         }
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -58,7 +58,7 @@ pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
 pub(crate) enum MLBackendGraph<'context> {
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     TrtxEngine(TrtxGraph<'context>),
-    OnnxSession(std::marker::PhantomData<&'context u8>),
+    OnnxSession(crate::backends::ort::OrtGraph),
 }
 
 impl<'context> MLBackendGraph<'context> {
@@ -66,6 +66,14 @@ impl<'context> MLBackendGraph<'context> {
     pub(crate) fn as_trtx_engine_mut(&mut self) -> Option<&mut TrtxGraph<'context>> {
         if let Self::TrtxEngine(v) = self {
             Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_onnx_session_mut(&mut self) -> Option<&mut crate::backends::ort::OrtGraph> {
+        if let Self::OnnxSession(g) = self {
+            Some(g)
         } else {
             None
         }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -262,8 +262,8 @@ impl<'context> MLContext<'context> {
         let desc = select_backend(options)?;
         info!("Backend selected: {desc:?}");
         let backend: Box<dyn MLBackendContext<'context> + 'context> = match desc {
-            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => {
-                Box::new(OrtContext::new_from_ty(device_type)?)
+            crate::backend_selection::BackendDevice::OnnxDevice { ep_device_idx, .. } => {
+                Box::new(OrtContext::new_from_ep_idx(ep_device_idx)?)
             }
             #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
             crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => Box::new(
@@ -282,7 +282,7 @@ impl<'context> MLContext<'context> {
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
         let desc = select_backend_by_gpu(gpu_device)?;
         let backend = match desc {
-            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::OnnxDevice { .. } => todo!(),
             crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => todo!(),
             crate::backend_selection::BackendDevice::CoremlDevice { device_type } => todo!(),
             crate::backend_selection::BackendDevice::WebNN => todo!(),

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -15,6 +15,7 @@ use crate::{
 pub(crate) trait ListDevices {
     fn list_devices() -> Vec<BackendDevice>;
 }
+
 // could make public later if interface stabilized
 pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
     fn accelerated(&self) -> bool;

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,6 +1,10 @@
+use crate::error::Result;
 use std::{collections::HashMap, fmt::Display};
 
-use crate::operator_enums::MLOperandDataType;
+use crate::{
+    backend_selection::{select_backend, select_backend_by_gpu},
+    operator_enums::MLOperandDataType,
+};
 
 // Backend traits
 
@@ -8,8 +12,6 @@ use crate::operator_enums::MLOperandDataType;
 pub(crate) trait MLBackendContext: std::fmt::Debug {
     fn accelerated(&self) -> bool;
 }
-
-pub(crate) trait MLBackendTensor: std::fmt::Debug {}
 
 // types for MLContext
 
@@ -34,9 +36,40 @@ impl Display for MLContextLostInfo {
     }
 }
 
+/// https://www.w3.org/TR/webnn/#api-mltensor
 #[derive(Debug)]
 pub struct MLTensor {
-    backend: Box<dyn MLBackendTensor>,
+    id: u64,
+    constant: bool,
+    /// internal slots as per https://www.w3.org/TR/webnn/#api-mltensor
+    descriptor: MLTensorDescriptor,
+    //context: &'context MLContext, // todo, omit context?
+    //// pending promises, need to be canceled when tensor is destroyed
+}
+
+impl MLTensor {
+    pub fn data_type(&self) -> MLOperandDataType {
+        self.descriptor.data_type
+    }
+    pub fn shape(&self) -> &[u64] {
+        &self.descriptor.shape
+    }
+    pub fn readable(&self) -> bool {
+        self.descriptor.readable
+    }
+    pub fn writable(&self) -> bool {
+        self.descriptor.writable
+    }
+    pub fn constant(&self) -> bool {
+        self.constant
+    }
+    // TODO: or replace by Rust's drop?
+    pub fn destoy(&self) {
+        todo!() // destroying needs to cancel pending promises
+    }
+    pub fn destroyed(&self) -> bool {
+        todo!() // JS has a isDestroyed method
+    }
 }
 
 #[derive(Debug)]
@@ -73,7 +106,7 @@ impl MLOperandDescriptor {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
 pub enum MLPowerPreference {
     #[default]
     Default,
@@ -87,8 +120,11 @@ pub enum MLPowerPreference {
 /// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
 #[derive(Debug, Eq, PartialEq)]
 pub struct MLContextOptions {
-    power_preference: MLPowerPreference,
-    accelerated: bool,
+    pub(crate) power_preference: MLPowerPreference,
+    pub(crate) accelerated: bool,
+    // could add our own experimental options
+    // could add device_type (CPU, NPU, GPU) like pywebnn
+    // could add backend preference
 }
 
 /// https://www.w3.org/TR/webnn/#dictdef-mltensordescriptor
@@ -146,12 +182,27 @@ pub struct MLContext {
 }
 
 impl MLContext {
-    pub async fn create_context(options: &MLContextOptions) -> Self {
-        todo!();
+    // those are methods on `create_context`
+    pub async fn create(options: &MLContextOptions) -> Result<Self> {
+        let desc = select_backend(options)?;
+        match desc {
+            crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => todo!(),
+            crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDesc::WebNN => todo!(),
+            crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
+        }
     }
 
-    pub async fn create_context_with_gpu_device(gpu_device: &GpuDevice) -> Self {
-        todo!()
+    pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
+        let desc = select_backend_by_gpu(gpu_device)?;
+        match desc {
+            crate::backend_selection::BackendDesc::OnnxRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDesc::TrtxRuntime { cuda_device_idx } => todo!(),
+            crate::backend_selection::BackendDesc::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDesc::WebNN => todo!(),
+            crate::backend_selection::BackendDesc::ExternalBackend => todo!(),
+        }
     }
     pub fn accelerated(&self) -> bool {
         self.backend.accelerated()

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,0 +1,182 @@
+use std::{collections::HashMap, fmt::Display};
+
+use crate::operator_enums::MLOperandDataType;
+
+// Backend traits
+
+// could make public later if interface stabilized
+pub(crate) trait MLBackendContext: std::fmt::Debug {
+    fn accelerated(&self) -> bool;
+}
+
+pub(crate) trait MLBackendTensor: std::fmt::Debug {}
+
+// types for MLContext
+
+// aka WebGpuDevice
+#[derive(Debug)]
+pub struct GpuDevice {}
+
+#[derive(Debug)]
+pub struct MLContextLostInfo {
+    message: String,
+}
+
+impl MLContextLostInfo {
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for MLContextLostInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+#[derive(Debug)]
+pub struct MLTensor {
+    backend: Box<dyn MLBackendTensor>,
+}
+
+#[derive(Debug)]
+pub struct MLGraph {}
+#[derive(Debug)]
+pub struct MLOpSupportLimits {}
+
+// https://www.w3.org/TR/webnn/#dictdef-mloperanddescriptor
+#[derive(Debug, Eq, PartialEq)]
+pub struct MLOperandDescriptor {
+    data_type: MLOperandDataType,
+    shape: Vec<u64>,
+}
+
+impl MLOperandDescriptor {
+    pub fn data_type(&self) -> MLOperandDataType {
+        self.data_type
+    }
+
+    pub fn shape(&self) -> &[u64] {
+        &self.shape
+    }
+
+    pub fn set_data_type(&mut self, data_type: MLOperandDataType) {
+        self.data_type = data_type;
+    }
+
+    pub fn set_shape(&mut self, shape: Vec<u64>) {
+        self.shape = shape;
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum MLPowerPreference {
+    #[default]
+    Default,
+    HighPerformance,
+    LowPower,
+}
+
+/// https://www.w3.org/TR/webnn/#dictdef-mlcontextoptions
+/// https://www.w3.org/TR/webnn/#api-ml
+///
+/// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
+#[derive(Debug, Eq, PartialEq)]
+pub struct MLContextOptions {
+    power_preference: MLPowerPreference,
+    accelerated: bool,
+}
+
+/// https://www.w3.org/TR/webnn/#dictdef-mltensordescriptor
+#[derive(Debug, Eq, PartialEq)]
+pub struct MLTensorDescriptor {
+    operand_descriptor: MLOperandDescriptor,
+    readable: bool,
+    writable: bool,
+}
+
+impl std::ops::Deref for MLTensorDescriptor {
+    type Target = MLOperandDescriptor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.operand_descriptor
+    }
+}
+
+impl MLTensorDescriptor {
+    pub fn readable(&self) -> bool {
+        self.readable
+    }
+
+    pub fn writable(&self) -> bool {
+        self.writable
+    }
+
+    pub fn set_writable(&mut self, writable: bool) {
+        self.writable = writable;
+    }
+
+    pub fn set_readable(&mut self, readable: bool) {
+        self.readable = readable;
+    }
+}
+
+#[derive(Debug)]
+pub struct MLContext {
+    backend: Box<dyn MLBackendContext>,
+}
+
+impl MLContext {
+    pub async fn create_context(options: &MLContextOptions) -> Self {
+        todo!();
+    }
+
+    pub async fn create_context_with_gpu_device(gpu_device: &GpuDevice) -> Self {
+        todo!()
+    }
+    pub fn accelerated(&self) -> bool {
+        self.backend.accelerated()
+    }
+
+    pub async fn lost(&self) -> MLContextLostInfo {
+        todo!()
+    }
+
+    pub async fn create_constant_tensor(
+        &mut self,
+        descriptor: &MLOperandDescriptor,
+        input_data: &[u8], // with owned variant?
+    ) -> MLTensor {
+        todo!()
+    }
+
+    pub async fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> MLTensor {
+        todo!()
+    }
+
+    // omit destroy()? We're not JS, objects can be destroyed via drop, we could do destroy stuff in Drop
+    pub fn destroy(self) {
+        todo!()
+    }
+
+    pub fn dispatch(
+        &mut self,
+        graph: &MLGraph,
+        inputs: &HashMap<&str, MLTensor>,
+        outputs: &HashMap<&str, MLTensor>,
+    ) {
+        todo!()
+    }
+
+    pub fn op_support_limits(&self) -> MLOpSupportLimits {
+        todo!()
+    }
+
+    pub async fn read_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &mut [T]) {
+        todo!();
+    }
+
+    pub async fn write_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &[T]) {
+        todo!();
+    }
+}

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -38,8 +38,8 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, MLTensor>,
-        outputs: &HashMap<&str, MLTensor>,
+        inputs: &HashMap<&str, &MLTensor>,
+        outputs: &HashMap<&str, &MLTensor>,
     ) -> Result<()>;
 }
 
@@ -318,11 +318,11 @@ impl<'context> MLContext<'context> {
 
     pub fn dispatch(
         &mut self,
-        graph: &MLGraph,
-        inputs: &HashMap<&str, MLTensor>,
-        outputs: &HashMap<&str, MLTensor>,
-    ) {
-        todo!()
+        graph: &mut MLGraph,
+        inputs: &HashMap<&str, &MLTensor>,
+        outputs: &HashMap<&str, &MLTensor>,
+    ) -> crate::error::Result<()> {
+        self.backend.dispatch(graph, inputs, outputs)
     }
 
     pub fn op_support_limits(&self) -> MLOpSupportLimits {
@@ -358,7 +358,7 @@ pub struct MLGraphBuilder<'context> {
 }
 
 impl<'context> MLGraphBuilder<'context> {
-    fn new(context: &'context mut MLContext<'context>) -> Result<Self> {
+    fn new(context: &'_ mut MLContext<'context>) -> Result<Self> {
         let backend = context.backend.create_builder()?;
         Ok(Self { backend })
     }
@@ -375,7 +375,7 @@ impl<'context> MLGraphBuilder<'context> {
 
 #[cfg(test)]
 mod test {
-    use crate::mlcontext::*;
+    use crate::{mlcontext::*, webnn_json::from_graph_json};
 
     #[test]
     fn test_tensor_desc() {
@@ -421,5 +421,60 @@ mod test {
         context.write_tensor(&tensor, &upload).unwrap();
         context.read_tensor(&tensor, &mut download).unwrap();
         assert_eq!(&upload, &download);
+    }
+
+    #[test]
+    fn test_dispatch() {
+        let contents = r#"
+webnn_graph "sample_graph" v1 {
+  inputs {
+    lhs: f32[2, 2];
+  }
+
+  consts {
+    rhs: f32[2, 2] @scalar(1.0);
+  }
+
+  nodes {
+    sum = add(lhs, rhs);
+  }
+
+  outputs { sum; }
+}"#;
+
+        let _ = pretty_env_logger::try_init();
+        let sanitized = crate::loader::sanitize_webnn_identifiers(contents);
+        let graph_json = webnn_graph::parser::parse_wg_text(&sanitized).unwrap();
+        let graph_info = from_graph_json(&graph_json).unwrap();
+
+        let mut context = MLContext::create(&MLContextOptions {
+            power_preference: MLPowerPreference::Default,
+            accelerated: true,
+        })
+        .unwrap();
+        dbg!(&context);
+        let mut desc = MLTensorDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+        desc.set_readable(true);
+        desc.set_writable(true);
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        builder.load_graph(&graph_info).unwrap();
+        let mut graph = builder.build(&HashMap::new()).unwrap();
+
+        let tensor = context.create_tensor(&desc).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("lhs", &tensor);
+        let mut outputs = HashMap::new();
+        outputs.insert("sum", &tensor);
+
+        let upload = vec![1.0f32, 2., 3., 4.];
+        let mut download = vec![0.0f32; 4];
+        context.write_tensor(&tensor, &upload).unwrap();
+        context.dispatch(&mut graph, &inputs, &outputs).unwrap();
+        context.read_tensor(&tensor, &mut download).unwrap();
+        assert_eq!(&vec![2.0f32, 3., 4., 5.], &download);
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -13,6 +13,7 @@ use crate::{
 // Backend traits
 
 pub(crate) trait ListDevices {
+    // TODO: should probably be a Result or just be an empty Vec when something is not working the
     fn list_devices() -> Vec<BackendDevice>;
 }
 
@@ -200,12 +201,12 @@ impl<'context> MLContext<'context> {
     pub async fn create(options: &MLContextOptions) -> Result<Self> {
         let desc = select_backend(options)?;
         let backend = match desc {
-            crate::backend_selection::BackendDevice::OnnxRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDevice::TrtxRuntime { cuda_device_idx } => Box::new(
+            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => Box::new(
                 TrtxContext::new(cuda_device_idx)
                     .map_err(|e| Error::ContextCreationError { source: e.into() })?,
             ),
-            crate::backend_selection::BackendDevice::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::CoremlDevice { device_type } => todo!(),
             crate::backend_selection::BackendDevice::WebNN => todo!(),
             crate::backend_selection::BackendDevice::ExternalBackend => todo!(),
         };
@@ -215,9 +216,9 @@ impl<'context> MLContext<'context> {
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
         let desc = select_backend_by_gpu(gpu_device)?;
         let backend = match desc {
-            crate::backend_selection::BackendDevice::OnnxRuntime { device_type } => todo!(),
-            crate::backend_selection::BackendDevice::TrtxRuntime { cuda_device_idx } => todo!(),
-            crate::backend_selection::BackendDevice::CoremlRuntime { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => todo!(),
+            crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => todo!(),
+            crate::backend_selection::BackendDevice::CoremlDevice { device_type } => todo!(),
             crate::backend_selection::BackendDevice::WebNN => todo!(),
             crate::backend_selection::BackendDevice::ExternalBackend => todo!(),
         };
@@ -304,12 +305,12 @@ mod test {
             default_operand_desc.data_type()
         );
         assert_eq!(default_tensor_desc.data_type(), MLOperandDataType::Float32);
-        assert_eq!(default_tensor_desc.writable(), false);
-        assert_eq!(default_tensor_desc.readable(), false);
+        assert!(!default_tensor_desc.writable());
+        assert!(!default_tensor_desc.readable());
         default_tensor_desc.set_writable(true);
-        assert_eq!(default_tensor_desc.writable(), true);
+        assert!(default_tensor_desc.writable());
         default_tensor_desc.set_writable(true);
-        assert_eq!(default_tensor_desc.writable(), true);
+        assert!(default_tensor_desc.writable());
 
         let desc = MLTensorDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
         let op_desc = MLOperandDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 use crate::{
     backend_selection::BackendDevice,
     error::{Error, Result},
@@ -21,6 +23,16 @@ pub(crate) trait ListDevices {
 pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
     fn accelerated(&self) -> bool;
     fn create_builder(&mut self) -> Result<Box<dyn MLBackendBuilder<'context> + 'context>>;
+    fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> Result<MLTensor>;
+    fn create_constant_tensor(
+        &mut self,
+        descriptor: &MLTensorDescriptor,
+        input_data: &[u8],
+    ) -> Result<MLTensor>;
+    /*async*/
+    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<()>;
+    /*async*/
+    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<()>;
 }
 
 pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
@@ -52,12 +64,12 @@ impl Display for MLContextLostInfo {
 }
 
 /// https://www.w3.org/TR/webnn/#api-mltensor
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MLTensor {
-    id: u64,
-    constant: bool,
+    pub(crate) id: usize,
+    pub(crate) constant: bool,
     /// internal slots as per https://www.w3.org/TR/webnn/#api-mltensor
-    descriptor: MLTensorDescriptor,
+    pub(crate) descriptor: MLTensorDescriptor,
     //context: &'context MLContext, // todo, omit context?
     //// pending promises, need to be canceled when tensor is destroyed
 }
@@ -93,7 +105,7 @@ pub struct MLGraph {}
 pub struct MLOpSupportLimits {}
 
 // https://www.w3.org/TR/webnn/#dictdef-mloperanddescriptor
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct MLOperandDescriptor {
     data_type: MLOperandDataType,
     shape: Vec<u64>,
@@ -133,7 +145,7 @@ pub enum MLPowerPreference {
 /// https://www.w3.org/TR/webnn/#api-ml
 ///
 /// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct MLContextOptions {
     pub(crate) power_preference: MLPowerPreference,
     pub(crate) accelerated: bool,
@@ -143,7 +155,7 @@ pub struct MLContextOptions {
 }
 
 /// https://www.w3.org/TR/webnn/#dictdef-mltensordescriptor
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct MLTensorDescriptor {
     operand_descriptor: MLOperandDescriptor,
     readable: bool,
@@ -213,6 +225,7 @@ impl<'context> MLContext<'context> {
         Ok(Self { backend })
     }
 
+    #[allow(unreachable_code)]
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
         let desc = select_backend_by_gpu(gpu_device)?;
         let backend = match desc {
@@ -240,8 +253,8 @@ impl<'context> MLContext<'context> {
         todo!()
     }
 
-    pub async fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> MLTensor {
-        todo!()
+    pub async fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> Result<MLTensor> {
+        self.backend.create_tensor(descriptor)
     }
 
     // omit destroy()? We're not JS, objects can be destroyed via drop, we could do destroy stuff in Drop
@@ -262,12 +275,28 @@ impl<'context> MLContext<'context> {
         todo!()
     }
 
-    pub async fn read_tensor<T>(&mut self, tensor: &MLTensor, array: &mut [T]) {
-        todo!();
+    pub async fn read_tensor<T: bytemuck::Pod>(
+        &mut self,
+        tensor: &MLTensor,
+        array: &mut [T],
+    ) -> Result<()> {
+        if !tensor.readable() {
+            panic!("Attempt to write non-readable tensor: {tensor:?}");
+        }
+        self.backend
+            .read_tensor(tensor, bytemuck::cast_slice_mut(array))
     }
 
-    pub async fn write_tensor<T>(&mut self, tensor: &MLTensor, array: &[T]) {
-        todo!();
+    pub async fn write_tensor<T: bytemuck::Pod>(
+        &mut self,
+        tensor: &MLTensor,
+        array: &[T],
+    ) -> Result<()> {
+        if !tensor.writable() {
+            panic!("Attempt to write non-writeable tensor: {tensor:?}");
+        }
+        self.backend
+            .write_tensor(tensor, bytemuck::cast_slice(array))
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -45,13 +45,17 @@ pub struct MLGraph {}
 pub struct MLOpSupportLimits {}
 
 // https://www.w3.org/TR/webnn/#dictdef-mloperanddescriptor
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub struct MLOperandDescriptor {
     data_type: MLOperandDataType,
     shape: Vec<u64>,
 }
 
 impl MLOperandDescriptor {
+    pub fn new(data_type: MLOperandDataType, shape: Vec<u64>) -> Self {
+        Self { data_type, shape }
+    }
+
     pub fn data_type(&self) -> MLOperandDataType {
         self.data_type
     }
@@ -88,7 +92,7 @@ pub struct MLContextOptions {
 }
 
 /// https://www.w3.org/TR/webnn/#dictdef-mltensordescriptor
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub struct MLTensorDescriptor {
     operand_descriptor: MLOperandDescriptor,
     readable: bool,
@@ -104,6 +108,13 @@ impl std::ops::Deref for MLTensorDescriptor {
 }
 
 impl MLTensorDescriptor {
+    pub fn new(data_type: MLOperandDataType, shape: Vec<u64>) -> Self {
+        Self {
+            operand_descriptor: MLOperandDescriptor { data_type, shape },
+            writable: false,
+            readable: false,
+        }
+    }
     pub fn readable(&self) -> bool {
         self.readable
     }
@@ -178,5 +189,32 @@ impl MLContext {
 
     pub async fn write_tensor<T>(this: &MLContext, tensor: &MLTensor, array: &[T]) {
         todo!();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::mlcontext::*;
+
+    #[test]
+    fn test_tensor_desc() {
+        let default_operand_desc = MLOperandDescriptor::default();
+        let mut default_tensor_desc = MLTensorDescriptor::default();
+        assert_eq!(default_tensor_desc.shape(), default_operand_desc.shape());
+        assert_eq!(
+            default_tensor_desc.data_type(),
+            default_operand_desc.data_type()
+        );
+        assert_eq!(default_tensor_desc.data_type(), MLOperandDataType::Float32);
+        assert_eq!(default_tensor_desc.writable(), false);
+        assert_eq!(default_tensor_desc.readable(), false);
+        default_tensor_desc.set_writable(true);
+        assert_eq!(default_tensor_desc.writable(), true);
+        default_tensor_desc.set_writable(true);
+        assert_eq!(default_tensor_desc.writable(), true);
+
+        let desc = MLTensorDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
+        let op_desc = MLOperandDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
+        assert_eq!(desc.operand_descriptor, op_desc);
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -3,12 +3,12 @@
 use log::info;
 
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
-use crate::executors::trtx::TrtxGraph;
+use crate::executors::trtx::{TrtxContext, TrtxGraph};
 use crate::{
     GraphInfo,
     backend_selection::BackendDevice,
+    backends::ort::OrtContext,
     error::{Error, Result},
-    executors::trtx::TrtxContext,
 };
 use std::{collections::HashMap, fmt::Display};
 
@@ -58,20 +58,11 @@ pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
 pub(crate) enum MLBackendGraph<'context> {
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     TrtxEngine(TrtxGraph<'context>),
-    OnnxSession(),
+    OnnxSession(std::marker::PhantomData<&'context u8>),
 }
 
 impl<'context> MLBackendGraph<'context> {
-    pub(crate) fn as_trtx_engine(&self) -> Option<&TrtxGraph<'context>> {
-        if let Self::TrtxEngine(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-}
-
-impl<'context> MLBackendGraph<'context> {
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     pub(crate) fn as_trtx_engine_mut(&mut self) -> Option<&mut TrtxGraph<'context>> {
         if let Self::TrtxEngine(v) = self {
             Some(v)
@@ -262,8 +253,11 @@ impl<'context> MLContext<'context> {
     pub fn create(options: &MLContextOptions) -> Result<Self> {
         let desc = select_backend(options)?;
         info!("Backend selected: {desc:?}");
-        let backend = match desc {
-            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => todo!(),
+        let backend: Box<dyn MLBackendContext<'context> + 'context> = match desc {
+            crate::backend_selection::BackendDevice::OnnxDevice { device_type } => {
+                Box::new(OrtContext::new_from_ty(device_type)?)
+            }
+            #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
             crate::backend_selection::BackendDevice::TrtxDevice { cuda_device_idx } => Box::new(
                 TrtxContext::new(cuda_device_idx)
                     .map_err(|e| Error::ContextCreationError { source: e.into() })?,
@@ -271,6 +265,7 @@ impl<'context> MLContext<'context> {
             crate::backend_selection::BackendDevice::CoremlDevice { device_type } => todo!(),
             crate::backend_selection::BackendDevice::WebNN => todo!(),
             crate::backend_selection::BackendDevice::ExternalBackend => todo!(),
+            _ => todo!(),
         };
         Ok(Self { backend })
     }
@@ -303,7 +298,8 @@ impl<'context> MLContext<'context> {
         todo!()
     }
 
-    pub async fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> Result<MLTensor> {
+    // async
+    pub fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> Result<MLTensor> {
         self.backend.create_tensor(descriptor)
     }
 
@@ -325,7 +321,8 @@ impl<'context> MLContext<'context> {
         todo!()
     }
 
-    pub async fn read_tensor<T: bytemuck::Pod>(
+    //async
+    pub fn read_tensor<T: bytemuck::Pod>(
         &mut self,
         tensor: &MLTensor,
         array: &mut [T],
@@ -337,11 +334,8 @@ impl<'context> MLContext<'context> {
             .read_tensor(tensor, bytemuck::cast_slice_mut(array))
     }
 
-    pub async fn write_tensor<T: bytemuck::Pod>(
-        &mut self,
-        tensor: &MLTensor,
-        array: &[T],
-    ) -> Result<()> {
+    //async
+    pub fn write_tensor<T: bytemuck::Pod>(&mut self, tensor: &MLTensor, array: &[T]) -> Result<()> {
         if !tensor.writable() {
             panic!("Attempt to write non-writeable tensor: {tensor:?}");
         }
@@ -400,11 +394,24 @@ mod test {
     #[test]
     fn test_create_context() {
         let _ = pretty_env_logger::try_init();
-        let context = MLContext::create(&MLContextOptions {
+        let mut context = MLContext::create(&MLContextOptions {
             power_preference: MLPowerPreference::Default,
             accelerated: true,
         })
         .unwrap();
         dbg!(&context);
+        let mut desc = MLTensorDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+        desc.set_readable(true);
+        desc.set_writable(true);
+        let tensor = context.create_tensor(&desc).unwrap();
+
+        let upload = vec![1.0f32, 2., 3., 4.];
+        let mut download = vec![0.0f32; 4];
+        context.write_tensor(&tensor, &upload).unwrap();
+        context.read_tensor(&tensor, &mut download).unwrap();
+        assert_eq!(&upload, &download);
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -47,7 +47,7 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug {
 pub(crate) trait MLBackendBuilder<'context>: std::fmt::Debug {
     /*async*/
     fn build(&mut self, outputs: &HashMap<&str, MLOperand>) -> Result<MLGraph<'context>>;
-    fn load_graph(&mut self, webnn: &'context GraphInfo) -> Result<()>;
+    fn load_graph(&mut self, graph: &'context GraphInfo) -> Result<()>;
 }
 
 // can be made a Box<dyn better_any::Tid<'context> + 'context> for dynamic dispatch
@@ -347,11 +347,11 @@ impl<'context> MLContext<'context> {
 }
 
 #[derive(Debug)]
-pub struct MLBuilder<'context> {
+pub struct MLGraphBuilder<'context> {
     backend: Box<dyn MLBackendBuilder<'context> + 'context>,
 }
 
-impl<'context> MLBuilder<'context> {
+impl<'context> MLGraphBuilder<'context> {
     fn new(context: &'context mut MLContext<'context>) -> Result<Self> {
         let backend = context.backend.create_builder()?;
         Ok(Self { backend })

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -130,6 +130,14 @@ impl MLTensorDescriptor {
     pub fn set_readable(&mut self, readable: bool) {
         self.readable = readable;
     }
+
+    pub fn operand_descriptor(&self) -> &MLOperandDescriptor {
+        &self.operand_descriptor
+    }
+
+    pub fn set_operand_descriptor(&mut self, operand_descriptor: MLOperandDescriptor) {
+        self.operand_descriptor = operand_descriptor;
+    }
 }
 
 #[derive(Debug)]
@@ -215,6 +223,6 @@ mod test {
 
         let desc = MLTensorDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
         let op_desc = MLOperandDescriptor::new(MLOperandDataType::Float16, vec![3, 4]);
-        assert_eq!(desc.operand_descriptor, op_desc);
+        assert_eq!(desc.operand_descriptor(), op_desc);
     }
 }

--- a/src/operator_enums.rs
+++ b/src/operator_enums.rs
@@ -14,6 +14,17 @@ pub enum MLOperandDataType {
     Uint8,
 }
 
+impl MLOperandDataType {
+    pub(crate) const fn element_size_bits(self) -> usize {
+        match self {
+            MLOperandDataType::Float32 | MLOperandDataType::Int32 | MLOperandDataType::Uint32 => 32,
+            MLOperandDataType::Float16 => 16,
+            MLOperandDataType::Int64 | MLOperandDataType::Uint64 => 64,
+            MLOperandDataType::Int8 | MLOperandDataType::Uint8 => 8,
+        }
+    }
+}
+
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum MLLstmWeightLayout {

--- a/tests/wpt_conformance/mod.rs
+++ b/tests/wpt_conformance/mod.rs
@@ -511,7 +511,7 @@ pub fn run_one_test_case_trtx(
                 graph_info.operand(id).and_then(|o| o.name.as_deref()) == Some(out_name.as_str())
             })
             .ok_or_else(|| format!("output operand '{}' not in graph_info", out_name))?;
-        let trt_out_name = TrtxConverter::engine_binding_name(out_op_id);
+        let trt_out_name = TrtxConverter::engine_io_tensor_name(&graph_info, out_op_id);
         let actual = outputs
             .iter()
             .find(|o| o.name == trt_out_name)

--- a/tests/wpt_conformance/wpt_to_graph.rs
+++ b/tests/wpt_conformance/wpt_to_graph.rs
@@ -1188,8 +1188,8 @@ fn parse_int_for_tensor(v: &serde_json::Value) -> Option<i64> {
         .or_else(|| v.as_u64().map(|u| u as i64))
 }
 
-/// Build TensorRT input list from WPT graph. Tensor names match [`TrtxConverter::engine_binding_name`]
-/// (operand index), not WebNN/WPT logical names, so TensorRT QDQ rewrite does not misfire on names like `...ZeroPoint`.
+/// Build TensorRT input list from WPT graph. Tensor names match [`TrtxConverter::engine_io_tensor_name`]
+/// (graph operand names when set, else `webnn_operand_{id}`).
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 pub fn wpt_graph_to_trtx_inputs(
     graph: &WptGraph,
@@ -1333,7 +1333,7 @@ pub fn wpt_graph_to_trtx_inputs(
         };
 
         inputs.push(rustnn::TrtxInput {
-            name: TrtxConverter::engine_binding_name(op_id),
+            name: TrtxConverter::engine_io_tensor_name(graph_info, op_id),
             data,
         });
     }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Attempt for a high-level API resembling WebNN, similar to what we already have in pywebnn. Need to decide whether 

Goal is to have context object that backends could implement to keep their resources alive and destroy them accordingly. A similar object will be needed for MLTensor, MLGraph. MLGraphBuild could be by passed for quick iteration by our serialization formats/converter infra.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

