### PR TITLE
CoreML MLProgram: fix neg 0-D scalar rank mismatch

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -662,6 +662,46 @@ impl CoremlMlProgramConverter {
         }
     }
 
+    /// Like `create_immediate_float` but produces a rank-1 `tensor<fp32,[1]>`
+    /// rather than a rank-0 scalar. MIL ops like `mul` preserve rank rather
+    /// than broadcasting scalars up, so when an operation's declared output
+    /// rank is 1 and one of its inputs is the scalar -1 (as in the `neg`
+    /// lowering), we need the constant to have matching rank.
+    fn create_immediate_float_1d(value: f32) -> Argument {
+        use crate::protos::coreml::mil_spec::{
+            DataType as MilDataType, TensorType, TensorValue, Value, ValueType, dimension,
+            tensor_value, value, value_type,
+        };
+        let tensor_value = TensorValue {
+            value: Some(tensor_value::Value::Floats(tensor_value::RepeatedFloats {
+                values: vec![value],
+            })),
+        };
+        let val = Value {
+            doc_string: String::new(),
+            r#type: Some(ValueType {
+                r#type: Some(value_type::Type::TensorType(TensorType {
+                    data_type: MilDataType::Float32 as i32,
+                    rank: 1,
+                    dimensions: vec![Dimension {
+                        dimension: Some(dimension::Dimension::Constant(
+                            dimension::ConstantDimension { size: 1 },
+                        )),
+                    }],
+                    attributes: HashMap::new(),
+                })),
+            }),
+            value: Some(value::Value::ImmediateValue(value::ImmediateValue {
+                value: Some(value::immediate_value::Value::Tensor(tensor_value)),
+            })),
+        };
+        Argument {
+            arguments: vec![crate::protos::coreml::mil_spec::argument::Binding {
+                binding: Some(Binding::Value(val)),
+            }],
+        }
+    }
+
     /// Create an Argument from an immediate float scalar value
     fn create_immediate_float(value: f32) -> Argument {
         use crate::protos::coreml::mil_spec::{
@@ -3454,9 +3494,17 @@ impl super::GraphConverter for CoremlMlProgramConverter {
 
                 let input_name = operand_name(graph_info, op.input_operands()[0]);
 
-                // Create typed -1 constant matching input dtype
+                // Create typed -1 constant matching input dtype. MIL `mul`
+                // preserves rank rather than broadcasting scalars, so when
+                // the input operand was promoted from rank-0 to rank-1 `[1]`
+                // (the `scalar_as_one_dim: true` rule applied to all graph
+                // inputs/outputs), the multiplier must be rank-1 `[1]` too.
+                // Otherwise Apple's loader rejects with
+                //   "Output '0' has unexpected type 'ios17.mul'.
+                //    Expected tensor<fp32, [1]>; got fp32."
+                // (WPT "neg float32 positive 0D scalar" surfaces this.)
                 let neg_one_immediate = match input_operand.descriptor.data_type {
-                    DataType::Float32 => Self::create_immediate_float(-1.0f32),
+                    DataType::Float32 => Self::create_immediate_float_1d(-1.0f32),
                     DataType::Float16 => Self::create_immediate_float16(-1.0f32),
                     DataType::Int32 => {
                         // create_immediate_int accepts u32 but converts to i32 internally
@@ -3520,8 +3568,12 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 })?;
 
                 let output_dtype = Self::mil_data_type(&output_operand.descriptor.data_type)?;
+                // Use `scalar_as_one_dim: true` so a rank-0 output is promoted
+                // to `tensor<fp32, [1]>`, matching the rank of the mul's
+                // (promoted) input/multiplier. See comment on the mul input
+                // above — this keeps the full op consistent.
                 let output_dimensions =
-                    Self::mil_dimensions_from_graph_shape(&output_operand.descriptor.shape, false);
+                    Self::mil_dimensions_from_graph_shape(&output_operand.descriptor.shape, true);
 
                 let output_value_type = ValueType {
                     r#type: Some(


### PR DESCRIPTION
Fifth PR in the stack from #101 (after #102, #103; alongside #106 and #107).

## Problem

WebNN `neg` is lowered in this converter as `mul(x, -1)`. MIL's `mul` preserves input rank rather than broadcasting scalar constants up to the operand's declared type. When the input operand is rank-0 and the graph's rank-0 → rank-1 `[1]` promotion (the `scalar_as_one_dim: true` rule applied to all graph inputs/outputs) applies to the operand's declared output type, the emitted

```
tensor<fp32,[1]> negOutput = mul(x = negInput, y = fp32(-1));
```

is inferred by MIL as producing `fp32` (not `tensor<fp32,[1]>`), and Apple's CoreML loader rejects the model on-device with:

```
Output '0' has unexpected type 'ios17.mul'.
Expected tensor<fp32, [1]>; got fp32.
```

## Fix

1. Add `create_immediate_float_1d`, a companion to `create_immediate_float` that produces a rank-1 `tensor<fp32, [1]>` instead of a rank-0 scalar.
2. Use it for the `-1` multiplier in the `neg` lowering so the mul has rank-matched inputs.
3. Promote the mul's declared output shape via `scalar_as_one_dim: true` so a rank-0 WebNN output becomes `tensor<fp32, [1]>` too.

## How this was surfaced

Running WPT conformance `neg.json` test "neg float32 positive 0D scalar" on Apple Watch SE 2 (arm64_32, watchOS 11). Same on-device sweep as #102, #103, #106, #107.

## CI

Green on rebeckerspecialties/rustnn#5 (Rust Tests + RustNNPT Conformance Gate + Doc Build all pass; rebased against current `main` at 2f7523d).

Refs #101.