### PR TITLE
CoreML MLProgram: fix hard_swish 0-D scalar rank mismatch

### DIFF
--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -3078,11 +3078,20 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                     hardsigmoid_inputs
                         .insert("beta".to_string(), Self::create_immediate_float(0.5));
 
-                    // Create tensor type for hardsigmoid output
+                    // Create tensor type for hardsigmoid output.
+                    // Use `scalar_as_one_dim: true` to match the promotion the
+                    // rest of the converter applies to rank-0 operands — with
+                    // `false`, a rank-0 input gives hardsigmoid an rank-0
+                    // intermediate while the graph's declared output is
+                    // `tensor<fp32, [1]>`, and Apple's loader rejects the
+                    // following `mul` with
+                    //   "Output '0' has unexpected type 'ios17.mul'.
+                    //    Expected tensor<fp32, [1]>; got fp32."
+                    // (surfaced by WPT "hardSwish float32 0D scalar default options").
                     let dtype = Self::mil_data_type(&input_operand.descriptor.data_type)?;
                     let dimensions = Self::mil_dimensions_from_graph_shape(
                         &input_operand.descriptor.shape,
-                        false,
+                        true,
                     );
 
                     let value_type = ValueType {
@@ -3131,9 +3140,14 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                         })?;
 
                     let output_dtype = Self::mil_data_type(&output_operand.descriptor.data_type)?;
+                    // Same promotion as the hardsigmoid intermediate above: the
+                    // mul output must have the same rank as its inputs, and
+                    // the graph's input/output operands already went through
+                    // the `scalar_as_one_dim: true` pass when they were
+                    // declared in `main` block — so rank-0 becomes [1] here too.
                     let output_dimensions = Self::mil_dimensions_from_graph_shape(
                         &output_operand.descriptor.shape,
-                        false,
+                        true,
                     );
 
                     let output_value_type = ValueType {


### PR DESCRIPTION
Sixth PR in the stack from #101.

## Problem

WebNN `hardSwish` is lowered in this converter as `x * hardsigmoid(x, alpha=1/6, beta=0.5)`. The emitter creates the hardsigmoid intermediate and the `mul` output using `mil_dimensions_from_graph_shape(shape, false)` — so rank-0 inputs produce rank-0 intermediates and outputs.

But the graph's input and output operands are declared in the function signature with `scalar_as_one_dim: true`, promoting rank-0 to rank-1 `[1]`. The result: `mul(tensor<fp32,[1]>, fp32) -> fp32`, and Apple's CoreML loader rejects the model on-device with:

```
Output '0' has unexpected type 'ios17.mul'.
Expected tensor<fp32, [1]>; got fp32.
```

## Fix

Pass `scalar_as_one_dim: true` in both `mil_dimensions_from_graph_shape` calls inside the hardswish lowering, so the lowered `sigmoid_hard` and `mul` sub-ops agree with the promoted operand types.

## How this was surfaced

Running WPT conformance `hard_swish.json` test "hardSwish float32 0D scalar default options" on Apple Watch SE 2 (arm64_32, watchOS 11). Same root-cause pattern as the neg PR submitted alongside this one but for a different op lowering.

## CI

Green on rebeckerspecialties/rustnn#6 (Rust Tests + RustNNPT Conformance Gate + Doc Build all pass; rebased against current `main` at 2f7523d).

Refs #101.