### PR TITLE
fix: validate input/output shapes for MLContext::dispatch

### DIFF
--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -118,12 +118,13 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for OrtBuilder<'co
             .map_err(|e| Error::GraphBuildError { source: e.into() })?
             .commit_from_memory(&converted.data)
             .map_err(|e| Error::GraphBuildError { source: e.into() })?;
-        Ok(MLGraph {
-            backend: crate::mlcontext::MLBackendGraph::OnnxSession(
+        MLGraph::new(
+            crate::mlcontext::MLBackendGraph::OnnxSession(
                 OrtGraph { session },
                 std::marker::PhantomData,
             ),
-        })
+            &graph_info,
+        )
     }
 }
 

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -213,8 +213,8 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
             .create_execution_context()
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
 
-        Ok(MLGraph {
-            backend: MLBackendGraph::TrtxEngine(TrtxGraph {
+        MLGraph::new(
+            MLBackendGraph::TrtxEngine(TrtxGraph {
                 _engine: engine,
                 exec,
                 cuda_stream: self
@@ -222,7 +222,8 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                     .new_stream()
                     .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?,
             }),
-        })
+            &graph,
+        )
     }
 }
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -2510,6 +2510,8 @@ impl TrtxConverter {
                 })
         };
 
+        // Constant stored flat: 1D int8. Try 1D -> Reshape(4D) -> DQ so DQ sees Shuffle output not Constant.
+        let stored_flat = constants_stored_flat.contains(&input_id);
         let _input_dims =
             input
                 .dimensions(&*network)

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -2510,8 +2510,6 @@ impl TrtxConverter {
                 })
         };
 
-        // Constant stored flat: 1D int8. Try 1D -> Reshape(4D) -> DQ so DQ sees Shuffle output not Constant.
-        let stored_flat = constants_stored_flat.contains(&input_id);
         let _input_dims =
             input
                 .dimensions(&*network)

--- a/src/error.rs
+++ b/src/error.rs
@@ -299,6 +299,21 @@ pub enum GraphError {
         expected: usize,
         actual: usize,
     },
+
+    #[error(
+        "graph input operand ids doesn't match the ids of OperandKind::Input: {input_ids:?} vs {input_ids_in_operands:?}"
+    )]
+    InputIdListMismatch {
+        input_ids: Vec<u32>,
+        input_ids_in_operands: Vec<u32>,
+    },
+    #[error(
+        "graph output operand ids doesn't match the ids of OperandKind::Input: {output_ids:?} vs {output_ids_in_operands:?}"
+    )]
+    OutputIdListMismatch {
+        output_ids: Vec<u32>,
+        output_ids_in_operands: Vec<u32>,
+    },
     #[error("graph input operand list does not match operand table")]
     InputOperandListMismatch,
     #[error("graph output operand list does not match operand table")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,15 @@ pub enum GraphBuilderError {
     #[error("Failed to build: requested MLGraphBuilder.build with an empty output map")]
     EmptyOutputHashMap,
 
+    #[error(
+        "Duplicates in outputs: used MLOperand {operand:?} for ouput name {first_name:?} and {second_name:?}"
+    )]
+    DuplicateOutput {
+        operand: MLOperand,
+        first_name: String,
+        second_name: String,
+    },
+
     #[error("Failed to build: did not provide an input name for tensor with descriptor {0:?}")]
     EmptyInputName(MLOperandDescriptor),
 
@@ -135,6 +144,11 @@ pub enum GraphBuilderError {
         required_size: usize,
         provided_size: usize,
     },
+
+    #[error(
+        "Build with invalid operand: operand {operand:?} assigned to name {name:?} is not part of this graph"
+    )]
+    BuildWithInvalidOperand { operand: MLOperand, name: String },
 }
 
 #[derive(Debug, Error)]
@@ -299,7 +313,8 @@ pub enum GraphError {
         expected: usize,
         actual: usize,
     },
-
+    // TODO: this indicates an invalid state of GraphError. Prevent this from occurring in GraphError and then remove the
+    // error
     #[error(
         "graph input operand ids doesn't match the ids of OperandKind::Input: {input_ids:?} vs {input_ids_in_operands:?}"
     )]
@@ -307,6 +322,8 @@ pub enum GraphError {
         input_ids: Vec<u32>,
         input_ids_in_operands: Vec<u32>,
     },
+    // TODO: this indicates an invalid state of GraphError. Prevent this from occurring in GraphError and then remove the
+    // error
     #[error(
         "graph output operand ids doesn't match the ids of OperandKind::Input: {output_ids:?} vs {output_ids_in_operands:?}"
     )]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 
+use crate::error::GraphError;
 use crate::operator_options::{MLDimension, MLDynamicDimension};
 use crate::operators::Operation;
 
@@ -214,11 +215,92 @@ impl GraphInfo {
             .iter()
             .any(|operand| operand.descriptor.has_dynamic_dimensions())
     }
+
+    /// Ensures `input_operands` / `output_operands` match operands tagged as graph I/O.
+    pub fn validate_io_operand_lists(&self) -> Result<(), GraphError> {
+        let mut derived_inputs = Vec::new();
+        let mut derived_outputs = Vec::new();
+
+        for (idx, operand) in self.operands.iter().enumerate() {
+            match operand.kind {
+                OperandKind::Input => derived_inputs.push(idx as u32),
+                OperandKind::Output => derived_outputs.push(idx as u32),
+                OperandKind::Constant | OperandKind::Intermediate => {}
+            }
+        }
+
+        if derived_inputs != self.input_operands {
+            return Err(GraphError::InputIdListMismatch {
+                input_ids: self.input_operands.clone(),
+                input_ids_in_operands: derived_inputs,
+            });
+        }
+        if derived_outputs != self.output_operands {
+            return Err(GraphError::OutputIdListMismatch {
+                output_ids: self.input_operands.clone(),
+                output_ids_in_operands: derived_inputs,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Named input/output operands for `MLGraph` dispatch, after list consistency checks.
+    pub fn io_binding_maps(
+        &self,
+    ) -> Result<
+        (
+            HashMap<String, OperandDescriptor>,
+            HashMap<String, OperandDescriptor>,
+        ),
+        GraphError,
+    > {
+        self.validate_io_operand_lists()?;
+
+        let mut inputs = HashMap::new();
+        for &id in &self.input_operands {
+            let operand = self.operand(id).expect("validated above");
+            let name = operand
+                .name
+                .as_ref()
+                .ok_or(GraphError::MissingInputName { operand: id })?;
+            if name.is_empty() {
+                return Err(GraphError::MissingInputName { operand: id });
+            }
+            if inputs
+                .insert(name.clone(), operand.descriptor.clone())
+                .is_some()
+            {
+                return Err(GraphError::DuplicateInputName { name: name.clone() });
+            }
+        }
+
+        let mut outputs = HashMap::new();
+        for &id in &self.output_operands {
+            let operand = self.operand(id).expect("validated above");
+            let name = operand
+                .name
+                .as_ref()
+                .ok_or(GraphError::MissingOutputName { operand: id })?;
+            if name.is_empty() {
+                return Err(GraphError::MissingOutputName { operand: id });
+            }
+            if outputs
+                .insert(name.clone(), operand.descriptor.clone())
+                .is_some()
+            {
+                return Err(GraphError::DuplicateOutputName { name: name.clone() });
+            }
+        }
+
+        Ok((inputs, outputs))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::GraphError;
 
     #[test]
     fn test_data_type_bytes_per_element() {
@@ -396,6 +478,111 @@ mod tests {
         assert_eq!(
             deserialized.operands[0].descriptor.data_type,
             DataType::Uint4
+        );
+    }
+
+    fn sample_io_graph() -> GraphInfo {
+        GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: to_dimension_vector(&[2, 2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("x".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: to_dimension_vector(&[2, 2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("y".to_string()),
+                },
+            ],
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operations: vec![],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        }
+    }
+
+    #[test]
+    fn validate_io_operand_lists_accepts_consistent_graph() {
+        assert!(sample_io_graph().validate_io_operand_lists().is_ok());
+        assert!(sample_io_graph().io_binding_maps().is_ok());
+    }
+
+    #[test]
+    fn validate_io_operand_lists_rejects_extra_input_operand_id() {
+        let mut graph = sample_io_graph();
+        graph.input_operands.push(99);
+        std::assert_matches!(
+            graph.validate_io_operand_lists(),
+            Err(GraphError::InputIdListMismatch { .. })
+        );
+    }
+
+    #[test]
+    fn validate_io_operand_lists_rejects_invalid_operand_id_in_list() {
+        let mut graph = sample_io_graph();
+        graph.input_operands = vec![0, 99];
+        graph.operands.push(Operand {
+            kind: OperandKind::Input,
+            descriptor: OperandDescriptor {
+                data_type: DataType::Float32,
+                shape: to_dimension_vector(&[1]),
+                pending_permutation: vec![],
+            },
+            name: Some("z".to_string()),
+        });
+        std::assert_matches!(
+            graph.validate_io_operand_lists(),
+            Err(GraphError::InputIdListMismatch { .. })
+        );
+    }
+
+    #[test]
+    fn validate_io_operand_lists_rejects_missing_input_in_list() {
+        let mut graph = sample_io_graph();
+        graph.operands.push(Operand {
+            kind: OperandKind::Input,
+            descriptor: OperandDescriptor {
+                data_type: DataType::Float32,
+                shape: to_dimension_vector(&[1]),
+                pending_permutation: vec![],
+            },
+            name: Some("z".to_string()),
+        });
+        std::assert_matches!(
+            graph.validate_io_operand_lists(),
+            Err(GraphError::InputIdListMismatch { .. })
+        );
+    }
+
+    #[test]
+    fn validate_io_operand_lists_rejects_wrong_kind_in_input_list() {
+        let mut graph = sample_io_graph();
+        graph.input_operands = vec![1];
+        std::assert_matches!(
+            graph.validate_io_operand_lists(),
+            Err(GraphError::InputIdListMismatch { .. })
+        );
+    }
+
+    #[test]
+    fn validate_io_operand_lists_rejects_output_kind_not_in_list() {
+        let mut graph = sample_io_graph();
+        graph.operands[0].kind = OperandKind::Output;
+        graph.output_operands.push(0);
+        std::assert_matches!(
+            graph.validate_io_operand_lists(),
+            Err(GraphError::InputIdListMismatch { .. })
         );
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -368,7 +368,7 @@ pub struct MLTensorDescriptor {
     writable: bool,
 }
 
-#[derive(Debug, Eq, PartialEq, Default, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Default, Copy, Clone, Hash)]
 pub struct MLOperand {
     pub(crate) id: usize,
 }
@@ -608,6 +608,50 @@ impl<'context> MLContext<'context> {
 mod test {
     use crate::{mlcontext::*, mlgraphbuilder::MLGraphBuilder, webnn_json::from_graph_json};
 
+    fn create_add_graph_context_and_graph() -> Option<(MLContext<'static>, MLGraph<'static>)> {
+        let contents = r#"
+webnn_graph "sample_graph" v1 {
+  inputs {
+    lhs: f32[2, 2];
+  }
+
+  consts {
+    rhs: f32[2, 2] @scalar(1.0);
+  }
+
+  nodes {
+    sum = add(lhs, rhs);
+  }
+
+  outputs { sum; }
+}"#;
+
+        let _ = pretty_env_logger::try_init();
+        let sanitized = crate::loader::sanitize_webnn_identifiers(contents);
+        let graph_json = webnn_graph::parser::parse_wg_text(&sanitized).unwrap();
+        let graph_info = from_graph_json(&graph_json).unwrap();
+
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvialable)) {
+            return None;
+        };
+
+        let mut context = context.unwrap();
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let graph = builder.build_graph_info(graph_info).unwrap();
+        drop(builder);
+
+        Some((context, graph))
+    }
+
+    fn rw_tensor_desc(shape: Vec<u64>) -> MLTensorDescriptor {
+        let mut desc =
+            MLTensorDescriptor::new(crate::operator_enums::MLOperandDataType::Float32, shape);
+        desc.set_readable(true);
+        desc.set_writable(true);
+        desc
+    }
+
     #[test]
     fn test_tensor_desc() {
         let default_operand_desc = MLOperandDescriptor::default();
@@ -657,44 +701,11 @@ mod test {
 
     #[test]
     fn test_dispatch() {
-        let contents = r#"
-webnn_graph "sample_graph" v1 {
-  inputs {
-    lhs: f32[2, 2];
-  }
-
-  consts {
-    rhs: f32[2, 2] @scalar(1.0);
-  }
-
-  nodes {
-    sum = add(lhs, rhs);
-  }
-
-  outputs { sum; }
-}"#;
-
-        let _ = pretty_env_logger::try_init();
-        let sanitized = crate::loader::sanitize_webnn_identifiers(contents);
-        let graph_json = webnn_graph::parser::parse_wg_text(&sanitized).unwrap();
-        let graph_info = from_graph_json(&graph_json).unwrap();
-
-        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
-        if matches!(context, Err(crate::error::Error::NoBackendAvialable)) {
+        let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {
             return;
         };
-        let mut context = context.unwrap();
         dbg!(&context);
-        let mut desc = MLTensorDescriptor::new(
-            crate::operator_enums::MLOperandDataType::Float32,
-            [2, 2].to_vec(),
-        );
-        desc.set_readable(true);
-        desc.set_writable(true);
-
-        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
-        let mut graph = builder.build_graph_info(graph_info).unwrap();
-        drop(builder); // TODO: should probably just consume builder on build
+        let desc = rw_tensor_desc([2, 2].to_vec());
 
         let tensor = context.create_tensor(&desc).unwrap();
         let mut inputs = HashMap::new();
@@ -710,5 +721,72 @@ webnn_graph "sample_graph" v1 {
         context.dispatch(&mut graph, &inputs, &outputs).unwrap();
         context.read_tensor(&tensor, &mut download).unwrap();
         assert_eq!(&vec![2.0f32, 3., 4., 5.], &download);
+    }
+
+    #[test]
+    fn test_dispatch_invalid_input_name_error_message() {
+        let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {
+            return;
+        };
+
+        let desc = rw_tensor_desc([2, 2].to_vec());
+        let tensor = context.create_tensor(&desc).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("invalid_input", &tensor);
+        let mut outputs = HashMap::new();
+        outputs.insert("sum", &tensor);
+
+        let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
+        std::assert_matches!(
+            err,
+            crate::error::Error::GraphDispatchError { source }
+                if source.to_string() == "missing runtime input tensor `lhs`"
+        );
+    }
+
+    #[test]
+    fn test_dispatch_invalid_input_shape_error_message() {
+        let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {
+            return;
+        };
+
+        let desc = rw_tensor_desc([2, 3].to_vec());
+        let tensor = context.create_tensor(&desc).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("lhs", &tensor);
+        let mut outputs = HashMap::new();
+        outputs.insert("sum", &tensor);
+
+        let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
+        std::assert_matches!(
+            err,
+            crate::error::Error::GraphDispatchError { source }
+                if source.to_string()
+                    == "runtime input tensor `lhs` dimension 1 mismatch (expected 2, got 3)"
+        );
+    }
+
+    #[test]
+    fn test_dispatch_invalid_output_shape_error_message() {
+        let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {
+            return;
+        };
+
+        let in_desc = rw_tensor_desc([2, 2].to_vec());
+        let out_desc = rw_tensor_desc([2, 3].to_vec());
+        let input_tensor = context.create_tensor(&in_desc).unwrap();
+        let output_tensor = context.create_tensor(&out_desc).unwrap();
+        let mut inputs = HashMap::new();
+        inputs.insert("lhs", &input_tensor);
+        let mut outputs = HashMap::new();
+        outputs.insert("sum", &output_tensor);
+
+        let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
+        std::assert_matches!(
+            err,
+            crate::error::Error::GraphDispatchError { source }
+                if source.to_string()
+                    == "runtime output tensor `sum` dimension 1 mismatch (expected 2, got 3)"
+        );
     }
 }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -6,8 +6,9 @@ use crate::OperandDescriptor;
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
 use crate::backends::trtx::TrtxGraph;
 use crate::error::Error;
-use crate::graph::{Dimension, get_static_or_max_size};
+use crate::graph::{DataType, Dimension, Operand, get_static_or_max_size};
 use crate::mlgraphbuilder::get_operand;
+use crate::runtime_checks::{RuntimeShapeState, TensorKind};
 use crate::{GraphInfo, backend_selection::BackendDevice, error::Result};
 
 use crate::backends::ort::OrtContext;
@@ -167,7 +168,97 @@ impl MLTensor {
 #[derive(Debug)]
 pub struct MLGraph<'context> {
     pub(crate) backend: MLBackendGraph<'context>,
+
+    // inputs/outputs of compiled graph
+    pub input_descriptors: HashMap<String, OperandDescriptor>,
+    pub output_descriptors: HashMap<String, OperandDescriptor>,
 }
+
+impl<'context> MLGraph<'context> {
+    pub(crate) fn new(backend: MLBackendGraph<'context>, graph_info: &GraphInfo) -> Result<Self> {
+        let (input_descriptors, output_descriptors) = graph_info
+            .io_binding_maps()
+            .map_err(|e| Error::GraphBuildError { source: e.into() })?;
+        Ok(Self {
+            backend,
+            input_descriptors,
+            output_descriptors,
+        })
+    }
+
+    fn operand_descriptors(
+        operands: &HashMap<String, Operand>,
+    ) -> HashMap<String, OperandDescriptor> {
+        operands
+            .iter()
+            .map(|(name, op)| (name.clone(), op.descriptor.clone()))
+            .collect()
+    }
+
+    fn verify_dispatch_bindings(
+        &mut self,
+        inputs: &HashMap<&str, &MLTensor>,
+        outputs: &HashMap<&str, &MLTensor>,
+    ) -> Result<()> {
+        let input_shapes: HashMap<String, Vec<usize>> = inputs
+            .iter()
+            .map(|(&name, tensor)| {
+                (
+                    name.to_string(),
+                    tensor.shape().iter().map(|&d| d as usize).collect(),
+                )
+            })
+            .collect();
+        let output_shapes: HashMap<String, Vec<usize>> = outputs
+            .iter()
+            .map(|(&name, tensor)| {
+                (
+                    name.to_string(),
+                    tensor.shape().iter().map(|&d| d as usize).collect(),
+                )
+            })
+            .collect();
+
+        let mut runtime_shape_state = RuntimeShapeState::new();
+        runtime_shape_state
+            .validate_named_shapes(&input_shapes, &self.input_descriptors, TensorKind::Input)
+            .map_err(|e| Error::GraphDispatchError { source: e.into() })?;
+        runtime_shape_state
+            .validate_named_shapes(&output_shapes, &self.output_descriptors, TensorKind::Output)
+            .map_err(|e| Error::GraphDispatchError { source: e.into() })?;
+
+        for (&name, tensor) in inputs {
+            let expected = self.input_descriptors.get(name).expect("validated above");
+            if DataType::from(tensor.data_type()) != expected.data_type {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "input '{name}' data type mismatch (expected {:?}, got {:?})",
+                        expected.data_type,
+                        tensor.data_type()
+                    )
+                    .into(),
+                });
+            }
+        }
+
+        for (&name, tensor) in outputs {
+            let expected = self.output_descriptors.get(name).expect("validated above");
+            if DataType::from(tensor.data_type()) != expected.data_type {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "output '{name}' data type mismatch (expected {:?}, got {:?})",
+                        expected.data_type,
+                        tensor.data_type()
+                    )
+                    .into(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 pub struct MLOpSupportLimits {}
 
@@ -444,6 +535,7 @@ impl<'context> MLContext<'context> {
             }
         }
 
+        graph.verify_dispatch_bindings(inputs, outputs)?;
         self.backend.dispatch(graph, inputs, outputs)
     }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -1718,10 +1718,20 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
             .take()
             .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
 
+        let mut duplicates = HashMap::<MLOperand, &str>::new();
         for (name, operand) in outputs.iter() {
-            // spec: If name is empty, then return a new promise in realm rejected with a TypeError.
-            if name.is_empty() {
-                return Err(GraphBuilderError::EmptyOutputHashMap.into());
+            match duplicates.entry(*operand) {
+                std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+                    return Err(GraphBuilderError::DuplicateOutput {
+                        operand: *operand,
+                        first_name: occupied_entry.get().to_string(),
+                        second_name: name.to_string(),
+                    }
+                    .into());
+                }
+                std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                    vacant_entry.insert(name);
+                }
             }
 
             if let Some(op) = graph.operands.get_mut(operand.id) {
@@ -1741,6 +1751,12 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
                 }
                 op.kind = OperandKind::Output;
                 op.name = Some(name.to_string());
+            } else {
+                return Err(GraphBuilderError::BuildWithInvalidOperand {
+                    operand: *operand,
+                    name: name.to_string(),
+                }
+                .into());
             }
             graph.output_operands.push(operand.id as u32);
         }

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -2594,8 +2594,7 @@ mod test {
         let incompatible = context.create_tensor(&inc_desc).unwrap();
         let output = context.create_tensor(&a_desc).unwrap();
 
-        // Only a is used, still need to provide all of them,
-        // TODO: currently not validated
+        // All declared graph inputs must be provided at dispatch (including unused ones).
         let mut inputs = HashMap::new();
         inputs.insert("a", &a);
         inputs.insert("unused", &unused);

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -173,6 +173,7 @@ impl<'a> GraphValidator<'a> {
             }
         }
 
+        self.graph.validate_io_operand_lists()?;
         if graph_inputs != self.graph.input_operands {
             return Err(GraphError::InputOperandListMismatch);
         }
@@ -393,12 +394,20 @@ impl<'a> GraphValidator<'a> {
         let zero_point_shape_dims = &zero_point_desc.shape;
         let input_shape = input_desc.static_or_max_shape();
         let scale_shape = scale_desc.static_or_max_shape();
+
+        // TODO: not ideal that scalar [] and unknown are represented in the same way
         // Intermediate operation outputs may still carry unresolved shape metadata ([]).
         // Treat those as unknown to avoid rejecting valid subgraphs during early validation.
-        let input_shape_known =
-            !(input_shape_dims.is_empty() && matches!(input_operand.kind, OperandKind::Output));
-        let output_shape_known =
-            !(output_desc.shape.is_empty() && matches!(output_operand.kind, OperandKind::Output));
+        let input_shape_known = !(input_shape_dims.is_empty()
+            && matches!(
+                input_operand.kind,
+                OperandKind::Output | OperandKind::Intermediate
+            ));
+        let output_shape_known = !(output_desc.shape.is_empty()
+            && matches!(
+                output_operand.kind,
+                OperandKind::Output | OperandKind::Intermediate
+            ));
 
         if scale_shape_dims.is_empty() {
             if !zero_point_shape_dims.is_empty() {
@@ -749,7 +758,7 @@ mod tests {
 
         // Intermediate output with unresolved shape metadata ([]).
         let unresolved_intermediate = Operand {
-            kind: OperandKind::Output,
+            kind: OperandKind::Intermediate,
             descriptor: OperandDescriptor {
                 data_type: DataType::Float32,
                 shape: vec![],
@@ -802,7 +811,7 @@ mod tests {
         };
 
         let validator = GraphValidator::new(&graph, ContextProperties::default());
-        assert!(validator.validate().is_ok());
+        validator.validate().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Asked cursor to validate the input/output shape before `MLContext::dispatch`. Not sure yet whether it did a good job. It used existing validation logic that I was not 100% aware of, but it went quite verbose.

I think this can be still improved. ~Especially since it somehow causes a test to fail and~ errors lack relevant contextual information (e.g. what operation/operand failed validation)

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

