### PR TITLE
CoreML MLProgram: always emit reshape `shape` input

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1491,14 +1491,20 @@ impl CoremlMlProgramConverter {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                if !new_shape.is_empty() {
-                    let shape_values =
-                        crate::operator_options::mldimensions_static_or_max(new_shape);
-                    inputs.insert(
-                        "shape".to_string(),
-                        Self::create_immediate_int_array(&shape_values),
-                    );
-                }
+                // MIL `reshape` declares `shape` as a required input. Always emit
+                // it, including the scalar-output case (`new_shape = []`) which is
+                // valid WebNN — the WPT "reshape (squeeze) 4D to scalar" test
+                // surfaces this: Apple's loader rejects the model with
+                // "Required param 'shape' is missing" otherwise.
+                let shape_values = if new_shape.is_empty() {
+                    Vec::new()
+                } else {
+                    crate::operator_options::mldimensions_static_or_max(new_shape)
+                };
+                inputs.insert(
+                    "shape".to_string(),
+                    Self::create_immediate_int_array(&shape_values),
+                );
             }
 
             // Convolution operations: input, filter + parameters

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1532,10 +1532,7 @@ impl CoremlMlProgramConverter {
                 }
 
                 // MIL `reshape` declares `shape` as a required input. Always emit
-                // it, including the scalar-output case (`new_shape = []`) which is
-                // valid WebNN — the WPT "reshape (squeeze) 4D to scalar" test
-                // surfaces this: Apple's loader rejects the model with
-                // "Required param 'shape' is missing" otherwise.
+                // it, including the valid WebNN scalar-output case (`new_shape = []`)
                 let shape_values = if new_shape.is_empty() {
                     Vec::new()
                 } else {


### PR DESCRIPTION
Third PR in the stack from #101 (after #102, #103).

## Problem

MIL's `reshape` op declares `shape` as a required input. The current emitter skips it when `new_shape` is empty, but that is a valid WebNN reshape-to-scalar case. Apple's CoreML loader rejects these models on-device with:

```
Validation error parsing MIL model: Required param 'shape' is missing
```

## Fix

Always emit the `shape` input — using an empty int32 array when `new_shape` is empty — so MIL's reshape has the required field in every case, including the 0-D output case.

## How this was surfaced

Running WPT conformance `reshape.json` test "reshape (squeeze) float32 4D tensor by eliminating all dimensions" on Apple Watch SE 2 (arm64_32, watchOS 11) as part of the same on-device WebNN sweep that produced #102 and #103.

## CI

Green on rebeckerspecialties/rustnn#3 (Rust Tests + RustNNPT Conformance Gate + Doc Build all pass; rebased against current `main` at 2f7523d).

Refs #101.