### PR TITLE
fix: intermittent test failure

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -237,8 +237,8 @@ impl GraphInfo {
         }
         if derived_outputs != self.output_operands {
             return Err(GraphError::OutputIdListMismatch {
-                output_ids: self.input_operands.clone(),
-                output_ids_in_operands: derived_inputs,
+                output_ids: self.output_operands.clone(),
+                output_ids_in_operands: derived_outputs,
             });
         }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -1760,6 +1760,8 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
             }
             graph.output_operands.push(operand.id as u32);
         }
+        // HashMap iteration order is nondeterministic; keep output_operands in operand-index order.
+        graph.output_operands.sort_unstable();
 
         debug!("Building graph with {} operands", graph.operands.len());
         // Verbose info for small graphs


### PR DESCRIPTION



## Summary

- [x] Describe the user-visible and code-level changes.

output_operands weren't ordered. Error message was not correct.

Fix regression (false positive error) introduced by #126

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

