### PR TITLE
ci: deny warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   rust-test:
     name: Rust Tests
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -433,7 +433,6 @@ impl TrtxConverter {
     ) -> Result<(), GraphError> {
         let mut tensor_map: HashMap<u32, trtx::Tensor<'a>> = HashMap::new();
         let promoted_constants: HashSet<u32> = HashSet::new();
-        let constants_stored_flat: HashSet<u32> = HashSet::new();
         let io_binding_names = Self::engine_io_binding_names(graph);
 
         // Step 1: Add inputs
@@ -565,7 +564,6 @@ impl TrtxConverter {
                 network,
                 &mut tensor_map,
                 &promoted_constants,
-                &constants_stored_flat,
                 operation,
             )?;
         }
@@ -599,7 +597,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'network_definition>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'network_definition>>,
         promoted_constants: &HashSet<u32>,
-        constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let op_type = operation.op_type();
@@ -705,14 +702,7 @@ impl TrtxConverter {
             "erf" => Self::add_unary_op(network, tensor_map, operation, UnaryOperation::kERF)?,
             "sign" => Self::add_unary_op(network, tensor_map, operation, UnaryOperation::kSIGN)?,
             "identity" => Self::add_identity_op(network, tensor_map, operation)?,
-            "cast" => Self::add_cast_op(
-                graph,
-                network,
-                tensor_map,
-                promoted_constants,
-                constants_stored_flat,
-                operation,
-            )?,
+            "cast" => Self::add_cast_op(graph, network, tensor_map, promoted_constants, operation)?,
             "quantizeLinear" => {
                 Self::add_quantize_linear_op(graph, network, tensor_map, operation)?
             }
@@ -2431,7 +2421,6 @@ impl TrtxConverter {
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         promoted_constants: &HashSet<u32>,
-        constants_stored_flat: &HashSet<u32>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
         let input_id = operation.input_operands()[0];


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Suppress warning when compiling with `-F trtx-runtime`, make warnings compile time errors in CI.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

