### PR TITLE
Add support for large ONNX files 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +890,13 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1026,15 +1039,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1598,7 +1602,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -1618,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1847,6 +1851,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "regex",
+ "safetensors",
  "serde",
  "serde_json",
  "serde_with",
@@ -1869,6 +1874,17 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "schannel"
@@ -2439,15 +2455,17 @@ dependencies = [
 
 [[package]]
 name = "webnn-graph"
-version = "0.2.1"
-source = "git+https://github.com/rustnn/webnn-graph?branch=main#eba3691f16f1ba25a127e82fc55a3f8abf1e269b"
+version = "0.3.0"
+source = "git+https://github.com/rustnn/webnn-graph?branch=main#4dd1ec6d15d396e198b7b1ca0884acfbb24ef230"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "clap",
+ "half",
  "pest",
  "pest_derive",
  "prost",
+ "safetensors",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2457,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "webnn-onnx-utils"
 version = "0.1.0"
-source = "git+https://github.com/rustnn/webnn-onnx-utils?branch=main#2e48450d12122dd0f776c1aca7ae9e09b1eaf743"
+source = "git+https://github.com/rustnn/webnn-onnx-utils?branch=main#9fcced36cd062cdca883addb771e96c98c4bdc13"
 dependencies = [
  "half",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 default = []
 dynamic-inputs = []
 coreml-runtime = ["objc"]
-onnx-runtime = ["ort", "ndarray", "tokenizers"]
+onnx-runtime = ["ort", "ndarray", "tokenizers", "dep:tempfile"]
 trtx-runtime = ["trtx"]
 trtx-runtime-mock = ["trtx/mock"]
 
@@ -39,6 +39,7 @@ bytemuck = { version = "1.15", features = ["extern_crate_std"] }
 ndarray = { version = "0.17", optional = true }
 objc = { version = "0.2", optional = true }
 ort = { version = "2.0.0-rc.11", optional = true, features = ["ndarray", "half", "load-dynamic"] }
+tempfile = { version = "3.8", optional = true }
 tokenizers = { version = "0.22", optional = true }
 half = "2.4"
 trtx = { version = "0.4.0", optional = true }
@@ -52,6 +53,7 @@ prost-build = "0.12"
 [dev-dependencies]
 tempfile = "3.8"
 half = "2.4"
+safetensors = "0.7"
 
 [lib]
 name = "rustnn"

--- a/docs/development/flexible-input-shapes.md
+++ b/docs/development/flexible-input-shapes.md
@@ -41,10 +41,8 @@ Phase 5 runtime checks enforce:
 
 ## Checked Execution APIs
 
-Use checked variants when runtime descriptor validation is required:
+Pass operand descriptor maps when runtime validation against the WebNN graph is required:
 
-- ONNX: `run_onnx_with_inputs_checked(...)`
+- ONNX: `run_onnx_with_inputs_checked(..., &input_descriptors, &output_descriptors)` passes the WebNN I/O descriptor maps from validation artifacts; ORT still validates feeds independently. Use `run_onnx_with_inputs` when you do not need descriptor checks.
 - TensorRT: `run_trtx_with_inputs_checked(...)`
 - CoreML: `run_coreml_with_inputs_checked(...)`
-
-Unchecked `run_*_with_inputs(...)` APIs are still available for compatibility.

--- a/examples/gpt2_webnn_rust.rs
+++ b/examples/gpt2_webnn_rust.rs
@@ -383,6 +383,7 @@ mod app {
             let inputs = to_onnx_inputs(&input_order, &state)?;
             let outputs = run_onnx_with_inputs_checked(
                 &converted.data,
+                converted.weights_data.as_deref(),
                 inputs,
                 &artifacts.input_names_to_descriptors,
                 &artifacts.output_names_to_descriptors,
@@ -419,6 +420,7 @@ mod app {
             let inputs = to_onnx_inputs(&input_order, &state)?;
             let outputs = run_onnx_with_inputs_checked(
                 &converted.data,
+                converted.weights_data.as_deref(),
                 inputs,
                 &artifacts.input_names_to_descriptors,
                 &artifacts.output_names_to_descriptors,

--- a/examples/smollm_webnn_rust.rs
+++ b/examples/smollm_webnn_rust.rs
@@ -345,8 +345,12 @@ mod app {
                 pos_before, token_id, pos_before, mask_ones
             ))?;
             let onnx_inputs = build_inputs(&input_order, &layout, &state, *token_id as i64)?;
-            let outputs = run_onnx_with_inputs(&converted.data, onnx_inputs)
-                .map_err(|e| format!("onnx run (prefill pos={}): {e}", state.current_pos))?;
+            let outputs = run_onnx_with_inputs(
+                &converted.data,
+                converted.weights_data.as_deref(),
+                onnx_inputs,
+            )
+            .map_err(|e| format!("onnx run (prefill pos={}): {e}", state.current_pos))?;
             let logits = outputs
                 .iter()
                 .find(|o| o.name == layout.logits_name)
@@ -385,8 +389,12 @@ mod app {
                 pos_before, next_id, pos_before, mask_ones
             ))?;
             let onnx_inputs = build_inputs(&input_order, &layout, &state, next_id as i64)?;
-            let outputs = run_onnx_with_inputs(&converted.data, onnx_inputs)
-                .map_err(|e| format!("onnx run (decode pos={}): {e}", state.current_pos))?;
+            let outputs = run_onnx_with_inputs(
+                &converted.data,
+                converted.weights_data.as_deref(),
+                onnx_inputs,
+            )
+            .map_err(|e| format!("onnx run (decode pos={}): {e}", state.current_pos))?;
             let logits_after = outputs
                 .iter()
                 .find(|o| o.name == layout.logits_name)

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -16,6 +16,12 @@ pub use onnx::OnnxConverter;
 pub use trtx::TrtxConverter;
 pub(crate) use weight_file_builder::WeightFileBuilder;
 
+/// Filename (relative to the `.onnx` file directory) for ONNX external initializer data produced by the ONNX converter.
+///
+/// When [`ConvertedGraph::weights_data`] is `Some`, write those bytes next to the model using this exact name so
+/// `external_data` `location` entries resolve correctly for ONNX Runtime and other tools.
+pub const ONNX_EXTERNAL_WEIGHTS_FILENAME: &str = "rustnn_external_weights.data";
+
 /// Get operand name for an operand ID, or generate a default name
 ///
 /// This is a shared helper used by all converters to ensure consistent

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-use crate::converters::{ConvertedGraph, operand_name};
+use crate::converters::{ConvertedGraph, ONNX_EXTERNAL_WEIGHTS_FILENAME, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
@@ -24,9 +24,10 @@ use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
 use crate::operators::Operation;
 use crate::protos::onnx::{
-    AttributeProto, GraphProto, ModelProto, NodeProto, OperatorSetIdProto, TensorProto,
-    TensorShapeProto, TypeProto, ValueInfoProto, attribute_proto::AttributeType,
-    tensor_proto::DataType as ProtoDataType, type_proto::Tensor as TensorTypeProto,
+    AttributeProto, GraphProto, ModelProto, NodeProto, OperatorSetIdProto, StringStringEntryProto,
+    TensorProto, TensorShapeProto, TypeProto, ValueInfoProto, attribute_proto::AttributeType,
+    tensor_proto::DataLocation as TensorDataLocation, tensor_proto::DataType as ProtoDataType,
+    type_proto::Tensor as TensorTypeProto,
 };
 use crate::shape_inference::{
     broadcast_shapes, infer_matmul_shape, infer_transpose_shape, infer_unsqueeze_shape,
@@ -39,6 +40,47 @@ use webnn_onnx_utils::{
     attributes::AttrBuilder, data_types as utils_data_types, operation_names::mapper,
     tensor_data::TensorData,
 };
+
+/// Append each initializer's `raw_data` into one external blob and point tensors at it (ONNX external data).
+///
+/// Tensors using `int32_data` / `float_data` / `int64_data` are left unchanged. Only non-empty `raw_data`
+/// is moved so large weight tensors leave the main `ModelProto`.
+fn onnx_pack_external_initializer_raw_data(initializers: &mut Vec<TensorProto>) -> Option<Vec<u8>> {
+    // Align each tensor's external slice to a page boundary. This is not required by ONNX; it can help
+    // mmap / large sequential file I/O patterns and some runtimes that prefer aligned tensor views.
+    const ALIGN: usize = 4096;
+    let mut blob: Vec<u8> = Vec::new();
+    let mut any = false;
+    for tensor in initializers.iter_mut() {
+        if tensor.raw_data.is_empty() {
+            continue;
+        }
+        let pad = (ALIGN - (blob.len() % ALIGN)) % ALIGN;
+        let new_len = blob.len() + pad;
+        blob.resize(new_len, 0u8);
+        let offset = blob.len();
+        let length = tensor.raw_data.len();
+        blob.extend_from_slice(&tensor.raw_data);
+        tensor.raw_data.clear();
+        tensor.external_data = vec![
+            StringStringEntryProto {
+                key: "location".to_string(),
+                value: ONNX_EXTERNAL_WEIGHTS_FILENAME.to_string(),
+            },
+            StringStringEntryProto {
+                key: "offset".to_string(),
+                value: offset.to_string(),
+            },
+            StringStringEntryProto {
+                key: "length".to_string(),
+                value: length.to_string(),
+            },
+        ];
+        tensor.data_location = TensorDataLocation::External as i32;
+        any = true;
+    }
+    any.then_some(blob)
+}
 
 #[derive(Default)]
 pub struct OnnxConverter;
@@ -1020,6 +1062,24 @@ impl OnnxConverter {
             debug_print!("[DEBUG] Invalid operand {} at {}", operand, context);
         }
         GraphError::InvalidConversionOperand { operand }
+    }
+
+    /// Pretty-print the webnn-graph-json style [`webnn_graph::ast::Node`] for `op_index` to stderr (ONNX conversion diagnostics).
+    fn eprintln_failed_operation_webnn_json(graph: &GraphInfo, op_index: usize) {
+        use crate::webnn_json::graph_operation_to_webnn_node;
+        match graph_operation_to_webnn_node(graph, op_index) {
+            Ok(node) => match serde_json::to_string_pretty(&node) {
+                Ok(s) => eprintln!(
+                    "[rustnn onnx converter] failing operation index {op_index} (WebNN graph JSON node):\n{s}"
+                ),
+                Err(e) => eprintln!(
+                    "[rustnn onnx converter] operation index {op_index}: failed to pretty-print JSON node: {e}"
+                ),
+            },
+            Err(e) => eprintln!(
+                "[rustnn onnx converter] operation index {op_index}: could not build WebNN JSON node for stderr: {e}"
+            ),
+        }
     }
 
     fn data_type_code(data_type: DataType) -> ProtoDataType {
@@ -8016,6 +8076,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 let input_shape = input_operand.descriptor.static_or_max_shape();
                 let rank = input_shape.len();
                 if axis >= rank {
+                    Self::eprintln_failed_operation_webnn_json(graph, idx);
                     return Err(GraphError::ConversionFailed {
                         format: "onnx".to_string(),
                         reason: format!("split axis {} out of bounds for rank {}", axis_attr, rank),
@@ -9458,6 +9519,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
             &seen_names,
         );
 
+        let weights_data = onnx_pack_external_initializer_raw_data(&mut initializers);
+
         let graph_proto = GraphProto {
             name: "webnn_graph".to_string(),
             node: nodes,
@@ -9499,7 +9562,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
             format: "onnx",
             content_type: "application/onnx",
             data,
-            weights_data: None, // ONNX doesn't use external weight files
+            weights_data,
         })
     }
 }

--- a/src/executors/onnx.rs
+++ b/src/executors/onnx.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "onnx-runtime")]
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Once;
 
@@ -11,6 +12,7 @@ use ort::session::Session;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::value::Value;
 
+use crate::converters::ONNX_EXTERNAL_WEIGHTS_FILENAME;
 use crate::error::GraphError;
 use crate::graph::OperandDescriptor;
 use crate::runtime_checks::{RuntimeShapeState, TensorKind, validate_shape_data_length};
@@ -173,28 +175,34 @@ pub fn run_onnx_zeroed(
     Ok(results)
 }
 
-/// Run ONNX model with actual input tensors and return output tensors with data
+/// Run ONNX model with actual input tensors and return output tensors with data.
+///
+/// ONNX Runtime performs its own shape checks. For validation against WebNN operand descriptors
+/// (rank, static dimensions, dynamic `maxSize`, linked dynamic names), use
+/// [`run_onnx_with_inputs_checked`].
 pub fn run_onnx_with_inputs(
     model_bytes: &[u8],
+    external_weights: Option<&[u8]>,
     inputs: Vec<OnnxInput>,
 ) -> Result<Vec<OnnxOutputWithData>, GraphError> {
-    run_onnx_with_inputs_impl(model_bytes, inputs, None, None)
+    run_onnx_with_inputs_impl(model_bytes, external_weights, inputs, None, None)
 }
 
-/// Run ONNX model with runtime descriptor checks for dynamic dimensions.
+/// Same as [`run_onnx_with_inputs`], plus optional WebNN operand descriptor validation.
 ///
-/// Enforces:
-/// - actual tensor shape matches descriptor (rank/static dims)
-/// - dynamic dimensions do not exceed maxSize
-/// - same-named dynamic dimensions are equal across inputs and outputs
+/// For each map that is `Some`, validates actual tensor shapes against that map (inputs before the
+/// run, outputs after). `None` skips that side. When both maps are `Some`, same-named dynamic
+/// dimensions are cross-checked (see `crate::runtime_checks::RuntimeShapeState`).
 pub fn run_onnx_with_inputs_checked(
     model_bytes: &[u8],
+    external_weights: Option<&[u8]>,
     inputs: Vec<OnnxInput>,
     input_descriptors: &HashMap<String, OperandDescriptor>,
     output_descriptors: &HashMap<String, OperandDescriptor>,
 ) -> Result<Vec<OnnxOutputWithData>, GraphError> {
     run_onnx_with_inputs_impl(
         model_bytes,
+        external_weights,
         inputs,
         Some(input_descriptors),
         Some(output_descriptors),
@@ -203,6 +211,7 @@ pub fn run_onnx_with_inputs_checked(
 
 fn run_onnx_with_inputs_impl(
     model_bytes: &[u8],
+    external_weights: Option<&[u8]>,
     inputs: Vec<OnnxInput>,
     input_descriptors: Option<&HashMap<String, OperandDescriptor>>,
     output_descriptors: Option<&HashMap<String, OperandDescriptor>>,
@@ -210,18 +219,30 @@ fn run_onnx_with_inputs_impl(
     // Initialize ort global environment (only once per process)
     ensure_ort_initialized()?;
 
-    let mut session = Session::builder()
+    let mut builder = Session::builder()
         .map_err(|e| GraphError::OnnxRuntimeFailed {
             reason: format!("session builder failed: {e}"),
         })?
         .with_optimization_level(GraphOptimizationLevel::Disable)
         .map_err(|e| GraphError::OnnxRuntimeFailed {
             reason: format!("set opt level failed: {e}"),
-        })?
-        .commit_from_memory(model_bytes)
-        .map_err(|e| GraphError::OnnxRuntimeFailed {
-            reason: format!("load model failed: {e}"),
         })?;
+    if let Some(weights) = external_weights {
+        builder = builder
+            .with_external_initializer_file_in_memory(
+                ONNX_EXTERNAL_WEIGHTS_FILENAME,
+                Cow::Owned(weights.to_vec()),
+            )
+            .map_err(|e| GraphError::OnnxRuntimeFailed {
+                reason: format!("set external initializer failed: {e}"),
+            })?;
+    }
+    let mut session =
+        builder
+            .commit_from_memory(model_bytes)
+            .map_err(|e| GraphError::OnnxRuntimeFailed {
+                reason: format!("load model failed: {e}"),
+            })?;
 
     // Extract output names for later use
     let output_names: Vec<String> = session

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,16 @@ pub mod webnn_json;
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
 pub use executors::coreml;
 
-pub use converters::{ConvertedGraph, ConverterRegistry, GraphConverter};
+pub use converters::{
+    ConvertedGraph, ConverterRegistry, GraphConverter, ONNX_EXTERNAL_WEIGHTS_FILENAME,
+};
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
 pub use coreml::{CoremlOutput, CoremlRunAttempt, run_coreml_zeroed, run_coreml_zeroed_cached};
 pub use error::GraphError;
 #[cfg(feature = "onnx-runtime")]
 pub use executors::onnx::{
-    OnnxInput, OnnxOutput, OnnxOutputWithData, TensorData, run_onnx_with_inputs, run_onnx_zeroed,
+    OnnxInput, OnnxOutput, OnnxOutputWithData, TensorData, run_onnx_with_inputs,
+    run_onnx_with_inputs_checked, run_onnx_zeroed,
 };
 #[cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 pub use executors::trtx::{

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use webnn_graph::external_weights::WeightResolveError;
 
 use crate::error::GraphError;
 use crate::graph::GraphInfo;
@@ -63,11 +63,37 @@ pub fn sanitize_webnn_identifiers(text: &str) -> String {
     result
 }
 
+fn map_weight_resolve_error(err: WeightResolveError) -> GraphError {
+    match err {
+        WeightResolveError::ReadFile { path, source } => GraphError::io(path, source),
+        WeightResolveError::ManifestJson { path, source } => GraphError::ConversionFailed {
+            format: "manifest-weights".to_string(),
+            reason: format!("`{}`: {source}", path.display()),
+        },
+        WeightResolveError::Safetensors(msg) => GraphError::ConversionFailed {
+            format: "safetensors".to_string(),
+            reason: msg,
+        },
+        WeightResolveError::Manifest(msg) => GraphError::ConversionFailed {
+            format: "manifest-weights".to_string(),
+            reason: msg,
+        },
+        WeightResolveError::Missing(msg) => GraphError::ConversionFailed {
+            format: "weights".to_string(),
+            reason: msg,
+        },
+    }
+}
+
 /// Load a graph from a webnn-graph file (.webnn text or .json)
 ///
 /// Supports two formats:
 /// - `.webnn` - Text DSL format (parsed and converted to JSON)
 /// - `.json` - Direct JSON format (webnn-graph-json)
+///
+/// When the graph contains `@weights` / `ConstInit::Weights` references, external tensors are
+/// resolved by [`webnn_graph::external_weights::resolve_external_weights`] (strict I/O
+/// and validation). See that module for file naming and behavior.
 pub fn load_graph_from_path(path: impl AsRef<Path>) -> Result<GraphInfo, GraphError> {
     let path_ref = path.as_ref();
     let contents = fs::read_to_string(path_ref).map_err(|err| GraphError::io(path_ref, err))?;
@@ -104,105 +130,30 @@ pub fn load_graph_from_path(path: impl AsRef<Path>) -> Result<GraphInfo, GraphEr
         });
     };
 
-    // If a manifest + weights file exist alongside the graph, inline referenced weights
-    // so that downstream conversion has access to raw bytes.
-    let stem = path_ref
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default()
-        .to_string();
+    webnn_graph::external_weights::resolve_external_weights(&mut graph_json, path_ref, None, None)
+        .map_err(map_weight_resolve_error)?;
 
-    let manifest_path = [
-        path_ref.with_file_name("manifest.json"),
-        path_ref.with_file_name(format!("{}.manifest.json", stem)),
-    ]
-    .into_iter()
-    .find(|p| p.exists());
-
-    let weights_path = [
-        path_ref.with_file_name("model.weights"),
-        path_ref.with_file_name(format!("{}.weights", stem)),
-    ]
-    .into_iter()
-    .find(|p| p.exists());
-
-    if let (Some(manifest_path), Some(weights_path)) = (manifest_path, weights_path) {
-        let Ok(manifest_text) = fs::read_to_string(&manifest_path) else {
-            return webnn_json::from_graph_json(&graph_json);
-        };
-        let Ok(weights_bytes) = fs::read(&weights_path) else {
-            return webnn_json::from_graph_json(&graph_json);
-        };
-        #[derive(Debug, Deserialize)]
-        struct Manifest {
-            #[allow(dead_code)]
-            format: Option<String>,
-            #[allow(dead_code)]
-            version: Option<u32>,
-            #[allow(dead_code)]
-            endianness: Option<String>,
-            tensors: std::collections::HashMap<String, TensorEntry>,
-        }
-
-        #[derive(Debug, Deserialize, Clone)]
-        #[allow(dead_code)]
-        struct TensorEntry {
-            #[serde(rename = "dataType")]
-            data_type: String,
-            shape: Vec<usize>,
-            #[serde(rename = "byteOffset")]
-            byte_offset: usize,
-            #[serde(rename = "byteLength")]
-            byte_length: usize,
-        }
-
-        if let Ok(manifest) = serde_json::from_str::<Manifest>(&manifest_text) {
-            let mut manifest_by_sanitized: std::collections::HashMap<String, Vec<TensorEntry>> =
-                std::collections::HashMap::new();
-            for (name, entry) in &manifest.tensors {
-                let sanitized = name.replace("::", "__").replace('.', "_");
-                manifest_by_sanitized
-                    .entry(sanitized)
-                    .or_default()
-                    .push(entry.clone());
-            }
-
-            for (_name, const_decl) in graph_json.consts.iter_mut() {
-                if let webnn_graph::ast::ConstInit::Weights { r#ref } = &const_decl.init {
-                    // Prefer exact name lookup; only use sanitized fallback when unique.
-                    let entry = manifest.tensors.get(r#ref).cloned().or_else(|| {
-                        manifest_by_sanitized.get(r#ref).and_then(|entries| {
-                            if entries.len() == 1 {
-                                Some(entries[0].clone())
-                            } else {
-                                None
-                            }
-                        })
-                    });
-
-                    if let Some(t) = entry {
-                        let start = t.byte_offset;
-                        let end = start + t.byte_length;
-                        if end <= weights_bytes.len() {
-                            const_decl.init = webnn_graph::ast::ConstInit::InlineBytes {
-                                bytes: weights_bytes[start..end].to_vec(),
-                            };
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Convert to internal GraphInfo format
     webnn_json::from_graph_json(&graph_json)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use safetensors::tensor::TensorView;
+    use safetensors::{Dtype, serialize};
     use std::fs;
     use tempfile::TempDir;
+
+    fn write_safetensors_f32(
+        path: &std::path::Path,
+        tensor_name: &str,
+        shape: Vec<usize>,
+        data: &[u8],
+    ) {
+        let view = TensorView::new(Dtype::F32, shape, data).unwrap();
+        let bytes = serialize(vec![(tensor_name.to_string(), view)], None).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
 
     #[test]
     fn test_sanitize_namespace_separators() {
@@ -571,7 +522,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let graph_path = temp_dir.path().join("model.json");
 
-        // Graph references weights but no manifest exists
+        // No external weight refs; no sidecar files required
         let graph_content = r#"{
             "format": "webnn-graph-json",
             "version": 1,
@@ -671,7 +622,187 @@ mod tests {
 
         // Should succeed but skip the out-of-bounds weight inlining
         let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok());
+        assert!(
+            matches!(result, Err(GraphError::ConversionFailed { ref format, .. }) if format == "manifest-weights"),
+            "expected manifest-weights error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_load_external_weights_missing_sidecars_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let graph_path = temp_dir.path().join("model.json");
+        let graph_content = r#"{
+            "format": "webnn-graph-json",
+            "version": 1,
+            "inputs": {
+                "x": { "dataType": "float32", "shape": [2] }
+            },
+            "consts": {
+                "w": {
+                    "dataType": "float32",
+                    "shape": [2],
+                    "init": { "kind": "weights", "ref": "w" }
+                }
+            },
+            "nodes": [],
+            "outputs": { "y": "x" }
+        }"#;
+        fs::write(&graph_path, graph_content).unwrap();
+        let result = load_graph_from_path(&graph_path);
+        assert!(
+            matches!(result, Err(GraphError::ConversionFailed { ref format, .. }) if format == "weights"),
+            "expected weights error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_load_with_safetensors() {
+        let temp_dir = TempDir::new().unwrap();
+        let graph_path = temp_dir.path().join("model.json");
+        let st_path = temp_dir.path().join("model.safetensors");
+
+        let graph_content = r#"{
+            "format": "webnn-graph-json",
+            "version": 1,
+            "inputs": {
+                "x": { "dataType": "float32", "shape": [2] }
+            },
+            "consts": {
+                "weight": {
+                    "dataType": "float32",
+                    "shape": [2],
+                    "init": { "kind": "weights", "ref": "weight" }
+                }
+            },
+            "nodes": [
+                {
+                    "id": "add_0",
+                    "op": "add",
+                    "inputs": ["x", "weight"],
+                    "options": {},
+                    "outputs": ["y"]
+                }
+            ],
+            "outputs": { "y": "y" }
+        }"#;
+
+        let tensor_bytes: Vec<u8> = vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40];
+        fs::write(&graph_path, graph_content).unwrap();
+        write_safetensors_f32(&st_path, "weight", vec![2], &tensor_bytes);
+
+        let result = load_graph_from_path(&graph_path);
+        assert!(result.is_ok(), "load: {:?}", result.err());
+        let graph = result.unwrap();
+        assert!(!graph.constant_operand_ids_to_handles.is_empty());
+    }
+
+    #[test]
+    fn test_load_safetensors_sanitized_tensor_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let graph_path = temp_dir.path().join("model.json");
+        let st_path = temp_dir.path().join("model.safetensors");
+
+        let graph_content = r#"{
+            "format": "webnn-graph-json",
+            "version": 1,
+            "inputs": {
+                "x": { "dataType": "float32", "shape": [2] }
+            },
+            "consts": {
+                "onnx__weight": {
+                    "dataType": "float32",
+                    "shape": [2],
+                    "init": { "kind": "weights", "ref": "onnx__weight" }
+                }
+            },
+            "nodes": [],
+            "outputs": { "y": "x" }
+        }"#;
+
+        let tensor_bytes: Vec<u8> = vec![0u8; 8];
+        fs::write(&graph_path, graph_content).unwrap();
+        write_safetensors_f32(&st_path, "onnx::weight", vec![2], &tensor_bytes);
+
+        let result = load_graph_from_path(&graph_path);
+        assert!(result.is_ok(), "load: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_safetensors_preferred_over_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        let graph_path = temp_dir.path().join("model.json");
+        let manifest_path = temp_dir.path().join("manifest.json");
+        let weights_path = temp_dir.path().join("model.weights");
+        let st_path = temp_dir.path().join("model.safetensors");
+
+        let graph_content = r#"{
+            "format": "webnn-graph-json",
+            "version": 1,
+            "inputs": {
+                "x": { "dataType": "float32", "shape": [2] }
+            },
+            "consts": {
+                "weight": {
+                    "dataType": "float32",
+                    "shape": [2],
+                    "init": { "kind": "weights", "ref": "weight" }
+                }
+            },
+            "nodes": [],
+            "outputs": { "y": "x" }
+        }"#;
+
+        fs::write(&graph_path, graph_content).unwrap();
+        fs::write(&manifest_path, "{ not valid manifest json").unwrap();
+        fs::write(&weights_path, [0u8; 8]).unwrap();
+        write_safetensors_f32(
+            &st_path,
+            "weight",
+            vec![2],
+            &[0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40],
+        );
+
+        let result = load_graph_from_path(&graph_path);
+        assert!(result.is_ok(), "safetensors should win: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_load_with_invalid_manifest_errors_when_weights_required() {
+        let temp_dir = TempDir::new().unwrap();
+        let graph_path = temp_dir.path().join("model.json");
+        let manifest_path = temp_dir.path().join("manifest.json");
+        let weights_path = temp_dir.path().join("model.weights");
+
+        let graph_content = r#"{
+            "format": "webnn-graph-json",
+            "version": 1,
+            "inputs": {
+                "x": { "dataType": "float32", "shape": [2] }
+            },
+            "consts": {
+                "weight": {
+                    "dataType": "float32",
+                    "shape": [2],
+                    "init": { "kind": "weights", "ref": "weight" }
+                }
+            },
+            "nodes": [],
+            "outputs": { "y": "x" }
+        }"#;
+
+        fs::write(&graph_path, graph_content).unwrap();
+        fs::write(&manifest_path, "{ invalid json }").unwrap();
+        fs::write(&weights_path, [0u8; 8]).unwrap();
+
+        let result = load_graph_from_path(&graph_path);
+        assert!(
+            matches!(result, Err(GraphError::ConversionFailed { ref format, .. }) if format == "manifest-weights"),
+            "expected manifest parse error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,18 @@ fn run() -> Result<(), GraphError> {
         if let Some(ref path) = cli.convert_output {
             std::fs::write(path, &converted.data)
                 .map_err(|err| GraphError::export(path.clone(), err))?;
+            if let Some(ref weights) = converted.weights_data {
+                let sidecar = path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new("."))
+                    .join(rustnn::ONNX_EXTERNAL_WEIGHTS_FILENAME);
+                std::fs::write(&sidecar, weights)
+                    .map_err(|err| GraphError::export(sidecar.clone(), err))?;
+                println!(
+                    "Wrote ONNX external weights to `{}` (same directory as the model).",
+                    sidecar.display()
+                );
+            }
             println!(
                 "Converted graph to `{}` format at `{}` (type {}).",
                 converted.format,
@@ -200,7 +212,11 @@ fn run() -> Result<(), GraphError> {
                 })
                 .collect();
 
-            let outputs = rustnn::run_onnx_with_inputs(&converted.data, inputs)?;
+            let outputs = rustnn::run_onnx_with_inputs(
+                &converted.data,
+                converted.weights_data.as_deref(),
+                inputs,
+            )?;
             println!("Executed ONNX model with zeroed inputs (CPU):");
             for out in outputs {
                 println!("  - {}: shape={:?}", out.name, out.shape);

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -2331,6 +2331,64 @@ pub fn infer_gemm_shape(
     Ok(vec![m, n])
 }
 
+/// Infer GEMM output shape while preserving dynamic dimensions.
+///
+/// Leading dimensions (all but the last two of each input) are broadcast like
+/// [`infer_matmul_shape_dimensions`]. The trailing two dimensions of `A` and `B` follow
+/// WebNN / ONNX GEMM transpose rules (same as [`infer_gemm_shape`]).
+pub fn infer_gemm_shape_dimensions(
+    shape_a: &[Dimension],
+    shape_b: &[Dimension],
+    a_transpose: bool,
+    b_transpose: bool,
+) -> Result<Vec<Dimension>, GraphError> {
+    if shape_a.len() < 2 || shape_b.len() < 2 {
+        return Err(GraphError::ShapeInferenceFailed {
+            reason: format!(
+                "GEMM requires tensors of rank >= 2, got shapes {:?} and {:?}",
+                shape_a, shape_b
+            ),
+        });
+    }
+
+    let a_r0 = shape_a[shape_a.len() - 2].clone();
+    let a_r1 = shape_a[shape_a.len() - 1].clone();
+    let (m_dim, k_a_dim) = if a_transpose {
+        (a_r1, a_r0)
+    } else {
+        (a_r0, a_r1)
+    };
+
+    let b_r0 = shape_b[shape_b.len() - 2].clone();
+    let b_r1 = shape_b[shape_b.len() - 1].clone();
+    let (k_b_dim, n_dim) = if b_transpose {
+        (b_r1, b_r0)
+    } else {
+        (b_r0, b_r1)
+    };
+
+    if let (Dimension::Static(ka), Dimension::Static(kb)) = (&k_a_dim, &k_b_dim)
+        && ka != kb
+    {
+        return Err(GraphError::ShapeInferenceFailed {
+            reason: format!(
+                "GEMM inner dimensions must match: A{}[M, K={}] x B{}[K={}, N]",
+                if a_transpose { "^T" } else { "" },
+                ka,
+                if b_transpose { "^T" } else { "" },
+                kb,
+            ),
+        });
+    }
+
+    let batch_a = &shape_a[..shape_a.len() - 2];
+    let batch_b = &shape_b[..shape_b.len() - 2];
+    let mut batch_dims = broadcast_shapes_dimensions(batch_a, batch_b)?;
+    batch_dims.push(m_dim);
+    batch_dims.push(n_dim);
+    Ok(batch_dims)
+}
+
 /// Infer output shapes for split operation
 /// Splits input along given axis into multiple outputs
 ///
@@ -3841,6 +3899,41 @@ mod tests {
         // Non-2D inputs
         assert!(infer_gemm_shape(&[3], &[3, 4], false, false).is_err());
         assert!(infer_gemm_shape(&[3, 4], &[4], false, false).is_err());
+    }
+
+    #[test]
+    fn test_gemm_dimensions_2d_b_transpose() {
+        let a = vec![Dimension::Static(1), Dimension::Static(256)];
+        let b = vec![Dimension::Static(3072), Dimension::Static(256)];
+        assert_eq!(
+            infer_gemm_shape_dimensions(&a, &b, false, true).unwrap(),
+            vec![Dimension::Static(1), Dimension::Static(3072)]
+        );
+    }
+
+    #[test]
+    fn test_gemm_dimensions_batched_b_transpose() {
+        let a = vec![
+            Dimension::Static(1),
+            Dimension::Static(64),
+            Dimension::Static(128),
+        ];
+        let b = vec![Dimension::Static(3072), Dimension::Static(128)];
+        assert_eq!(
+            infer_gemm_shape_dimensions(&a, &b, false, true).unwrap(),
+            vec![
+                Dimension::Static(1),
+                Dimension::Static(64),
+                Dimension::Static(3072),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_gemm_dimensions_inner_mismatch() {
+        let a = vec![Dimension::Static(2), Dimension::Static(3)];
+        let b = vec![Dimension::Static(4), Dimension::Static(5)];
+        assert!(infer_gemm_shape_dimensions(&a, &b, false, false).is_err());
     }
 
     // Split tests

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -81,6 +81,66 @@ fn from_webnn_dimension(dim: &webnn_graph::ast::Dimension) -> Dimension {
     }
 }
 
+/// Build one [`webnn_graph::ast::Node`] for the operation at `op_index`, matching the shape produced by [`to_graph_json`].
+///
+/// Useful for diagnostics (for example ONNX conversion failures) without serializing the full graph.
+pub fn graph_operation_to_webnn_node(
+    graph: &GraphInfo,
+    op_index: usize,
+) -> Result<Node, GraphError> {
+    let operation = graph
+        .operations
+        .get(op_index)
+        .ok_or_else(|| GraphError::ConversionFailed {
+            format: "webnn-graph-json".to_string(),
+            reason: format!("operation index {op_index} out of range"),
+        })?;
+    let id = format!("op_{}", op_index);
+
+    let input_names: Vec<String> = operation
+        .input_operands()
+        .iter()
+        .map(|&idx| {
+            graph.operands[idx as usize]
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("operand_{}", idx))
+        })
+        .collect();
+
+    let output_operands = operation.output_operands_slice();
+    let output_names: Option<Vec<String>> = if output_operands.is_empty() {
+        None
+    } else {
+        Some(
+            output_operands
+                .iter()
+                .map(|&idx| {
+                    graph.operands[idx as usize]
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| format!("operand_{}", idx))
+                })
+                .collect(),
+        )
+    };
+
+    let mut options: serde_json::Map<String, serde_json::Value> = operation
+        .attributes_value()
+        .as_object()
+        .cloned()
+        .unwrap_or_else(serde_json::Map::new);
+    options.remove("kind");
+
+    Ok(Node {
+        id,
+        op: operation.op_type().to_string(),
+        inputs: input_names,
+        options,
+        outputs: output_names,
+    })
+}
+
 /// Convert GraphInfo to GraphJson
 pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, GraphError> {
     let mut inputs = BTreeMap::new();
@@ -145,54 +205,8 @@ pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, Gr
     }
 
     // Process operations
-    for (op_idx, operation) in graph.operations.iter().enumerate() {
-        let id = format!("op_{}", op_idx);
-
-        // Collect input names
-        let input_names: Vec<String> = operation
-            .input_operands()
-            .iter()
-            .map(|&idx| {
-                graph.operands[idx as usize]
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| format!("operand_{}", idx))
-            })
-            .collect();
-
-        // Collect output names
-        let output_operands = operation.output_operands_slice();
-        let output_names: Option<Vec<String>> = if output_operands.is_empty() {
-            None
-        } else {
-            Some(
-                output_operands
-                    .iter()
-                    .map(|&idx| {
-                        graph.operands[idx as usize]
-                            .name
-                            .clone()
-                            .unwrap_or_else(|| format!("operand_{}", idx))
-                    })
-                    .collect(),
-            )
-        };
-
-        // Convert attributes to JSON options (strip "kind" for plain-option format)
-        let mut options: serde_json::Map<String, serde_json::Value> = operation
-            .attributes_value()
-            .as_object()
-            .cloned()
-            .unwrap_or_else(serde_json::Map::new);
-        options.remove("kind");
-
-        nodes.push(Node {
-            id,
-            op: operation.op_type().to_string(),
-            inputs: input_names,
-            options,
-            outputs: output_names,
-        });
+    for op_idx in 0..graph.operations.len() {
+        nodes.push(graph_operation_to_webnn_node(graph, op_idx)?);
     }
 
     // Process outputs from graph.output_operands
@@ -660,6 +674,44 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         } else {
                             infer_matmul_shape_dimensions(&input_shapes[0], &input_shapes[1]).ok()
                         }
+                    } else {
+                        None
+                    }
+                }
+
+                // Gemm: same trailing-2D layout as matmul; optional `c` must broadcast to output.
+                "gemm" => {
+                    if input_shapes.len() >= 2 {
+                        let (a_transpose, b_transpose) = match &op {
+                            Operation::Gemm { options, .. } => options
+                                .as_ref()
+                                .map(|o| (o.a_transpose, o.b_transpose))
+                                .unwrap_or((false, false)),
+                            _ => (false, false),
+                        };
+                        infer_gemm_shape_dimensions(
+                            &input_shapes[0],
+                            &input_shapes[1],
+                            a_transpose,
+                            b_transpose,
+                        )
+                        .ok()
+                        .and_then(|inferred| match &op {
+                            Operation::Gemm { options, .. } => {
+                                if let Some(c_id) = options.as_ref().and_then(|o| o.c) {
+                                    let c_shape =
+                                        graph.operands[c_id as usize].descriptor.shape.clone();
+                                    if c_shape.is_empty() {
+                                        Some(inferred)
+                                    } else {
+                                        broadcast_shapes_dimensions(&inferred, &c_shape).ok()
+                                    }
+                                } else {
+                                    Some(inferred)
+                                }
+                            }
+                            _ => Some(inferred),
+                        })
                     } else {
                         None
                     }

--- a/tests/wpt_conformance/mod.rs
+++ b/tests/wpt_conformance/mod.rs
@@ -426,7 +426,8 @@ pub fn run_one_test_case(
     let converter = OnnxConverter;
     let converted = converter.convert(&graph_info).map_err(|e| e.to_string())?;
 
-    let outputs = run_onnx_with_inputs(&converted.data, inputs).map_err(|e| e.to_string())?;
+    let outputs = run_onnx_with_inputs(&converted.data, converted.weights_data.as_deref(), inputs)
+        .map_err(|e| e.to_string())?;
 
     let (tolerance_kind, tolerance_value) =
         get_operation_tolerance(operation, test_case.tolerance.as_ref());


### PR DESCRIPTION
* Use shared webnn_graph resolve_external_weights function instead of duplicating the logic.
* Move ONNX weights from protobuf to external weights to support models >2gb
* Add shape_inference for GEMM

## Summary

- [ ] Describe the user-visible and code-level changes.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

