### PR TITLE
CoreML MLProgram: always emit slice `begin` and `size` inputs

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1947,24 +1947,26 @@ impl CoremlMlProgramConverter {
                 options,
                 ..
             } => {
-                // slice_by_size: x, begin, size
+                // slice_by_size: x, begin, size. Both `begin` and `size` are
+                // declared required inputs in MIL's slice_by_size schema. Apple
+                // rejects the model with "Required param 'size' is missing"
+                // when an empty-shape no-op slice (0D scalar, WPT surfaces this)
+                // is emitted without the fields. Emit them as empty int32 arrays
+                // in that case so the MIL loader sees the param even though the
+                // tensor is rank-0.
                 if !input_names.is_empty() {
                     inputs.insert("x".to_string(), Self::create_argument(&input_names[0]));
                 }
 
-                if !starts.is_empty() {
-                    inputs.insert(
-                        "begin".to_string(),
-                        Self::create_immediate_int_array(starts),
-                    );
-                }
-                if !sizes.is_empty() {
-                    let sizes_u32: Vec<u32> = sizes.iter().map(|d| d.static_or_max()).collect();
-                    inputs.insert(
-                        "size".to_string(),
-                        Self::create_immediate_int_array(&sizes_u32),
-                    );
-                }
+                inputs.insert(
+                    "begin".to_string(),
+                    Self::create_immediate_int_array(starts),
+                );
+                let sizes_u32: Vec<u32> = sizes.iter().map(|d| d.static_or_max()).collect();
+                inputs.insert(
+                    "size".to_string(),
+                    Self::create_immediate_int_array(&sizes_u32),
+                );
                 let _ = options;
             }
 


### PR DESCRIPTION
Fourth PR in the stack from #101.

## Problem

MIL's `slice_by_size` op declares `begin` and `size` as required inputs. The current emitter skips them when the corresponding `starts` / `sizes` vectors are empty — valid WebNN for the 0-D scalar no-op slice case. Apple's CoreML loader rejects the model on-device with:

```
Validation error parsing MIL model: Required param 'size' is missing
```

## Fix

Always emit both `begin` and `size` inputs — using empty int32 arrays when the WebNN fields are empty — so MIL receives the required params.

## How this was surfaced

Running WPT conformance `slice.json` test "slicing float32 0D constant tensor with empty starts and sizes should be a no-op" on Apple Watch SE 2 (arm64_32, watchOS 11). Same on-device sweep as #102, #103, and the reshape PR submitted alongside this one.

## CI

Green on rebeckerspecialties/rustnn#4 (Rust Tests + RustNNPT Conformance Gate + Doc Build all pass; rebased against current `main` at 2f7523d).

Refs #101.