### PR TITLE
tests: replace assert!(foo.is_ok()) with unwrap()

### DIFF
--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -210,9 +210,9 @@ mod tests {
         };
 
         // Should work with different cases
-        assert!(registry.convert("dummy", &graph).is_ok());
-        assert!(registry.convert("DUMMY", &graph).is_ok());
-        assert!(registry.convert("Dummy", &graph).is_ok());
+        registry.convert("dummy", &graph).unwrap();
+        registry.convert("DUMMY", &graph).unwrap();
+        registry.convert("Dummy", &graph).unwrap();
     }
 
     #[test]

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -9830,8 +9830,6 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
-
         let converted = result.unwrap();
         assert_eq!(converted.format, "onnx");
 
@@ -9918,8 +9916,6 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
-
         let converted = result.unwrap();
         let model = ModelProto::decode(converted.data.as_slice()).unwrap();
         let graph_proto = model.graph.unwrap();
@@ -10004,8 +10000,6 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
-
         let converted = result.unwrap();
         let model = ModelProto::decode(converted.data.as_slice()).unwrap();
         let graph_proto = model.graph.unwrap();
@@ -10048,7 +10042,7 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -10075,7 +10069,7 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -10123,7 +10117,7 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[cfg(not(feature = "dynamic-inputs"))]
@@ -10238,8 +10232,6 @@ mod tests {
 
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
-        assert!(result.is_ok());
-
         let converted = result.unwrap();
         let model = ModelProto::decode(converted.data.as_slice()).unwrap();
         let graph_proto = model.graph.unwrap();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -514,8 +514,8 @@ mod tests {
 
     #[test]
     fn validate_io_operand_lists_accepts_consistent_graph() {
-        assert!(sample_io_graph().validate_io_operand_lists().is_ok());
-        assert!(sample_io_graph().io_binding_maps().is_ok());
+        sample_io_graph().validate_io_operand_lists().unwrap();
+        sample_io_graph().io_binding_maps().unwrap();
     }
 
     #[test]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -249,14 +249,7 @@ mod tests {
         fs::write(&json_path, json_content).unwrap();
 
         // Load the graph
-        let result = load_graph_from_path(&json_path);
-        assert!(
-            result.is_ok(),
-            "Failed to load JSON graph: {:?}",
-            result.err()
-        );
-
-        let graph = result.unwrap();
+        let graph = load_graph_from_path(&json_path).expect("Failed to load JSON graph");
         assert!(graph.operands.len() >= 2); // At least input and output
         assert_eq!(graph.input_operands.len(), 1);
         assert_eq!(graph.output_operands.len(), 1);
@@ -446,11 +439,8 @@ mod tests {
         fs::write(&weights_path, &weights_data).unwrap();
 
         // Load the graph - weights should be inlined automatically
-        let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok(), "Failed to load graph: {:?}", result.err());
-
         // The weight constant should have inline bytes instead of a reference
-        let graph = result.unwrap();
+        let graph = load_graph_from_path(&graph_path).expect("Failed to load graph");
         assert!(!graph.constant_operand_ids_to_handles.is_empty());
     }
 
@@ -513,8 +503,7 @@ mod tests {
         fs::write(&weights_path, &weights_data).unwrap();
 
         // Should successfully match sanitized name to dotted manifest name
-        let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok(), "Failed to load graph: {:?}", result.err());
+        load_graph_from_path(&graph_path).expect("Failed to load graph");
     }
 
     #[test]
@@ -543,7 +532,7 @@ mod tests {
 
         // Should succeed even without manifest/weights
         let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -568,7 +557,7 @@ mod tests {
 
         // Should succeed by falling back to non-inlined weights
         let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -693,9 +682,7 @@ mod tests {
         fs::write(&graph_path, graph_content).unwrap();
         write_safetensors_f32(&st_path, "weight", vec![2], &tensor_bytes);
 
-        let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok(), "load: {:?}", result.err());
-        let graph = result.unwrap();
+        let graph = load_graph_from_path(&graph_path).expect("load");
         assert!(!graph.constant_operand_ids_to_handles.is_empty());
     }
 
@@ -726,8 +713,7 @@ mod tests {
         fs::write(&graph_path, graph_content).unwrap();
         write_safetensors_f32(&st_path, "onnx::weight", vec![2], &tensor_bytes);
 
-        let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok(), "load: {:?}", result.err());
+        load_graph_from_path(&graph_path).expect("load");
     }
 
     #[test]
@@ -765,8 +751,7 @@ mod tests {
             &[0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40],
         );
 
-        let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok(), "safetensors should win: {:?}", result.err());
+        load_graph_from_path(&graph_path).expect("safetensors should win");
     }
 
     #[test]
@@ -857,6 +842,6 @@ mod tests {
 
         // Should match namespace separator (:: -> __)
         let result = load_graph_from_path(&graph_path);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 }

--- a/src/runtime_checks.rs
+++ b/src/runtime_checks.rs
@@ -172,11 +172,9 @@ mod tests {
     fn validates_static_shape() {
         let mut state = RuntimeShapeState::new();
         let desc = input_desc(vec![Dimension::Static(2), Dimension::Static(3)]);
-        assert!(
-            state
-                .validate_shape("x", &[2, 3], &desc, TensorKind::Input)
-                .is_ok()
-        );
+        state
+            .validate_shape("x", &[2, 3], &desc, TensorKind::Input)
+            .unwrap();
     }
 
     #[test]
@@ -250,11 +248,9 @@ mod tests {
         let mut actual = HashMap::new();
         actual.insert("x".to_string(), vec![2, 3]);
 
-        assert!(
-            state
-                .validate_named_shapes(&actual, &descs, TensorKind::Input)
-                .is_ok()
-        );
+        state
+            .validate_named_shapes(&actual, &descs, TensorKind::Input)
+            .unwrap();
     }
 
     #[test]
@@ -285,8 +281,8 @@ mod tests {
 
     #[test]
     fn validates_shape_data_length() {
-        assert!(validate_shape_data_length("x", &[2, 3], 6).is_ok());
-        assert!(validate_shape_data_length("x", &[], 1).is_ok());
+        validate_shape_data_length("x", &[2, 3], 6).unwrap();
+        validate_shape_data_length("x", &[], 1).unwrap();
     }
 
     #[test]

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -2551,9 +2551,9 @@ mod tests {
 
     #[test]
     fn test_validate_reshape_valid() {
-        assert!(validate_reshape(&[2, 3], &[6]).is_ok());
-        assert!(validate_reshape(&[2, 3, 4], &[6, 4]).is_ok());
-        assert!(validate_reshape(&[6], &[2, 3]).is_ok());
+        validate_reshape(&[2, 3], &[6]).unwrap();
+        validate_reshape(&[2, 3, 4], &[6, 4]).unwrap();
+        validate_reshape(&[6], &[2, 3]).unwrap();
     }
 
     #[test]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -651,7 +651,7 @@ mod tests {
     fn dynamic_shapes_validate_when_feature_enabled() {
         let graph = build_dynamic_relu_graph();
         let validator = GraphValidator::new(&graph, ContextProperties::default());
-        assert!(validator.validate().is_ok());
+        validator.validate().unwrap();
     }
 
     #[test]
@@ -665,7 +665,7 @@ mod tests {
             vec![1, 3, 1],
         );
         let validator = GraphValidator::new(&graph, ContextProperties::default());
-        assert!(validator.validate().is_ok());
+        validator.validate().unwrap();
     }
 
     #[test]
@@ -679,7 +679,7 @@ mod tests {
             vec![2, 2],
         );
         let validator = GraphValidator::new(&graph, ContextProperties::default());
-        assert!(validator.validate().is_ok());
+        validator.validate().unwrap();
     }
 
     #[test]
@@ -1314,7 +1314,7 @@ mod tests {
         };
 
         let validator = GraphValidator::new(&graph, ContextProperties::default());
-        assert!(validator.validate().is_ok());
+        validator.validate().unwrap();
     }
 
     #[test]

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -1570,7 +1570,7 @@ mod tests {
         };
 
         let result = from_graph_json(&graph_json);
-        assert!(result.is_ok());
+        result.unwrap();
 
         // Test Uint32, Int64, Uint64, Int8, Uint8
         let types_to_test = vec![
@@ -1605,8 +1605,8 @@ mod tests {
                 outputs: BTreeMap::new(),
             };
 
-            let result = from_graph_json(&graph_json);
-            assert!(result.is_ok(), "Failed for type {:?}", dtype);
+            from_graph_json(&graph_json)
+                .unwrap_or_else(|e| panic!("Failed for type {:?}: {e}", dtype));
         }
     }
 
@@ -1822,7 +1822,7 @@ mod tests {
         };
 
         let result = from_graph_json(&graph_json);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -1851,7 +1851,7 @@ mod tests {
         };
 
         let result = from_graph_json(&graph_json);
-        assert!(result.is_ok());
+        result.unwrap();
     }
 
     #[test]
@@ -1886,7 +1886,6 @@ mod tests {
 
         let result = from_graph_json(&graph_json);
         // Should succeed but create no output operands for the operation
-        assert!(result.is_ok());
         let graph_info = result.unwrap();
         assert_eq!(graph_info.operations.len(), 1);
         assert_eq!(graph_info.operations[0].output_operands().len(), 0);


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

assert!(foo.is_ok()) just prints "assertion failed".
Unwrap panics with actual error message.


## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

