### PR TITLE
ci: put `cargo fmt` to beginning of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Is Cargo.lock consistent with Cargo.toml?
         run: cargo fetch --locked
 
+      - name: Run cargo fmt check
+        run: cargo fmt --all -- --check
+
       - name: Run cargo check
         run: cargo check
 
@@ -58,9 +61,6 @@ jobs:
 
       - name: Run cargo test (library only)
         run: cargo test --lib
-
-      - name: Run cargo fmt check
-        run: cargo fmt --all -- --check
 
       - name: Check backend operator report is up to date
         run: |


### PR DESCRIPTION
Easy fast checks should come first to provide user quick feedback and not fail after long running test.

## Summary

- [x] Describe the user-visible and code-level changes.

If I need to run `cargo fmt` then tell me right away and not after long running tests. Faster checks should come first.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

