### PR TITLE
CoreML MLProgram: always emit required conv2d/conv_transpose2d params

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1513,31 +1513,45 @@ impl CoremlMlProgramConverter {
                     inputs.insert("bias".to_string(), Self::create_argument(&input_names[2]));
                 }
 
-                // Add parameters from operator options
-                if let Some(opts) = options {
-                    if !opts.strides.is_empty() {
-                        inputs.insert(
-                            "strides".to_string(),
-                            Self::create_immediate_int_array(&opts.strides),
-                        );
-                    }
-                    if !opts.dilations.is_empty() {
-                        inputs.insert(
-                            "dilations".to_string(),
-                            Self::create_immediate_int_array(&opts.dilations),
-                        );
-                    }
-                    if !opts.padding.is_empty() {
-                        inputs.insert(
-                            "pad".to_string(),
-                            Self::create_immediate_int_array(&opts.padding),
-                        );
-                    }
-                    inputs.insert(
-                        "groups".to_string(),
-                        Self::create_immediate_int(opts.groups),
-                    );
-                }
+                // MIL `conv` requires `strides`, `pad`, `dilations`, `groups` — all
+                // four are declared as required inputs in the MIL op schema, so
+                // Apple's CoreML loader rejects the model with
+                // "Required param '...' is missing" when any is omitted. Emit the
+                // WebNN defaults when the WebNN graph left them unset.
+                let (strides, dilations, padding, groups) = match options {
+                    Some(o) => (
+                        if o.strides.is_empty() {
+                            vec![1, 1]
+                        } else {
+                            o.strides.clone()
+                        },
+                        if o.dilations.is_empty() {
+                            vec![1, 1]
+                        } else {
+                            o.dilations.clone()
+                        },
+                        if o.padding.is_empty() {
+                            vec![0, 0, 0, 0]
+                        } else {
+                            o.padding.clone()
+                        },
+                        o.groups,
+                    ),
+                    None => (vec![1, 1], vec![1, 1], vec![0, 0, 0, 0], 1),
+                };
+                inputs.insert(
+                    "strides".to_string(),
+                    Self::create_immediate_int_array(&strides),
+                );
+                inputs.insert(
+                    "dilations".to_string(),
+                    Self::create_immediate_int_array(&dilations),
+                );
+                inputs.insert(
+                    "pad".to_string(),
+                    Self::create_immediate_int_array(&padding),
+                );
+                inputs.insert("groups".to_string(), Self::create_immediate_int(groups));
 
                 // Add pad_type - required parameter in CoreML
                 // Use "custom" when explicit padding is provided
@@ -1565,31 +1579,44 @@ impl CoremlMlProgramConverter {
                     Self::create_immediate_string("custom"),
                 );
 
-                // Add parameters from operator options
-                if let Some(opts) = options {
-                    if !opts.strides.is_empty() {
-                        inputs.insert(
-                            "strides".to_string(),
-                            Self::create_immediate_int_array(&opts.strides),
-                        );
-                    }
-                    if !opts.dilations.is_empty() {
-                        inputs.insert(
-                            "dilations".to_string(),
-                            Self::create_immediate_int_array(&opts.dilations),
-                        );
-                    }
-                    if !opts.padding.is_empty() {
-                        inputs.insert(
-                            "pad".to_string(),
-                            Self::create_immediate_int_array(&opts.padding),
-                        );
-                    }
-                    inputs.insert(
-                        "groups".to_string(),
-                        Self::create_immediate_int(opts.groups),
-                    );
-                }
+                // MIL `conv_transpose` requires `strides`, `pad`, `dilations`,
+                // `groups` — same as `conv` above. Apple's loader emits
+                // "Required param '...' is missing" when any is dropped, even
+                // when the WebNN graph left the attribute at its default.
+                let (strides, dilations, padding, groups) = match options {
+                    Some(o) => (
+                        if o.strides.is_empty() {
+                            vec![1, 1]
+                        } else {
+                            o.strides.clone()
+                        },
+                        if o.dilations.is_empty() {
+                            vec![1, 1]
+                        } else {
+                            o.dilations.clone()
+                        },
+                        if o.padding.is_empty() {
+                            vec![0, 0, 0, 0]
+                        } else {
+                            o.padding.clone()
+                        },
+                        o.groups,
+                    ),
+                    None => (vec![1, 1], vec![1, 1], vec![0, 0, 0, 0], 1),
+                };
+                inputs.insert(
+                    "strides".to_string(),
+                    Self::create_immediate_int_array(&strides),
+                );
+                inputs.insert(
+                    "dilations".to_string(),
+                    Self::create_immediate_int_array(&dilations),
+                );
+                inputs.insert(
+                    "pad".to_string(),
+                    Self::create_immediate_int_array(&padding),
+                );
+                inputs.insert("groups".to_string(), Self::create_immediate_int(groups));
                 // Handle outputSizes (explicit output spatial dimensions [H, W])
                 // Following Chromium: For conv_transpose, CoreML requires output_shape
                 // to be the full output tensor dimensions [N, C, H, W] (from output operand),


### PR DESCRIPTION
Second PR in the stack from #101 (after #102).

## Problem

MIL's `conv` and `conv_transpose` ops declare `strides`, `pad`, `dilations`, and `groups` as **required** inputs in the MIL op schema — not optional. The current emitter skips them when the WebNN graph leaves the corresponding `MLConv2dOptions` field at its default (empty vec or 1). Apple's CoreML loader rejects these models on-device with:

```
Validation error parsing MIL model: Required param 'pad' is missing
Validation error parsing MIL model: Required param 'dilations' is missing
```

## Fix

Emit the WebNN defaults (`strides` / `dilations` `[1, 1]`, `pad [0, 0, 0, 0]`, `groups 1`) when the options vec is empty or the options struct is absent, so the MIL output always has the full set of required inputs.

## How this was surfaced

Running the WPT conformance bundles `conv2d.json` ("conv2d float32 4D input and filter tensors options.dilations") and `conv_transpose2d.json` ("convTranspose2d float32 4D input and filter tensors options.padding") through rustnn → CoreML MLProgram → Apple CoreML on Apple Watch SE 2 (arm64_32, watchOS 11). See #101 for the full umbrella context and on-device validation methodology.

## CI

This branch is green on rebeckerspecialties/rustnn#2 (Rust Tests + RustNNPT Conformance Gate + Doc Build all pass; rebased against current `main` at 3645f82). Part of #101.

Refs #101.