### PR TITLE
deps: bump trtx to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,15 +57,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aquamarine"
@@ -154,7 +154,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "autocxx-engine",
  "env_logger",
  "indexmap 1.9.3",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ dependencies = [
  "regex_static",
  "rustversion",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.117",
  "tempfile",
  "thiserror 1.0.69",
  "version_check",
@@ -209,7 +209,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
@@ -265,14 +265,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d250916401487680ed13b8b675660281dcfc3ab0121fe44c94bcab9eae2fb"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -343,9 +343,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -388,21 +388,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -438,13 +438,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.2",
  "windows-sys",
 ]
@@ -535,7 +534,7 @@ dependencies = [
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash",
+ "foldhash 0.2.0",
  "link-cplusplus",
 ]
 
@@ -547,11 +546,11 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -561,10 +560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "035b6c61a944483e8a4b2ad4fb8b13830d63491bd004943716ad16d85dcc64bc"
 dependencies = [
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -575,10 +574,10 @@ checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -593,10 +592,10 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -611,12 +610,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -630,21 +629,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -655,34 +653,34 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -690,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -716,7 +714,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -726,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -797,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -818,6 +816,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -841,6 +845,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,8 +886,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -887,16 +928,31 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -972,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,12 +1052,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1045,6 +1107,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1063,25 +1134,33 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1114,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1191,7 +1270,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1219,7 +1298,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1290,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1323,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1335,9 +1414,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -1347,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1357,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1378,7 +1457,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1389,9 +1468,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -1401,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "half",
  "libloading 0.9.0",
@@ -1416,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -1433,9 +1512,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1476,7 +1555,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1496,20 +1575,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1519,9 +1598,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1548,7 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1602,7 +1681,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -1611,7 +1690,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -1622,10 +1701,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1639,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1653,10 +1732,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1678,7 +1763,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1689,9 +1774,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1735,7 +1820,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1747,7 +1832,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1758,7 +1843,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1769,9 +1854,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regex_static"
@@ -1809,15 +1894,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1828,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -1888,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys",
 ]
@@ -1927,9 +2012,9 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1940,13 +2025,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1975,7 +2066,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1993,15 +2084,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2012,14 +2103,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2038,6 +2129,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2093,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2104,12 +2201,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2150,7 +2247,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2161,7 +2258,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2207,7 +2304,7 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.3.4",
  "indicatif",
  "itertools 0.14.0",
  "log",
@@ -2219,7 +2316,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax 0.8.9",
+ "regex-syntax 0.8.10",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -2250,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "trtx"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33e2037d309568bc023bb161c9ea23168ac0e345d398c912061d63dc3fb8415"
+checksum = "58fe5f8fc1b4d8dda3a9ebd5fe232e81149bd68361d7f932a55e1fed866de1a5"
 dependencies = [
  "autocxx",
  "cudarc",
@@ -2266,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "trtx-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e29236a965ef87398a0cb398f69e7a83b0eead80578cea5bbe1131363955ee"
+checksum = "1efd9036abbd2775da5df4e49793ec8e656f026fb9c60dff7e95bda2d654e634"
 dependencies = [
  "autocxx",
  "autocxx-build",
@@ -2280,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -2307,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2322,6 +2419,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -2337,9 +2440,9 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "der",
@@ -2349,15 +2452,15 @@ dependencies = [
  "rustls-pki-types",
  "socks",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-root-certs",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -2366,10 +2469,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -2391,18 +2494,27 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2413,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2423,24 +2535,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -2489,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2548,7 +2694,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2559,7 +2705,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2600,25 +2746,113 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ort = { version = "2.0.0-rc.11", optional = true, features = ["ndarray", "half",
 tempfile = { version = "3.8", optional = true }
 tokenizers = { version = "0.22", optional = true }
 half = "2.4"
-trtx = { version = "0.4.0", optional = true }
+trtx = { version = "0.5.0", optional = true }
 regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -325,7 +325,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -344,7 +344,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -363,7 +363,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -382,7 +382,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -507,7 +507,7 @@ impl TrtxConverter {
 
                 let tensor =
                     layer
-                        .get_output(&*network, 0)
+                        .output(&*network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Failed to get constant layer output: {}", e),
@@ -872,7 +872,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor0: {}", e),
                 })?;
             let t0 = id0
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -885,7 +885,7 @@ impl TrtxConverter {
                     reason: format!("Failed to clone tensor1: {}", e),
                 })?;
             let t1 = id1
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -923,12 +923,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
-                let t0 =
-                    id0.get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get identity output: {}", e),
-                        })?;
+                let t0 = id0
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?;
 
                 let id1 =
                     network
@@ -937,12 +937,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
-                let t1 =
-                    id1.get_output(&*network, 0)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Failed to get identity output: {}", e),
-                        })?;
+                let t1 = id1
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?;
 
                 return Ok((t0, t1));
             }
@@ -966,7 +966,7 @@ impl TrtxConverter {
                 resize_layer.set_output_dimensions(network, &dims1);
 
                 resize_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -979,7 +979,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor0: {}", e),
                         })?;
-                id.get_output(&*network, 0)
+                id.output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -1003,7 +1003,7 @@ impl TrtxConverter {
                 resize_layer.set_output_dimensions(network, &dims0);
 
                 resize_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get resize output: {}", e),
@@ -1016,7 +1016,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("Failed to clone tensor1: {}", e),
                         })?;
-                id.get_output(&*network, 0)
+                id.output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -1071,7 +1071,7 @@ impl TrtxConverter {
 
         let reshaped =
             shuffle_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape output: {}", e),
@@ -1085,7 +1085,7 @@ impl TrtxConverter {
                 reason: format!("Failed to clone kept tensor: {}", e),
             })?;
         let kept = id_keep
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -1140,7 +1140,7 @@ impl TrtxConverter {
                     reason: format!("{op_label} broadcast identity: {e}"),
                 })?;
             return layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{op_label} broadcast identity output: {e}"),
@@ -1168,12 +1168,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("{op_label} broadcast reshape: {e}"),
                 })?;
-            let out = shuffle_layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_label} broadcast shuffle output: {e}"),
-                }
-            })?;
+            let out =
+                shuffle_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_label} broadcast shuffle output: {e}"),
+                    })?;
             staged = Some(out);
             dims = new_shape;
             cur = staged
@@ -1223,7 +1224,7 @@ impl TrtxConverter {
                 })?;
         resize_layer.set_output_dimensions(network, target_dims);
         resize_layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{op_label} broadcast resize output: {e}"),
@@ -1265,7 +1266,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1311,13 +1312,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add comparison operation: {}", e),
             })?;
 
-        let bool_output =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let bool_output = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         // Cast BOOL to Float32 for WebNN compatibility
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -1386,13 +1386,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add logical operation: {}", e),
             })?;
 
-        let bool_output =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let bool_output = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         // Cast BOOL output back to Float32
         let output = Self::cast_to_float32(network, &bool_output)?;
@@ -1456,12 +1455,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: failed to add BOOL constant: {}", e),
                         })?;
-                    const_layer.get_output(&*network, 0).map_err(|e| {
-                        GraphError::ConversionFailed {
+                    const_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LogicalNot: BOOL constant output: {}", e),
-                        }
-                    })?
+                        })?
                 }
                 _ => Self::cast_to_bool(network, input)?,
             }
@@ -1476,13 +1475,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add logical NOT: {}", e),
             })?;
 
-        let not_output =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let not_output = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         let output = Self::cast_to_float32(network, &not_output)?;
 
@@ -1515,7 +1513,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1594,7 +1592,7 @@ impl TrtxConverter {
             })?;
         let relu_output =
             relu_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get relu output: {}", e),
@@ -1608,7 +1606,7 @@ impl TrtxConverter {
             })?;
         let exp_output =
             exp_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get exp output: {}", e),
@@ -1622,7 +1620,7 @@ impl TrtxConverter {
             })?;
         let one_tensor =
             one_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get one constant output: {}", e),
@@ -1637,12 +1635,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to subtract 1 for elu: {}", e),
             })?;
-        let exp_minus_1 = exp_minus_1_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get exp-1 output: {}", e),
-            }
-        })?;
+        let exp_minus_1 =
+            exp_minus_1_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get exp-1 output: {}", e),
+                })?;
 
         let zero_const = network
             .add_small_constant_copied(&broadcast_shape, &zero_bytes, trt_dtype)
@@ -1652,7 +1651,7 @@ impl TrtxConverter {
             })?;
         let zero_tensor =
             zero_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get zero constant output: {}", e),
@@ -1669,7 +1668,7 @@ impl TrtxConverter {
             })?;
         let neg_part =
             neg_part_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get neg part output: {}", e),
@@ -1683,7 +1682,7 @@ impl TrtxConverter {
             })?;
         let alpha_tensor =
             alpha_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get alpha constant output: {}", e),
@@ -1698,12 +1697,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to multiply by alpha for elu: {}", e),
             })?;
-        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get scaled neg output: {}", e),
-            }
-        })?;
+        let scaled_neg =
+            scaled_neg_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get scaled neg output: {}", e),
+                })?;
 
         let (bc_relu, bc_scaled) =
             Self::ensure_broadcast_compatible(network, &relu_output, &scaled_neg, "elu_add")?;
@@ -1716,7 +1716,7 @@ impl TrtxConverter {
             })?;
         let output =
             final_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get elu output: {}", e),
@@ -1752,7 +1752,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -1817,7 +1817,7 @@ impl TrtxConverter {
             })?;
         let alpha_tensor =
             alpha_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LeakyReLU: alpha const output: {}", e),
@@ -1832,7 +1832,7 @@ impl TrtxConverter {
             })?;
         let relu_output =
             relu_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get relu output: {}", e),
@@ -1847,7 +1847,7 @@ impl TrtxConverter {
             })?;
         let neg_part =
             neg_part_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get neg part output: {}", e),
@@ -1860,12 +1860,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale neg part for leaky relu: {}", e),
             })?;
-        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get scaled neg output: {}", e),
-            }
-        })?;
+        let scaled_neg =
+            scaled_neg_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get scaled neg output: {}", e),
+                })?;
 
         // relu(x) + alpha * min(0, x)
         let final_layer = network
@@ -1877,7 +1878,7 @@ impl TrtxConverter {
 
         let output =
             final_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get leaky relu output: {}", e),
@@ -1921,7 +1922,7 @@ impl TrtxConverter {
             })?;
         let relu_output =
             relu_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get relu output: {}", e),
@@ -1936,7 +1937,7 @@ impl TrtxConverter {
             })?;
         let zero_output =
             zero_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get zero output: {}", e),
@@ -1951,7 +1952,7 @@ impl TrtxConverter {
             })?;
         let neg_part =
             neg_part_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get negative part: {}", e),
@@ -1966,12 +1967,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to scale negative part: {}", e),
             })?;
-        let scaled_neg = scaled_neg_layer.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get scaled negative: {}", e),
-            }
-        })?;
+        let scaled_neg =
+            scaled_neg_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get scaled negative: {}", e),
+                })?;
 
         // Final: relu + slope * neg_part
         let final_layer = network
@@ -1983,7 +1985,7 @@ impl TrtxConverter {
 
         let output =
             final_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get prelu output: {}", e),
@@ -2023,13 +2025,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add hard sigmoid: {}", e),
                 })?;
-            let output =
-                layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get layer output: {}", e),
-                    })?;
+            let output = layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get layer output: {}", e),
+                })?;
             let output_ids = operation.output_operands_slice();
             tensor_map.insert(output_ids[0], output);
             return Ok(());
@@ -2096,32 +2097,31 @@ impl TrtxConverter {
 
         let alpha_out =
             alpha_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: alpha const output: {}", e),
                 })?;
         let beta_out =
             beta_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: beta const output: {}", e),
                 })?;
         let zero_out =
             zero_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: zero const output: {}", e),
                 })?;
-        let one_out =
-            one_const
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSigmoid: one const output: {}", e),
-                })?;
+        let one_out = one_const
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSigmoid: one const output: {}", e),
+            })?;
 
         // linear = alpha * x + beta
         let ax = network
@@ -2131,7 +2131,7 @@ impl TrtxConverter {
                 reason: format!("HardSigmoid: alpha*x: {}", e),
             })?;
         let linear = ax
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear get output: {}", e),
@@ -2142,12 +2142,13 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: linear+beta: {}", e),
             })?;
-        let linear_out = linear_plus_beta.get_output(&*network, 0).map_err(|e| {
-            GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("HardSigmoid: linear_out: {}", e),
-            }
-        })?;
+        let linear_out =
+            linear_plus_beta
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("HardSigmoid: linear_out: {}", e),
+                })?;
 
         // clamp(linear, 0, 1) = max(0, min(1, linear))
         let min1 = network
@@ -2157,7 +2158,7 @@ impl TrtxConverter {
                 reason: format!("HardSigmoid: min(1, linear): {}", e),
             })?;
         let min1_out = min1
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSigmoid: min1 output: {}", e),
@@ -2170,7 +2171,7 @@ impl TrtxConverter {
             })?;
         let output =
             output_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSigmoid: output: {}", e),
@@ -2252,21 +2253,20 @@ impl TrtxConverter {
 
         let three_out =
             three_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: 3 const output: {}", e),
                 })?;
-        let six_out =
-            six_const
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSwish: 6 const output: {}", e),
-                })?;
+        let six_out = six_const
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSwish: 6 const output: {}", e),
+            })?;
         let zero_out =
             zero_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: zero const output: {}", e),
@@ -2281,7 +2281,7 @@ impl TrtxConverter {
             })?;
         let x_plus_3_out =
             x_plus_3
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: x+3 output: {}", e),
@@ -2293,7 +2293,7 @@ impl TrtxConverter {
                 reason: format!("HardSwish: min(6, x+3): {}", e),
             })?;
         let min6_out = min6
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: min6 output: {}", e),
@@ -2304,13 +2304,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("HardSwish: max(0, ...): {}", e),
             })?;
-        let inner_out =
-            inner
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("HardSwish: inner output: {}", e),
-                })?;
+        let inner_out = inner
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("HardSwish: inner output: {}", e),
+            })?;
         let x_times_inner = network
             .add_elementwise(input, &inner_out, ElementWiseOperation::kPROD)
             .map_err(|e| GraphError::ConversionFailed {
@@ -2319,7 +2318,7 @@ impl TrtxConverter {
             })?;
         let x_times_inner_out =
             x_times_inner
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: x*inner output: {}", e),
@@ -2332,7 +2331,7 @@ impl TrtxConverter {
             })?;
         let output =
             output_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("HardSwish: output: {}", e),
@@ -2367,7 +2366,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get identity output: {}", e),
@@ -2448,12 +2447,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Failed to add identity for promoted scalar cast: {}", e),
                     })?;
-            let output = identity_layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get identity output: {}", e),
-                }
-            })?;
+            let output =
+                identity_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get identity output: {}", e),
+                    })?;
             tensor_map.insert(output_id, output);
             return Ok(());
         }
@@ -2470,7 +2470,7 @@ impl TrtxConverter {
                     reason: format!("{}: {}", err_prefix, e),
                 })?;
             scale_constant
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: get scale output: {}", err_prefix, e),
@@ -2515,7 +2515,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let reshaped_4d = shuffle_to_4d.get_output(&*network, 0).map_err(|e| {
+                let reshaped_4d = shuffle_to_4d.output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to get reshape output: {}", e),
@@ -2530,12 +2530,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add dequantize for int8->float32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_f32");
-                let output = dq_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get dequantize output: {}", e),
-                    }
-                })?;
+                let output =
+                    dq_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get dequantize output: {}", e),
+                        })?;
                 let _ = output.set_name(network, "cast_flat_dq_f32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
@@ -2571,7 +2572,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to set reshape dimensions: {}", e),
                     })?;
-                let reshaped_4d = shuffle_to_4d.get_output(&*network, 0).map_err(|e| {
+                let reshaped_4d = shuffle_to_4d.output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Cast: failed to get reshape output: {}", e),
@@ -2586,12 +2587,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add dequantize for int8->int32 cast: {}", e),
                     })?;
                 let _ = dq_layer.set_name(network, "cast_flat_dq_int32");
-                let dq_out = dq_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get dequantize output: {}", e),
-                    }
-                })?;
+                let dq_out =
+                    dq_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get dequantize output: {}", e),
+                        })?;
                 let _ = dq_out.set_name(network, "cast_flat_dq_int32");
                 let mut cast_layer =
                     network
@@ -2601,12 +2603,13 @@ impl TrtxConverter {
                             reason: format!("Failed to add cast to INT32: {}", e),
                         })?;
                 let _ = cast_layer.set_name(network, "cast_flat_cast_int32");
-                let output = cast_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get cast output: {}", e),
-                    }
-                })?;
+                let output =
+                    cast_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get cast output: {}", e),
+                        })?;
                 let _ = output.set_name(network, "cast_flat_cast_int32");
                 tensor_map.insert(output_id, output);
                 return Ok(());
@@ -2625,7 +2628,7 @@ impl TrtxConverter {
                 })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cast output: {}", e),
@@ -2664,7 +2667,7 @@ impl TrtxConverter {
                     reason: format!("{label}: reshape [1]: {e}"),
                 }
             })?;
-            sh.get_output(&*network, 0)
+            sh.output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{label}: shuffle output: {e}"),
@@ -2676,7 +2679,7 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("{label}: identity: {e}"),
                 })?;
-            id.get_output(&*network, 0)
+            id.output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{label}: identity output: {e}"),
@@ -2705,7 +2708,7 @@ impl TrtxConverter {
                     reason: format!("{label}: prepend identity: {e}"),
                 })?;
             return id
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{label}: prepend identity output: {e}"),
@@ -2734,7 +2737,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label}: prepend reshape: {e}"),
             })?;
-        sh.get_output(&*network, 0)
+        sh.output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label}: prepend shuffle output: {e}"),
@@ -2783,7 +2786,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix zero: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix zero out: {e}"),
@@ -2794,7 +2797,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix 256: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix 256 out: {e}"),
@@ -2805,7 +2808,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix less0: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix less0 out: {e}"),
@@ -2817,7 +2820,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix +256: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix +256 out: {e}"),
@@ -2829,7 +2832,7 @@ impl TrtxConverter {
             }
         })?;
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} uint8 zp fix select out: {e}"),
@@ -2870,7 +2873,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} identity DQ scale constant: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label} identity DQ scale tensor: {e}"),
@@ -2881,13 +2884,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("{label} identity DQ: {e}"),
             })?;
-        let dq_out =
-            dq_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{label} identity DQ output: {e}"),
-                })?;
+        let dq_out = dq_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label} identity DQ output: {e}"),
+            })?;
 
         match (webnn_integer_dtype, input_ty) {
             (DataType::Uint8, TrtDataType::kINT8) => {
@@ -2922,7 +2924,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("{label} kUINT8 +128 bias: {e}"),
                     })?
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{label} kUINT8 +128 tensor: {e}"),
@@ -2933,7 +2935,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("{label} kUINT8 +128 sum: {e}"),
                     })?
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{label} kUINT8 +128 output: {e}"),
@@ -3064,7 +3066,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("{label}: block tile slice ax={ax} k={k}: {e}"),
                     })?
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{label}: block tile slice output ax={ax} k={k}: {e}"),
@@ -3077,7 +3079,7 @@ impl TrtxConverter {
                     }
                 })?;
                 cat.set_axis(network, ax as i32);
-                expanded_parts.push(cat.get_output(&*network, 0).map_err(|e| {
+                expanded_parts.push(cat.output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{label}: block tile dup out ax={ax} k={k}: {e}"),
@@ -3093,7 +3095,7 @@ impl TrtxConverter {
             })?;
             cat2.set_axis(network, ax as i32);
             cur = cat2
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{label}: block tile merge out ax={ax}: {e}"),
@@ -3172,7 +3174,7 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("quantizeLinear manual {lab} to compute fp: {e}"),
                         })?
-                        .get_output(&*network, 0)
+                        .output(&*network, 0)
                         .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("quantizeLinear manual {lab} cast out: {e}"),
@@ -3189,7 +3191,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual div: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual div output: {e}"),
@@ -3201,7 +3203,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual round: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual round output: {e}"),
@@ -3213,7 +3215,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual add zero_point: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual add output: {e}"),
@@ -3256,7 +3258,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual qmin constant: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual qmin output: {e}"),
@@ -3268,7 +3270,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual qmax constant: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual qmax output: {e}"),
@@ -3280,7 +3282,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual clamp max(qmin): {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual clamp lo output: {e}"),
@@ -3292,7 +3294,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual clamp min(qmax): {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual clamp hi output: {e}"),
@@ -3304,7 +3306,7 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual output cast: {e}"),
             })?
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("quantizeLinear manual output: {e}"),
@@ -3498,7 +3500,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("quantizeLinear default zero_point constant: {e}"),
                     })?
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("quantizeLinear default zero_point output: {e}"),
@@ -3551,7 +3553,7 @@ impl TrtxConverter {
                         reason: format!("quantizeLinear scalar output reshape: {e}"),
                     }
                 })?;
-                sh.get_output(&*network, 0)
+                sh.output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("quantizeLinear scalar shuffle output: {e}"),
@@ -3587,7 +3589,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get quantize output: {}", e),
@@ -3718,7 +3720,7 @@ impl TrtxConverter {
 
         let mut dq_out =
             dq_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get dequantize output: {}", e),
@@ -3766,7 +3768,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("dequantizeLinear zero_point identity: {e}"),
                     })?;
-                id.get_output(&*network, 0)
+                id.output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("dequantizeLinear zero_point identity output: {e}"),
@@ -3783,7 +3785,7 @@ impl TrtxConverter {
                     })?;
             let zp_fp =
                 zp_fp_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("dequantizeLinear zero_point cast output: {}", e),
@@ -3794,7 +3796,7 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("dequantizeLinear zero_point * scale: {}", e),
                 })?
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dequantizeLinear zero_point * scale output: {}", e),
@@ -3805,7 +3807,7 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("dequantizeLinear subtract zp*scale: {}", e),
                 })?
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dequantizeLinear corrected output: {}", e),
@@ -3849,30 +3851,31 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
-            if layout == "nhwc" {
-                let mut shuffle =
-                    network
-                        .add_shuffle(input)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("globalPool NHWC->NCHW shuffle: {e}"),
-                        })?;
-                shuffle
-                    .set_first_transpose(network, &[0, 3, 1, 2])
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("globalPool set_first_transpose NHWC: {e}"),
+                        reason: format!("globalPool NHWC->NCHW shuffle: {e}"),
                     })?;
-                Some(shuffle.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("globalPool set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("globalPool NHWC shuffle output: {e}"),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let pool_in = nhwc_to_nchw.as_ref().unwrap_or(input);
 
         let input_dims =
@@ -3902,13 +3905,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add global pooling: {}", e),
             })?;
 
-        let pooled_nchw =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let pooled_nchw = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         let output = if layout == "nhwc" {
             let mut shuffle =
@@ -3925,7 +3927,7 @@ impl TrtxConverter {
                     reason: format!("globalPool set_first_transpose NCHW: {e}"),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("globalPool NCHW shuffle output: {e}"),
@@ -4005,7 +4007,7 @@ impl TrtxConverter {
                 })?;
             let reshaped0 =
                 shuffle
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: shuffle output: {}", e),
@@ -4036,7 +4038,7 @@ impl TrtxConverter {
                 })?;
             let reshaped1 =
                 shuffle
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Matmul: shuffle output: {}", e),
@@ -4054,7 +4056,7 @@ impl TrtxConverter {
         })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -4128,7 +4130,7 @@ impl TrtxConverter {
                 }
             })?;
             return shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
@@ -4161,7 +4163,7 @@ impl TrtxConverter {
             })?;
         let mut result =
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get shuffle output for {}: {}", op_name, e),
@@ -4184,16 +4186,12 @@ impl TrtxConverter {
                     reason: format!("Failed to set second transpose for {}: {}", op_name, e),
                 }
             })?;
-            result =
-                shuffle2
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!(
-                            "Failed to get second shuffle output for {}: {}",
-                            op_name, e
-                        ),
-                    })?;
+            result = shuffle2
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get second shuffle output for {}: {}", op_name, e),
+                })?;
         }
         Ok(result)
     }
@@ -4258,7 +4256,7 @@ impl TrtxConverter {
 
         let x_minus_mean =
             sub_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sub output: {}", e),
@@ -4289,7 +4287,7 @@ impl TrtxConverter {
 
         let sqrt_var =
             sqrt_var_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sqrt output: {}", e),
@@ -4306,7 +4304,7 @@ impl TrtxConverter {
 
         let normalized =
             div_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get div output: {}", e),
@@ -4342,13 +4340,12 @@ impl TrtxConverter {
                 })?;
             let _ = mul_layer.set_name(network, "batch_norm_scale_mul");
 
-            result =
-                mul_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get mul output: {}", e),
-                    })?;
+            result = mul_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mul output: {}", e),
+                })?;
         }
 
         // Step 6: Apply bias if present (WebNN: bias is in MLBatchNormalizationOptions, not a positional input)
@@ -4380,13 +4377,12 @@ impl TrtxConverter {
                 })?;
             let _ = add_layer.set_name(network, "batch_norm_bias_add");
 
-            result =
-                add_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get add output: {}", e),
-                    })?;
+            result = add_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get add output: {}", e),
+                })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -4455,13 +4451,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add mean reduce for instance norm: {}", e),
             })?;
 
-        let mean =
-            mean_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mean output: {}", e),
-                })?;
+        let mean = mean_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get mean output: {}", e),
+            })?;
 
         // x - mean
         let sub_layer = network
@@ -4473,7 +4468,7 @@ impl TrtxConverter {
 
         let x_minus_mean =
             sub_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sub output: {}", e),
@@ -4489,7 +4484,7 @@ impl TrtxConverter {
 
         let squared =
             square_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
@@ -4510,7 +4505,7 @@ impl TrtxConverter {
 
         let variance =
             var_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get variance output: {}", e),
@@ -4559,7 +4554,7 @@ impl TrtxConverter {
             })?;
         let epsilon_out =
             epsilon_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: epsilon const output: {}", e),
@@ -4572,7 +4567,7 @@ impl TrtxConverter {
             })?;
         let var_plus_eps_out =
             var_plus_eps
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: var_plus_eps output: {}", e),
@@ -4588,7 +4583,7 @@ impl TrtxConverter {
 
         let std_dev =
             sqrt_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sqrt output: {}", e),
@@ -4604,7 +4599,7 @@ impl TrtxConverter {
 
         let mut result =
             div_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get div output: {}", e),
@@ -4666,12 +4661,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set scale reshape: {}", e),
                 })?;
-            let scale_bc = scale_shuffle.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
-                }
-            })?;
+            let scale_bc =
+                scale_shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("InstanceNorm: failed to get scale shuffle output: {}", e),
+                    })?;
 
             let mul_layer = network
                 .add_elementwise(&result, &scale_bc, ElementWiseOperation::kPROD)
@@ -4680,13 +4676,12 @@ impl TrtxConverter {
                     reason: format!("Failed to add mul for scale: {}", e),
                 })?;
 
-            result =
-                mul_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get mul output: {}", e),
-                    })?;
+            result = mul_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mul output: {}", e),
+                })?;
         }
 
         // Apply bias if present (add)
@@ -4712,12 +4707,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("InstanceNorm: failed to set bias reshape: {}", e),
                 })?;
-            let bias_bc = bias_shuffle.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
-                }
-            })?;
+            let bias_bc =
+                bias_shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("InstanceNorm: failed to get bias shuffle output: {}", e),
+                    })?;
 
             let add_layer = network
                 .add_elementwise(&result, &bias_bc, ElementWiseOperation::kSUM)
@@ -4726,13 +4722,12 @@ impl TrtxConverter {
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result =
-                add_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get add output: {}", e),
-                    })?;
+            result = add_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get add output: {}", e),
+                })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -4807,7 +4802,7 @@ impl TrtxConverter {
                 })?;
             let mut result =
                 zero_const
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: zero const output: {}", e),
@@ -4834,7 +4829,7 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to set bias reshape: {}", e),
                     })?;
-                let bias_bc = bias_shuffle.get_output(&*network, 0).map_err(|e| {
+                let bias_bc = bias_shuffle.output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: bias shuffle output: {}", e),
@@ -4846,12 +4841,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm 0D: failed to add bias: {}", e),
                     })?;
-                result = add_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm 0D: bias add output: {}", e),
-                    }
-                })?;
+                result =
+                    add_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm 0D: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -4904,7 +4900,7 @@ impl TrtxConverter {
                 })?;
             let mut result =
                 zero_const
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: zero const output: {}", e),
@@ -4958,12 +4954,12 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    bias_const.get_output(&*network, 0).map_err(|e| {
-                        GraphError::ConversionFailed {
+                    bias_const
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: bias const output: {}", e),
-                        }
-                    })?
+                        })?
                 } else {
                     // Bias is an input (e.g. from test harness). Broadcast scalar to result shape via ensure_broadcast_compatible with ones.
                     let ones_bytes: Vec<u8> = match input_operand.descriptor.data_type {
@@ -4981,7 +4977,7 @@ impl TrtxConverter {
                                 e
                             ),
                         })?;
-                    let ones_tensor = ones_const.get_output(&*network, 0).map_err(|e| {
+                    let ones_tensor = ones_const.output(&*network, 0).map_err(|e| {
                         GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm axes=[]: ones const output: {}", e),
@@ -5001,12 +4997,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm axes=[]: failed to add bias: {}", e),
                     })?;
-                result = add_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("LayerNorm axes=[]: bias add output: {}", e),
-                    }
-                })?;
+                result =
+                    add_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("LayerNorm axes=[]: bias add output: {}", e),
+                        })?;
             }
             let output_id = operation.output_operands_slice()[0];
             tensor_map.insert(output_id, result);
@@ -5032,13 +5029,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add mean reduce for layer norm: {}", e),
             })?;
 
-        let mean =
-            mean_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get mean output: {}", e),
-                })?;
+        let mean = mean_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get mean output: {}", e),
+            })?;
 
         // x - mean
         let sub_layer = network
@@ -5050,7 +5046,7 @@ impl TrtxConverter {
 
         let x_minus_mean =
             sub_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sub output: {}", e),
@@ -5066,7 +5062,7 @@ impl TrtxConverter {
 
         let squared =
             square_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
@@ -5087,7 +5083,7 @@ impl TrtxConverter {
 
         let variance =
             var_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get variance output: {}", e),
@@ -5134,7 +5130,7 @@ impl TrtxConverter {
             })?;
         let epsilon_out =
             epsilon_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: epsilon const output: {}", e),
@@ -5147,7 +5143,7 @@ impl TrtxConverter {
             })?;
         let variance_eps =
             var_plus_eps
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm: variance+eps output: {}", e),
@@ -5163,7 +5159,7 @@ impl TrtxConverter {
 
         let std_dev =
             sqrt_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sqrt output: {}", e),
@@ -5179,7 +5175,7 @@ impl TrtxConverter {
 
         let mut result =
             div_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get div output: {}", e),
@@ -5216,12 +5212,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("LayerNorm {}: identity: {}", op_name, e),
                         })?;
-                return id_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+                return id_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("LayerNorm {}: identity output: {}", op_name, e),
-                    }
-                });
+                    });
             }
             let (new_shape, transpose_perm): (Vec<i32>, Option<Vec<i32>>) =
                 if tensor_dims.len() == axes.len() {
@@ -5282,7 +5278,7 @@ impl TrtxConverter {
                     reason: format!("LayerNorm {}: set reshape: {}", op_name, e),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("LayerNorm {}: shuffle output: {}", op_name, e),
@@ -5305,13 +5301,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Failed to add scale: {}", e),
                 })?;
-            result =
-                mul_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get mul output: {}", e),
-                    })?;
+            result = mul_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get mul output: {}", e),
+                })?;
         }
 
         if let Some(bias_id) = bias_operand_id {
@@ -5330,13 +5325,12 @@ impl TrtxConverter {
                     reason: format!("Failed to add bias: {}", e),
                 })?;
 
-            result =
-                add_layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get add output: {}", e),
-                    })?;
+            result = add_layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Failed to get add output: {}", e),
+                })?;
         }
 
         let output_ids = operation.output_operands_slice();
@@ -5388,7 +5382,7 @@ impl TrtxConverter {
                     })?;
             let output =
                 id_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Reduce axes=[] output: {}", e),
@@ -5413,7 +5407,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -5447,7 +5441,7 @@ impl TrtxConverter {
 
         let abs_output =
             abs_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get abs output: {}", e),
@@ -5493,7 +5487,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -5534,7 +5528,7 @@ impl TrtxConverter {
 
         let square_output =
             square_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
@@ -5563,7 +5557,7 @@ impl TrtxConverter {
                 })?;
             let output =
                 sqrt_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("ReduceL2 axes=[] output: {}", e),
@@ -5596,7 +5590,7 @@ impl TrtxConverter {
 
         let sum_output =
             sum_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sum output: {}", e),
@@ -5611,7 +5605,7 @@ impl TrtxConverter {
 
         let sqrt_output =
             sqrt_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get layer output: {}", e),
@@ -5664,7 +5658,7 @@ impl TrtxConverter {
                 })?;
             let output =
                 log_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("ReduceLogSum axes=[] output: {}", e),
@@ -5695,7 +5689,7 @@ impl TrtxConverter {
 
         let sum_output =
             sum_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sum output: {}", e),
@@ -5709,13 +5703,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add log for LogSum: {}", e),
             })?;
 
-        let output =
-            log_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let output = log_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -5745,7 +5738,7 @@ impl TrtxConverter {
 
         let exp_output =
             exp_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get exp output: {}", e),
@@ -5775,7 +5768,7 @@ impl TrtxConverter {
                     })?;
             let output =
                 id_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("ReduceLogSumExp axes=[] output: {}", e),
@@ -5806,7 +5799,7 @@ impl TrtxConverter {
 
         let sum_output =
             sum_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get sum output: {}", e),
@@ -5820,13 +5813,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add log for LogSumExp: {}", e),
             })?;
 
-        let output =
-            log_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let output = log_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -5856,7 +5848,7 @@ impl TrtxConverter {
 
         let square_output =
             square_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get square output: {}", e),
@@ -5902,7 +5894,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -5965,7 +5957,7 @@ impl TrtxConverter {
                     })?;
             let output =
                 id_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Slice no-op output: {}", e),
@@ -6011,7 +6003,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -6118,7 +6110,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add slice layer for split {}: {}", k, e),
                     })?;
                 layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get layer output for split {}: {}", k, e),
@@ -6163,7 +6155,7 @@ impl TrtxConverter {
         // For now, this creates the layer structure correctly
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -6222,7 +6214,7 @@ impl TrtxConverter {
         // with the expanded shape (inserting 1s at specified axes)
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -6300,7 +6292,7 @@ impl TrtxConverter {
             })?;
         let ones_tensor =
             ones_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get ones constant output: {}", e),
@@ -6315,13 +6307,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add multiply for expand: {}", e),
             })?;
-        let output =
-            mul_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get expand output: {}", e),
-                })?;
+        let output = mul_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get expand output: {}", e),
+            })?;
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
@@ -6408,12 +6399,16 @@ impl TrtxConverter {
             concat_layer.set_axis(network, axis as i32);
 
             // Get the output tensor
-            let output_tensor = concat_layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get concat output for tile axis {}: {}", axis, e),
-                }
-            })?;
+            let output_tensor =
+                concat_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Failed to get concat output for tile axis {}: {}",
+                            axis, e
+                        ),
+                    })?;
 
             // Use a temporary ID for intermediate results
             // We use a large number to avoid collisions with actual operand IDs
@@ -6451,12 +6446,13 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Tile: identity: {}", e),
                     })?;
-            let output_tensor = identity_layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Tile: identity output: {}", e),
-                }
-            })?;
+            let output_tensor =
+                identity_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Tile: identity output: {}", e),
+                    })?;
             tensor_map.insert(output_id, output_tensor);
         }
 
@@ -6500,7 +6496,7 @@ impl TrtxConverter {
 
         let greater_output =
             greater_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get greater output: {}", e),
@@ -6515,7 +6511,7 @@ impl TrtxConverter {
 
         let equal_output =
             equal_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get equal output: {}", e),
@@ -6530,7 +6526,7 @@ impl TrtxConverter {
 
         let bool_output =
             or_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get OR output: {}", e),
@@ -6578,7 +6574,7 @@ impl TrtxConverter {
 
         let lesser_output =
             lesser_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get lesser output: {}", e),
@@ -6593,7 +6589,7 @@ impl TrtxConverter {
 
         let equal_output =
             equal_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get equal output: {}", e),
@@ -6608,7 +6604,7 @@ impl TrtxConverter {
 
         let bool_output =
             or_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get OR output: {}", e),
@@ -6656,7 +6652,7 @@ impl TrtxConverter {
 
         let equal_output =
             equal_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get equal output: {}", e),
@@ -6671,7 +6667,7 @@ impl TrtxConverter {
 
         let bool_output =
             not_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get NOT output: {}", e),
@@ -6792,14 +6788,14 @@ impl TrtxConverter {
 
         let min_const_out =
             min_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get clamp min output: {}", e),
                 })?;
         let max_const_out =
             max_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get clamp max output: {}", e),
@@ -6813,7 +6809,7 @@ impl TrtxConverter {
             })?;
         let clamped_upper_out =
             clamped_upper
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get gather clamp upper output: {}", e),
@@ -6831,7 +6827,7 @@ impl TrtxConverter {
             })?;
         let clamped_indices =
             clamped
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get gather clamped indices output: {}", e),
@@ -6845,7 +6841,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gather output: {}", e),
@@ -6973,14 +6969,14 @@ impl TrtxConverter {
 
         let min_const_out =
             min_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherND: clamp min output: {}", e),
                 })?;
         let max_const_out =
             max_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherND: clamp max output: {}", e),
@@ -6994,7 +6990,7 @@ impl TrtxConverter {
             })?;
         let clamped_upper_out =
             clamped_upper
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherND: clamp upper tensor: {}", e),
@@ -7012,7 +7008,7 @@ impl TrtxConverter {
             })?;
         let clamped_indices =
             clamped
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherND: clamped indices: {}", e),
@@ -7028,7 +7024,7 @@ impl TrtxConverter {
         layer.set_gather_mode(network, trtx::GatherMode::kND);
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherND output: {}", e),
@@ -7092,7 +7088,7 @@ impl TrtxConverter {
         layer.set_axis(network, axis);
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterElements output: {}", e),
@@ -7146,7 +7142,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get scatterND output: {}", e),
@@ -7219,7 +7215,7 @@ impl TrtxConverter {
                 })?;
             let rank2 =
                 shuffle_in
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{}: rank-2 TopK input: {}", label, e),
@@ -7231,7 +7227,7 @@ impl TrtxConverter {
                     reason: format!("{}: topK layer: {}", label, e),
                 })?;
             layer
-                .get_output(&*network, 1)
+                .output(&*network, 1)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: topK indices output: {}", label, e),
@@ -7257,7 +7253,7 @@ impl TrtxConverter {
                 })?;
             let shuffled =
                 shuffle_pre
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("{}: pre-shuffle output: {}", label, e),
@@ -7275,7 +7271,7 @@ impl TrtxConverter {
                     reason: format!("{}: topK layer: {}", label, e),
                 })?;
             let idx = layer
-                .get_output(&*network, 1)
+                .output(&*network, 1)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: topK indices output: {}", label, e),
@@ -7295,7 +7291,7 @@ impl TrtxConverter {
                     reason: format!("{}: set post-transpose: {}", label, e),
                 })?;
             shuffle_post
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: post-shuffle output: {}", label, e),
@@ -7308,7 +7304,7 @@ impl TrtxConverter {
                     reason: format!("{}: topK layer: {}", label, e),
                 })?;
             layer
-                .get_output(&*network, 1)
+                .output(&*network, 1)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("{}: topK indices output: {}", label, e),
@@ -7328,7 +7324,7 @@ impl TrtxConverter {
                 reason: format!("{}: set reshape dimensions: {}", label, e),
             })?;
         shuffle_layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{}: shuffle output: {}", label, e),
@@ -7603,7 +7599,7 @@ impl TrtxConverter {
 
         let max_const_output =
             max_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get max constant output: {}", e),
@@ -7618,7 +7614,7 @@ impl TrtxConverter {
 
         let clamped_upper_output =
             clamped_upper
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get upper clamp output: {}", e),
@@ -7634,7 +7630,7 @@ impl TrtxConverter {
 
         let min_const_output =
             min_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get min constant output: {}", e),
@@ -7652,7 +7648,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get clamp output: {}", e),
@@ -7750,7 +7746,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get select output: {}", e),
@@ -7818,12 +7814,13 @@ impl TrtxConverter {
                     reason: format!("Failed to create alpha constant: {}", e),
                 })?;
 
-            let alpha_tensor = alpha_constant.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get alpha constant output: {}", e),
-                }
-            })?;
+            let alpha_tensor =
+                alpha_constant
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get alpha constant output: {}", e),
+                    })?;
 
             // Multiply: alpha * x
             let mul_layer = network
@@ -7834,7 +7831,7 @@ impl TrtxConverter {
                 })?;
 
             mul_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get multiply output: {}", e),
@@ -7849,7 +7846,7 @@ impl TrtxConverter {
                         reason: format!("Failed to add identity layer: {}", e),
                     })?;
             identity_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -7873,12 +7870,13 @@ impl TrtxConverter {
                     reason: format!("Failed to create beta constant: {}", e),
                 })?;
 
-            let beta_tensor = beta_constant.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get beta constant output: {}", e),
-                }
-            })?;
+            let beta_tensor =
+                beta_constant
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Failed to get beta constant output: {}", e),
+                    })?;
 
             // Add: (alpha * x) + beta
             let add_layer = network
@@ -7889,7 +7887,7 @@ impl TrtxConverter {
                 })?;
 
             add_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get add output: {}", e),
@@ -7942,7 +7940,7 @@ impl TrtxConverter {
                     reason: format!("Pad concat: identity: {}", e),
                 })?;
             return id
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad concat: identity output: {}", e),
@@ -8008,7 +8006,7 @@ impl TrtxConverter {
                     reason: format!("Pad concat: constant: {}", e),
                 })?;
             layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad concat: constant output: {}", e),
@@ -8042,7 +8040,7 @@ impl TrtxConverter {
                     reason: format!("Pad concat: concat: {}", e),
                 })?;
         cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0)
+        cat.output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Pad concat: concat out: {}", e),
@@ -8065,7 +8063,7 @@ impl TrtxConverter {
                     reason: format!("Pad edge: identity: {}", e),
                 })?;
             return id
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad edge: identity output: {}", e),
@@ -8104,13 +8102,12 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Pad edge: left slice: {}", e),
             })?;
-        let left_t =
-            left_layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Pad edge: left slice output: {}", e),
-                })?;
+        let left_t = left_layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Pad edge: left slice output: {}", e),
+            })?;
 
         let mut start_right = vec![0i64; rank];
         start_right[axis] = d_ax - 1;
@@ -8124,7 +8121,7 @@ impl TrtxConverter {
             })?;
         let right_t =
             right_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad edge: right slice output: {}", e),
@@ -8147,7 +8144,7 @@ impl TrtxConverter {
                     reason: format!("Pad edge: concat: {}", e),
                 })?;
         cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0)
+        cat.output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Pad edge: concat out: {}", e),
@@ -8171,7 +8168,7 @@ impl TrtxConverter {
                     reason: format!("Pad reflect: identity: {}", e),
                 })?;
             return id
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Pad reflect: identity output: {}", e),
@@ -8221,13 +8218,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Pad reflect: pre slice: {}", e),
                 })?;
-            let slab =
-                layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad reflect: pre slice out: {}", e),
-                    })?;
+            let slab = layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: pre slice out: {}", e),
+                })?;
             pre_slabs.push(slab);
         }
 
@@ -8244,13 +8240,12 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("Pad reflect: post slice: {}", e),
                 })?;
-            let slab =
-                layer
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad reflect: post slice out: {}", e),
-                    })?;
+            let slab = layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad reflect: post slice out: {}", e),
+                })?;
             post_slabs.push(slab);
         }
 
@@ -8266,7 +8261,7 @@ impl TrtxConverter {
                     reason: format!("Pad reflect: concat: {}", e),
                 })?;
         cat.set_axis(network, axis as i32);
-        cat.get_output(&*network, 0)
+        cat.output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Pad reflect: concat out: {}", e),
@@ -8355,13 +8350,12 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("Pad no-op: failed to add identity: {}", e),
                     })?;
-            let out =
-                identity
-                    .get_output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Pad no-op: identity output: {}", e),
-                    })?;
+            let out = identity
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Pad no-op: identity output: {}", e),
+                })?;
             tensor_map.insert(operation.output_operands_slice()[0], out);
             return Ok(());
         }
@@ -8484,7 +8478,7 @@ impl TrtxConverter {
                 })?;
 
             reshape_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape output: {}", e),
@@ -8498,7 +8492,7 @@ impl TrtxConverter {
                         reason: format!("Failed to create identity layer: {}", e),
                     })?;
             identity
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get identity output: {}", e),
@@ -8558,7 +8552,7 @@ impl TrtxConverter {
 
         let padded_output =
             padding_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get padding output: {}", e),
@@ -8590,7 +8584,7 @@ impl TrtxConverter {
                 })?;
 
             reshape_back
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get reshape-back output: {}", e),
@@ -8704,13 +8698,12 @@ impl TrtxConverter {
                 reason: format!("Failed to add GEMM matrix multiply: {}", e),
             })?;
 
-        let mut result =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get GEMM layer output: {}", e),
-                })?;
+        let mut result = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get GEMM layer output: {}", e),
+            })?;
 
         // If alpha != 1.0, scale the result
         if (alpha - 1.0).abs() > 1e-6 {
@@ -8752,7 +8745,7 @@ impl TrtxConverter {
 
             let alpha_tensor =
                 alpha_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get alpha tensor: {}", e),
@@ -8768,7 +8761,7 @@ impl TrtxConverter {
 
             result =
                 scale_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get scaled output: {}", e),
@@ -8822,12 +8815,13 @@ impl TrtxConverter {
                         reason: format!("Failed to create beta constant: {}", e),
                     })?;
 
-                let beta_tensor = beta_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get beta tensor: {}", e),
-                    }
-                })?;
+                let beta_tensor =
+                    beta_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get beta tensor: {}", e),
+                        })?;
 
                 // Multiply C by beta
                 let scale_c_layer = network
@@ -8837,7 +8831,7 @@ impl TrtxConverter {
                         reason: format!("Failed to scale C by beta: {}", e),
                     })?;
 
-                let scaled_c = scale_c_layer.get_output(&*network, 0).map_err(|e| {
+                let scaled_c = scale_c_layer.output(&*network, 0).map_err(|e| {
                     GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get scaled C: {}", e),
@@ -8862,12 +8856,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add scaled C to result: {}", e),
                     })?;
 
-                result = add_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    }
-                })?;
+                result =
+                    add_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             } else {
                 let (r_bc, c_bc) =
                     Self::ensure_broadcast_compatible(network, &result, input_c, "gemm_options_c")?;
@@ -8881,12 +8876,13 @@ impl TrtxConverter {
                         reason: format!("Failed to add C to result: {}", e),
                     })?;
 
-                result = add_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("Failed to get final GEMM output: {}", e),
-                    }
-                })?;
+                result =
+                    add_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Failed to get final GEMM output: {}", e),
+                        })?;
             }
         }
 
@@ -9078,50 +9074,52 @@ impl TrtxConverter {
             })?;
 
         // NHWC input: TensorRT conv expects NCHW. Insert shuffle to transpose NHWC->NCHW before conv.
-        let nhwc_shuffle_output =
-            if input_layout == "nhwc" {
-                let mut shuffle =
-                    network
-                        .add_shuffle(input)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
-                        })?;
-                shuffle
-                    .set_first_transpose(network, &[0, 3, 1, 2])
+        let nhwc_shuffle_output = if input_layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
+                        reason: format!("Conv2d NHWC->NCHW shuffle: {}", e),
                     })?;
-                Some(shuffle.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Conv2d set_first_transpose NHWC->NCHW: {}", e),
+                })?;
+            Some(
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Conv2d NHWC shuffle output: {}", e),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let pre_conv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
         // TensorRT conv kernel is always Float; cast Half input to Float so types match.
-        let half_cast_output: Option<trtx::Tensor<'a>> =
-            if input_dtype == DataType::Float16 {
-                let cast_layer = network
-                    .add_cast(pre_conv_input, TrtDataType::kFLOAT)
+        let half_cast_output: Option<trtx::Tensor<'a>> = if input_dtype == DataType::Float16 {
+            let cast_layer = network
+                .add_cast(pre_conv_input, TrtDataType::kFLOAT)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Conv2d Half->Float cast: {}", e),
+                })?;
+            Some(
+                cast_layer
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("Conv2d Half->Float cast: {}", e),
-                    })?;
-                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
                         reason: format!("Conv2d cast output: {}", e),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let conv_input_source = half_cast_output.as_ref().unwrap_or(pre_conv_input);
 
         // Stride, padding, dilation, groups from typed options
@@ -9169,12 +9167,12 @@ impl TrtxConverter {
                         reason: format!("Failed to add padding layer: {}", e),
                     })?;
 
-                padding_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+                padding_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get padding layer output: {}", e),
-                    }
-                })?
+                    })?
             } else {
                 // No padding needed, use conv_input_source directly
                 let id_layer = network.add_identity(conv_input_source).map_err(|e| {
@@ -9184,7 +9182,7 @@ impl TrtxConverter {
                     }
                 })?;
                 id_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get identity output: {}", e),
@@ -9233,7 +9231,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                        Some(cast_layer.output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("Conv2d filter cast output: {}", e),
@@ -9259,7 +9257,7 @@ impl TrtxConverter {
                                         reason: format!("Conv2d bias Half->Float cast: {}", e),
                                     }
                                 })?;
-                            Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                            Some(cast_layer.output(&*network, 0).map_err(|e| {
                                 GraphError::ConversionFailed {
                                     format: "trtx".to_string(),
                                     reason: format!("Conv2d bias cast output: {}", e),
@@ -9288,7 +9286,7 @@ impl TrtxConverter {
                             reason: format!("Conv2d dynamic filter set_first_transpose: {}", e),
                         }
                     })?;
-                    Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    Some(shuffle.output(&*network, 0).map_err(|e| {
                         GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("Conv2d dynamic filter shuffle output: {}", e),
@@ -9342,13 +9340,12 @@ impl TrtxConverter {
         layer.set_num_groups(network, groups as i64);
 
         // Extract output tensor from layer (NCHW, Float)
-        let conv_output =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get convolution output: {}", e),
-                })?;
+        let conv_output = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get convolution output: {}", e),
+            })?;
 
         // If input was Half, cast conv output back to Half to match graph output type.
         let conv_output = if input_dtype == DataType::Float16 {
@@ -9359,7 +9356,7 @@ impl TrtxConverter {
                     reason: format!("Conv2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d cast output: {}", e),
@@ -9384,7 +9381,7 @@ impl TrtxConverter {
                     reason: format!("Conv2d set_first_transpose NCHW->NHWC: {}", e),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Conv2d NHWC output shuffle: {}", e),
@@ -9582,49 +9579,51 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", input_id),
             })?;
 
-        let nhwc_shuffle_output =
-            if input_layout == "nhwc" {
-                let mut shuffle =
-                    network
-                        .add_shuffle(input)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
-                        })?;
-                shuffle
-                    .set_first_transpose(network, &[0, 3, 1, 2])
+        let nhwc_shuffle_output = if input_layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
+                        reason: format!("convTranspose2d NHWC->NCHW shuffle: {}", e),
                     })?;
-                Some(shuffle.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("convTranspose2d set_first_transpose NHWC->NCHW: {}", e),
+                })?;
+            Some(
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("convTranspose2d NHWC shuffle output: {}", e),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let pre_deconv_input = nhwc_shuffle_output.as_ref().unwrap_or(input);
 
-        let half_cast_output: Option<trtx::Tensor<'a>> =
-            if input_dtype == DataType::Float16 {
-                let cast_layer = network
-                    .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
+        let half_cast_output: Option<trtx::Tensor<'a>> = if input_dtype == DataType::Float16 {
+            let cast_layer = network
+                .add_cast(pre_deconv_input, TrtDataType::kFLOAT)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("convTranspose2d Half->Float cast: {}", e),
+                })?;
+            Some(
+                cast_layer
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("convTranspose2d Half->Float cast: {}", e),
-                    })?;
-                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
                         reason: format!("convTranspose2d cast output: {}", e),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let deconv_input_source = half_cast_output.as_ref().unwrap_or(pre_deconv_input);
 
         let strides: [i32; 2] = deconv_opts
@@ -9667,7 +9666,7 @@ impl TrtxConverter {
                 }
             })?;
             id_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d identity output: {}", e),
@@ -9724,7 +9723,7 @@ impl TrtxConverter {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter Half->Float cast: {}", e),
                             })?;
-                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                        Some(cast_layer.output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d filter cast output: {}", e),
@@ -9751,7 +9750,7 @@ impl TrtxConverter {
                                     reason: format!("convTranspose2d bias Half->Float cast: {}", e),
                                 }
                             })?;
-                        Some(cast_layer.get_output(&*network, 0).map_err(|e| {
+                        Some(cast_layer.output(&*network, 0).map_err(|e| {
                             GraphError::ConversionFailed {
                                 format: "trtx".to_string(),
                                 reason: format!("convTranspose2d bias cast output: {}", e),
@@ -9783,7 +9782,7 @@ impl TrtxConverter {
                             ),
                         }
                     })?;
-                    Some(shuffle.get_output(&*network, 0).map_err(|e| {
+                    Some(shuffle.output(&*network, 0).map_err(|e| {
                         GraphError::ConversionFailed {
                             format: "trtx".to_string(),
                             reason: format!("convTranspose2d dynamic filter shuffle output: {}", e),
@@ -9899,7 +9898,7 @@ impl TrtxConverter {
 
         let deconv_output =
             layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get deconvolution output: {}", e),
@@ -9916,7 +9915,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d outputPadding remainder: {}", e),
                 })?;
             pad_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d outputPadding remainder output: {}", e),
@@ -10005,7 +10004,7 @@ impl TrtxConverter {
                                         format: "trtx".to_string(),
                                         reason: format!("convTranspose2d outputSizes slice: {}", e),
                                     })?;
-                                current = slice_layer.get_output(&*network, 0).map_err(|e| {
+                                current = slice_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!(
@@ -10026,7 +10025,7 @@ impl TrtxConverter {
                                         format: "trtx".to_string(),
                                         reason: format!("convTranspose2d outputSizes pad: {}", e),
                                     })?;
-                                pad_layer.get_output(&*network, 0).map_err(|e| {
+                                pad_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!(
@@ -10054,7 +10053,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d Float->Half cast: {}", e),
                 })?;
             cast_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d cast output: {}", e),
@@ -10078,7 +10077,7 @@ impl TrtxConverter {
                     reason: format!("convTranspose2d set_first_transpose NCHW->NHWC: {}", e),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("convTranspose2d NHWC output shuffle: {}", e),
@@ -10196,7 +10195,7 @@ impl TrtxConverter {
                         reason: format!("pool concat identity: {e}"),
                     })?;
             return id_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("pool concat identity output: {e}"),
@@ -10212,7 +10211,7 @@ impl TrtxConverter {
                 })?;
         layer.set_axis(network, axis);
         layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("pool concat output: {e}"),
@@ -10386,14 +10385,14 @@ impl TrtxConverter {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated max pool slice: {e}"),
                                     })?;
-                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                slice_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated max pool slice output: {e}"),
                                     }
                                 })?
                             } else {
-                                neg_inf_layer.get_output(&*network, 0).map_err(|e| {
+                                neg_inf_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated max pool neg-inf tap: {e}"),
@@ -10418,12 +10417,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated max pool elementwise max: {e}"),
                         })?;
-                    acc =
-                        ew.get_output(&*network, 0)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("dilated max pool max output: {e}"),
-                            })?;
+                    acc = ew
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated max pool max output: {e}"),
+                        })?;
                 }
                 cols.push(acc);
             }
@@ -10450,7 +10449,7 @@ impl TrtxConverter {
                     reason: format!("dilated max pool Float->Half: {e}"),
                 })?;
             cast_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dilated max pool cast output: {e}"),
@@ -10626,14 +10625,14 @@ impl TrtxConverter {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated average pool slice: {e}"),
                                     })?;
-                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                slice_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated average pool slice output: {e}"),
                                     }
                                 })?
                             } else {
-                                zero_layer.get_output(&*network, 0).map_err(|e| {
+                                zero_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated average pool zero tap: {e}"),
@@ -10658,12 +10657,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated average pool elementwise sum: {e}"),
                         })?;
-                    acc =
-                        ew.get_output(&*network, 0)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("dilated average pool sum output: {e}"),
-                            })?;
+                    acc = ew
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated average pool sum output: {e}"),
+                        })?;
                 }
                 cols.push(acc);
             }
@@ -10688,7 +10687,7 @@ impl TrtxConverter {
             })?;
         let inv_tensor =
             inv_const_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dilated average pool inv scale output: {e}"),
@@ -10701,7 +10700,7 @@ impl TrtxConverter {
             })?;
         let out_nchw =
             prod_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dilated average pool prod output: {e}"),
@@ -10723,7 +10722,7 @@ impl TrtxConverter {
                     reason: format!("dilated average pool Float->Half: {e}"),
                 })?;
             cast_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("dilated average pool cast output: {e}"),
@@ -10896,14 +10895,14 @@ impl TrtxConverter {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated l2 pool slice: {e}"),
                                     })?;
-                                slice_layer.get_output(&*network, 0).map_err(|e| {
+                                slice_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated l2 pool slice output: {e}"),
                                     }
                                 })?
                             } else {
-                                zero_layer.get_output(&*network, 0).map_err(|e| {
+                                zero_layer.output(&*network, 0).map_err(|e| {
                                     GraphError::ConversionFailed {
                                         format: "trtx".to_string(),
                                         reason: format!("dilated l2 pool zero tap: {e}"),
@@ -10928,12 +10927,12 @@ impl TrtxConverter {
                             format: "trtx".to_string(),
                             reason: format!("dilated l2 pool elementwise sum: {e}"),
                         })?;
-                    acc =
-                        ew.get_output(&*network, 0)
-                            .map_err(|e| GraphError::ConversionFailed {
-                                format: "trtx".to_string(),
-                                reason: format!("dilated l2 pool sum output: {e}"),
-                            })?;
+                    acc = ew
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("dilated l2 pool sum output: {e}"),
+                        })?;
                 }
                 cols.push(acc);
             }
@@ -11047,30 +11046,31 @@ impl TrtxConverter {
         };
 
         // TensorRT pooling is NCHW; WebNN NHWC must be transposed first (same as conv2d).
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
-            if layout == "nhwc" {
-                let mut shuffle =
-                    network
-                        .add_shuffle(input)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("pool2d NHWC->NCHW shuffle: {e}"),
-                        })?;
-                shuffle
-                    .set_first_transpose(network, &[0, 3, 1, 2])
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(input)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("pool2d set_first_transpose NHWC: {e}"),
+                        reason: format!("pool2d NHWC->NCHW shuffle: {e}"),
                     })?;
-                Some(shuffle.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("pool2d set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("pool2d NHWC shuffle output: {e}"),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let pool_nchw_in = nhwc_to_nchw.as_ref().unwrap_or(input);
 
         let dh = opts.dilations.first().copied().unwrap_or(1);
@@ -11090,22 +11090,23 @@ impl TrtxConverter {
                 .map(|o| o.descriptor.data_type)
                 .unwrap_or(DataType::Float32);
 
-            let half_to_float: Option<trtx::Tensor<'a>> = if input_dtype == DataType::Float16 {
-                let cast_layer = network
-                    .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("pool2d dilated Half->Float: {e}"),
-                    })?;
-                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("pool2d dilated cast output: {e}"),
-                    }
-                })?)
-            } else {
-                None
-            };
+            let half_to_float: Option<trtx::Tensor<'a>> =
+                if input_dtype == DataType::Float16 {
+                    let cast_layer = network
+                        .add_cast(pool_nchw_in, TrtDataType::kFLOAT)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("pool2d dilated Half->Float: {e}"),
+                        })?;
+                    Some(cast_layer.output(&*network, 0).map_err(|e| {
+                        GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("pool2d dilated cast output: {e}"),
+                        }
+                    })?)
+                } else {
+                    None
+                };
             let dilated_input = half_to_float.as_ref().unwrap_or(pool_nchw_in);
 
             let out_nchw = if pool_type == PoolingType::kMAX {
@@ -11143,7 +11144,7 @@ impl TrtxConverter {
                         reason: format!("pool2d dilated NCHW->NHWC transpose: {e}"),
                     })?;
                 shuffle
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("pool2d dilated NCHW shuffle output: {e}"),
@@ -11167,13 +11168,12 @@ impl TrtxConverter {
 
         Self::trtx_apply_pool2d_options(&mut layer, network, opts, round_up);
 
-        let pooled_nchw =
-            layer
-                .get_output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("Failed to get layer output: {}", e),
-                })?;
+        let pooled_nchw = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to get layer output: {}", e),
+            })?;
 
         let output = if layout == "nhwc" {
             let mut shuffle =
@@ -11190,7 +11190,7 @@ impl TrtxConverter {
                     reason: format!("pool2d set_first_transpose NCHW: {e}"),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("pool2d NCHW shuffle output: {e}"),
@@ -11241,7 +11241,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -11305,7 +11305,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -11378,7 +11378,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -11443,7 +11443,7 @@ impl TrtxConverter {
 
         // Extract output tensor from layer
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get layer output: {}", e),
@@ -11617,7 +11617,7 @@ impl TrtxConverter {
         }
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get resize output: {}", e),
@@ -11657,7 +11657,7 @@ impl TrtxConverter {
 
         let equal_output =
             layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get EQUAL output: {}", e),
@@ -11673,7 +11673,7 @@ impl TrtxConverter {
 
         let bool_output =
             not_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get isNaN output: {}", e),
@@ -11712,7 +11712,7 @@ impl TrtxConverter {
 
         let abs_output =
             abs_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get ABS output: {}", e),
@@ -11757,7 +11757,7 @@ impl TrtxConverter {
 
         let inf_tensor =
             inf_constant
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get infinity tensor: {}", e),
@@ -11773,7 +11773,7 @@ impl TrtxConverter {
 
         let bool_output =
             equal_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get isInfinite output: {}", e),
@@ -11810,7 +11810,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get roundEven output: {}", e),
@@ -11922,14 +11922,14 @@ impl TrtxConverter {
 
         let min_const_out =
             min_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherElements: clamp min output: {}", e),
                 })?;
         let max_const_out =
             max_const
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherElements: clamp max output: {}", e),
@@ -11943,7 +11943,7 @@ impl TrtxConverter {
             })?;
         let clamped_upper_out =
             clamped_upper
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherElements: clamp upper output: {}", e),
@@ -11961,7 +11961,7 @@ impl TrtxConverter {
             })?;
         let clamped_indices =
             clamped
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("gatherElements: clamped indices output: {}", e),
@@ -11977,7 +11977,7 @@ impl TrtxConverter {
         layer.set_gather_mode(network, trtx::GatherMode::kELEMENT);
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get gatherElements output: {}", e),
@@ -12025,7 +12025,7 @@ impl TrtxConverter {
 
         let squared =
             square_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get squared output: {}", e),
@@ -12045,30 +12045,31 @@ impl TrtxConverter {
             s => s,
         };
 
-        let nhwc_to_nchw: Option<trtx::Tensor<'a>> =
-            if layout == "nhwc" {
-                let mut shuffle =
-                    network
-                        .add_shuffle(&squared)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("l2Pool2d NHWC->NCHW shuffle: {e}"),
-                        })?;
-                shuffle
-                    .set_first_transpose(network, &[0, 3, 1, 2])
+        let nhwc_to_nchw: Option<trtx::Tensor<'a>> = if layout == "nhwc" {
+            let mut shuffle =
+                network
+                    .add_shuffle(&squared)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
-                        reason: format!("l2Pool2d set_first_transpose NHWC: {e}"),
+                        reason: format!("l2Pool2d NHWC->NCHW shuffle: {e}"),
                     })?;
-                Some(shuffle.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
+            shuffle
+                .set_first_transpose(network, &[0, 3, 1, 2])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("l2Pool2d set_first_transpose NHWC: {e}"),
+                })?;
+            Some(
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("l2Pool2d NHWC shuffle output: {e}"),
-                    }
-                })?)
-            } else {
-                None
-            };
+                    })?,
+            )
+        } else {
+            None
+        };
         let pool_in = nhwc_to_nchw.as_ref().unwrap_or(&squared);
 
         let input_dtype = graph
@@ -12084,12 +12085,14 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("l2Pool2d dilated Half->Float: {e}"),
                     })?;
-                Some(cast_layer.get_output(&*network, 0).map_err(|e| {
-                    GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("l2Pool2d dilated cast output: {e}"),
-                    }
-                })?)
+                Some(
+                    cast_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("l2Pool2d dilated cast output: {e}"),
+                        })?,
+                )
             } else {
                 None
             };
@@ -12123,7 +12126,7 @@ impl TrtxConverter {
 
             let mean_sq_nchw =
                 pool_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("Failed to get pooled output: {}", e),
@@ -12140,7 +12143,7 @@ impl TrtxConverter {
                         reason: format!("l2Pool2d mean_sq Half->Float: {e}"),
                     })?;
                 cast_layer
-                    .get_output(&*network, 0)
+                    .output(&*network, 0)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("l2Pool2d mean_sq cast output: {e}"),
@@ -12158,12 +12161,13 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d kernel volume constant: {e}"),
                 })?;
-            let k_tensor = k_const_layer.get_output(&*network, 0).map_err(|e| {
-                GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("l2Pool2d kernel volume output: {e}"),
-                }
-            })?;
+            let k_tensor =
+                k_const_layer
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("l2Pool2d kernel volume output: {e}"),
+                    })?;
             let sum_sq_layer = network
                 .add_elementwise(&mean_for_prod, &k_tensor, ElementWiseOperation::kPROD)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -12171,7 +12175,7 @@ impl TrtxConverter {
                     reason: format!("l2Pool2d mean_sq to sum_sq: {e}"),
                 })?;
             sum_sq_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d sum_sq output: {e}"),
@@ -12193,7 +12197,7 @@ impl TrtxConverter {
                     reason: format!("l2Pool2d set_first_transpose NCHW: {e}"),
                 })?;
             shuffle
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d NCHW shuffle output: {e}"),
@@ -12212,7 +12216,7 @@ impl TrtxConverter {
 
         let sqrt_out =
             sqrt_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get l2Pool2d output: {}", e),
@@ -12226,7 +12230,7 @@ impl TrtxConverter {
                     reason: format!("l2Pool2d sqrt Float->Half: {e}"),
                 })?;
             cast_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("l2Pool2d sqrt half cast output: {e}"),
@@ -12312,7 +12316,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get reverse output: {}", e),
@@ -12376,7 +12380,7 @@ impl TrtxConverter {
 
         let axis_tensor =
             axis_constant
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get axis constant output: {}", e),
@@ -12397,7 +12401,7 @@ impl TrtxConverter {
             })?;
 
         let output = layer
-            .get_output(&*network, 0)
+            .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get cumulative sum output: {}", e),
@@ -12504,7 +12508,7 @@ impl TrtxConverter {
 
         let mask_tensor =
             mask_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get mask tensor: {}", e),
@@ -12520,7 +12524,7 @@ impl TrtxConverter {
 
         let output =
             multiply_layer
-                .get_output(&*network, 0)
+                .output(&*network, 0)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
                     reason: format!("Failed to get triangular output: {}", e),

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -222,7 +222,7 @@ fn execute_trtx_engine(
     let mut context = engine.create_execution_context()?;
 
     // Get tensor information
-    let num_tensors = engine.get_nb_io_tensors()?;
+    let num_tensors = engine.nb_io_tensors()?;
 
     // Prepare CUDA buffers for inputs and outputs
     let mut device_buffers: Vec<(String, trtx::DeviceBuffer)> = Vec::new();
@@ -231,12 +231,12 @@ fn execute_trtx_engine(
     // Process each tensor - allocate buffers for ALL tensors (inputs and outputs)
     // TensorRT requires ALL tensor addresses to be set, even for intermediate results
     for i in 0..num_tensors {
-        let name = engine.get_tensor_name(i)?;
-        let dtype = engine.get_tensor_dtype(&name)?;
+        let name = engine.io_tensor_name(i)?;
+        let dtype = engine.tensor_data_type(&name)?;
         let bytes_per_elem = trt_dtype_bytes_per_element(&dtype);
 
         if let Some(input) = inputs.iter().find(|inp| inp.name == name) {
-            let expected_shape_i64 = engine.get_tensor_shape(&name)?;
+            let expected_shape_i64 = engine.tensor_shape(&name)?;
             let expected_shape: Vec<usize> =
                 expected_shape_i64.iter().map(|&d| d as usize).collect();
             let expected_size = expected_shape.iter().product::<usize>() * bytes_per_elem;
@@ -260,7 +260,7 @@ fn execute_trtx_engine(
             device_buffers.push((name.clone(), buffer));
         } else {
             // Non-input tensor (output or intermediate) - allocate buffer
-            let shape_i64 = engine.get_tensor_shape(&name)?;
+            let shape_i64 = engine.tensor_shape(&name)?;
             let shape: Vec<usize> = shape_i64.iter().map(|&d| d as usize).collect();
 
             let num_elements: usize = shape.iter().product();
@@ -278,7 +278,7 @@ fn execute_trtx_engine(
 
     // Execute inference
     unsafe {
-        context.enqueue_v3(trtx::cuda::get_default_stream())?;
+        context.enqueue_v3(trtx::cuda::default_stream())?;
     }
 
     // Synchronize to ensure completion

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -202,12 +202,12 @@ mod tests {
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
-        let num_tensors = engine.get_nb_io_tensors()?;
+        let num_tensors = engine.nb_io_tensors()?;
         assert_eq!(num_tensors, 3, "Expected 3 tensors (2 inputs + 1 output)");
 
-        let input_a_name = engine.get_tensor_name(0)?;
-        let input_b_name = engine.get_tensor_name(1)?;
-        let output_name = engine.get_tensor_name(2)?;
+        let input_a_name = engine.tensor_name(0)?;
+        let input_b_name = engine.tensor_name(1)?;
+        let output_name = engine.tensor_name(2)?;
 
         // Calculate output size from graph's output operand descriptor
         let output_operand_id = graph.output_operands[0];
@@ -286,11 +286,11 @@ mod tests {
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
-        let num_tensors = engine.get_nb_io_tensors()?;
+        let num_tensors = engine.nb_io_tensors()?;
         assert_eq!(num_tensors, 2, "Expected 2 tensors (input + output)");
 
-        let input_name = engine.get_tensor_name(0)?;
-        let output_name = engine.get_tensor_name(1)?;
+        let input_name = engine.tensor_name(0)?;
+        let output_name = engine.tensor_name(1)?;
 
         // Calculate output size from graph's output operand descriptor
         let output_operand_id = graph.output_operands[0];
@@ -359,7 +359,7 @@ mod tests {
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
-        let num_tensors = engine.get_nb_io_tensors()?;
+        let num_tensors = engine.nb_io_tensors()?;
         let num_inputs = graph.input_operands.len();
         let num_graph_outputs = graph.output_operands.len();
         // Note: TensorRT may have more outputs than graph.output_operands due to intermediate values
@@ -445,7 +445,7 @@ mod tests {
 
         // Set tensor addresses for all inputs
         for (i, buffer) in input_buffers.iter().enumerate() {
-            let tensor_name = engine.get_tensor_name(i as i32)?;
+            let tensor_name = engine.tensor_name(i as i32)?;
             unsafe {
                 context.set_tensor_address(&tensor_name, buffer.as_ptr())?;
             }
@@ -453,7 +453,7 @@ mod tests {
 
         // Set tensor addresses for all outputs
         for (i, buffer) in output_buffers.iter().enumerate() {
-            let tensor_name = engine.get_tensor_name((num_inputs + i) as i32)?;
+            let tensor_name = engine.tensor_name((num_inputs + i) as i32)?;
             unsafe {
                 context.set_tensor_address(&tensor_name, buffer.as_ptr())?;
             }
@@ -911,12 +911,12 @@ mod tests {
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
-        let num_tensors = engine.get_nb_io_tensors()?;
+        let num_tensors = engine.nb_io_tensors()?;
         assert_eq!(num_tensors, 3, "Expected 3 tensors (2 inputs + 1 output)");
 
-        let input_a_name = engine.get_tensor_name(0)?;
-        let input_b_name = engine.get_tensor_name(1)?;
-        let output_name = engine.get_tensor_name(2)?;
+        let input_a_name = engine.tensor_name(0)?;
+        let input_b_name = engine.tensor_name(1)?;
+        let output_name = engine.tensor_name(2)?;
 
         // Allocate device buffers
         let input_a_size = input_a.len() * std::mem::size_of::<f32>();
@@ -1131,13 +1131,13 @@ mod tests {
         let mut context = engine.create_execution_context()?;
 
         // Get tensor info
-        let num_tensors = engine.get_nb_io_tensors()?;
+        let num_tensors = engine.nb_io_tensors()?;
         assert_eq!(num_tensors, 4, "Expected 4 tensors (3 inputs + 1 output)");
 
-        let input_a_name = engine.get_tensor_name(0)?;
-        let input_b_name = engine.get_tensor_name(1)?;
-        let input_c_name = engine.get_tensor_name(2)?;
-        let output_name = engine.get_tensor_name(3)?;
+        let input_a_name = engine.tensor_name(0)?;
+        let input_b_name = engine.tensor_name(1)?;
+        let input_c_name = engine.tensor_name(2)?;
+        let output_name = engine.tensor_name(3)?;
 
         // Allocate device buffers
         let input_a_size = input_a.len() * std::mem::size_of::<f32>();


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Bump trtx to version 0.5.0 (to be published, will fail while not yet published)

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

