### PR TITLE
feat: expose `converters::trtx::TrtxConverter::build_network`

### DIFF
--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -390,7 +390,7 @@ impl TrtxConverter {
     }
 
     /// Build TensorRT network from WebNN graph.
-    fn build_network<'a>(
+    pub fn build_network<'a>(
         graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
     ) -> Result<(), GraphError> {


### PR DESCRIPTION


## Summary

- [x] Describe the user-visible and code-level changes.

This allows external libs like trtexec-rs to build the network with the builder config they want.

The API signature of `build_network` is similar to the one of the ONNX parser.


See https://github.com/rustnn/trtx-rs/pull/70

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

