### PR TITLE
CoreML MLProgram: emit explicit gelu mode=EXACT

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -2105,13 +2105,16 @@ impl CoremlMlProgramConverter {
                 // WebNN modes: "constant", "edge", "reflection", "symmetric"
             }
 
-            Operation::Gelu { .. }
-                // gelu: x (mode is optional, defaults to "EXACT")
-                if !input_names.is_empty() => {
+            Operation::Gelu { .. } => {
+                // gelu: x, mode
+                if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
-                // CoreML GELU supports "EXACT" and "TANH_APPROXIMATION" modes
-                // WebNN GELU has no mode parameter (uses exact by default)
+                // watchOS MIL loader rejects gelu without an explicit mode ("Required
+                // param 'mode' is missing"); iOS/macOS loaders accept the default.
+                // WebNN spec has no mode parameter — exact (erf) is the implicit default.
+                inputs.insert("mode".to_string(), Self::create_immediate_string("EXACT"));
+            }
 
             Operation::Squeeze { options, .. } => {
                 if !input_names.is_empty() {
@@ -4566,5 +4569,98 @@ mod tests {
             .expect("CoreML7 block");
 
         assert!(main_block.operations.iter().any(|op| op.r#type == "cumsum"));
+    }
+
+    #[test]
+    fn test_gelu_emits_explicit_mode_input() {
+        // The watchOS MIL loader rejects gelu without an explicit `mode` input
+        // ("Required param 'mode' is missing"); iOS/macOS loaders accept the
+        // default. WebNN gelu has no mode parameter — spec default is exact
+        // (erf), so emitting mode=EXACT is correct on every platform.
+        let graph = GraphInfo {
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operands: vec![
+                Operand {
+                    name: Some("input".to_string()),
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: s(&[1, 4]),
+                        pending_permutation: vec![],
+                    },
+                },
+                Operand {
+                    name: Some("output".to_string()),
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: s(&[1, 4]),
+                        pending_permutation: vec![],
+                    },
+                },
+            ],
+            operations: vec![op_from_operator_options(
+                "gelu",
+                vec![0],
+                Some(1),
+                vec![],
+                OperatorOptions::from_json_with_op_type("gelu", &serde_json::json!({}))
+                    .expect("gelu options"),
+            )],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let converted = CoremlMlProgramConverter
+            .convert(&graph)
+            .expect("coreml gelu conversion should succeed");
+        let model = Model::decode(converted.data.as_slice()).expect("decode coreml model");
+        let program = match model.r#type.expect("model type") {
+            crate::protos::coreml::specification::model::Type::MlProgram(program) => program,
+            _ => panic!("expected MLProgram model"),
+        };
+        let main_fn = program.functions.get("main").expect("main function");
+        let main_block = main_fn
+            .block_specializations
+            .get("CoreML7")
+            .expect("CoreML7 block");
+
+        let gelu = main_block
+            .operations
+            .iter()
+            .find(|op| op.r#type == "gelu")
+            .expect("gelu op");
+
+        let mode_arg = gelu
+            .inputs
+            .get("mode")
+            .expect("gelu must emit a `mode` input for the watchOS MIL loader");
+        let binding = mode_arg
+            .arguments
+            .first()
+            .expect("mode arg should have a binding");
+        let value = match binding.binding.as_ref().expect("mode arg binding present") {
+            crate::protos::coreml::mil_spec::argument::binding::Binding::Value(v) => v.clone(),
+            _ => panic!("mode input should be an immediate Value, not a variable reference"),
+        };
+        let immediate = match value.value.as_ref().expect("mode value present") {
+            crate::protos::coreml::mil_spec::value::Value::ImmediateValue(iv) => iv,
+            _ => panic!("mode input should be an ImmediateValue"),
+        };
+        let tensor = match immediate.value.as_ref().expect("immediate value present") {
+            crate::protos::coreml::mil_spec::value::immediate_value::Value::Tensor(t) => t,
+            _ => panic!("mode input should wrap a TensorValue"),
+        };
+        let strings = match tensor.value.as_ref().expect("tensor value present") {
+            crate::protos::coreml::mil_spec::tensor_value::Value::Strings(s) => s,
+            _ => panic!("mode input tensor should be Strings-typed"),
+        };
+        assert_eq!(
+            strings.values.as_slice(),
+            ["EXACT"],
+            "mode must be the scalar string \"EXACT\" to match the WebNN spec default",
+        );
     }
 }


### PR DESCRIPTION
Refs #101.

## Problem

rustnn emits `gelu` MIL operations without a `mode` input, relying on the CoreML default. The iOS 17+ / macOS 14+ / macCatalyst MIL loaders are permissive and accept this, but the **watchOS 11 MIL loader** rejects the model during `MLModel(contentsOf:)` with:

```
Validation error parsing MIL model: Required param 'mode' is missing
```

This blocks every WebNN graph that contains a `gelu` op from loading on Apple Watch (Series 6+, SE 2, Ultra 1+, and later) running watchOS 11.

## Fix

WebNN's `gelu()` has no user-facing `mode` parameter; the spec defines the exact (erf-based) form as the implicit default, which maps to MIL's `mode = "EXACT"`. Emit this explicitly in the MLProgram protobuf. The change is a no-op on iOS/macOS loaders (same numerical behaviour, explicit vs. default), and unblocks `MLModel` loads on watchOS 11.

Adds a regression test that decodes the emitted MLProgram protobuf and asserts the `gelu` op carries an immediate `mode = string("EXACT")` input.

## How this was surfaced

Running a 2-layer char-level transformer (gelu-in-FFN) through rustnn → CoreML MLProgram → `MILTextCompiler` → Apple CoreML on **Apple Watch SE 2 (arm64_32, watchOS 11)** as part of an on-device WebNN conformance sweep. See #101 for the full context (stack diagram, on-device validation results, and the rest of the patch series).

## CI

All checks green on the fork PR ([rebeckerspecialties/rustnn#1](https://github.com/rebeckerspecialties/rustnn/pull/1)) against the current `main` (includes the recent `MLOperandDataType` / `MLOperatorOptions::label` / clippy-fix refactors): Rust Tests, RustNNPT Conformance Gate, Documentation Build all pass.