### PR TITLE
chore(trtx): ensure_trtx_loaded is not needed anymore

### DIFF
--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -29,7 +29,7 @@ use super::{
     ConvertedGraph, GraphConverter, pool2d_shared::infer_pool2d_ceil_mode_from_output_sizes,
 };
 use crate::error::GraphError;
-use crate::executors::trtx::{create_trtx_logger, ensure_trtx_loaded};
+use crate::executors::trtx::create_trtx_logger;
 use crate::graph::{DataType, GraphInfo, OperandKind, get_static_or_max_size};
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
@@ -12569,11 +12569,6 @@ impl GraphConverter for TrtxConverter {
                 format: "trtx".to_string(),
                 reason: e.to_string(),
             }
-        })?;
-
-        ensure_trtx_loaded().map_err(|e| GraphError::ConversionFailed {
-            format: "trtx".to_string(),
-            reason: e.to_string(),
         })?;
 
         // TODO: TRTX converter does not support dynamic dimensions yet

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -1,7 +1,6 @@
 #![cfg(any(feature = "trtx-runtime-mock", feature = "trtx-runtime"))]
 
 use std::collections::HashMap;
-use std::sync::Once;
 
 use crate::error::GraphError;
 use crate::graph::{OperandDescriptor, get_static_or_max_size};
@@ -35,8 +34,6 @@ fn trt_dtype_to_string(dtype: &trtx::DataType) -> &'static str {
         _ => "float32",
     }
 }
-
-static TRTX_INIT: Once = Once::new();
 
 /// Log handler that only emits messages at or above a minimum severity.
 /// Used when RUSTNN_TRTX_LOG_VERBOSITY is set (e.g. by WPT test runner).
@@ -77,35 +74,6 @@ pub(crate) fn create_trtx_logger() -> Result<trtx::Logger, GraphError> {
     trtx::Logger::new(handler).map_err(|e| GraphError::TrtxRuntimeFailed {
         reason: format!("failed to create TensorRT logger: {e}"),
     })
-}
-
-/// Load TensorRT and ONNX parser libraries once per process (no-op when using mock).
-/// Called by the converter and executor so the library is loaded before any trtx API use.
-pub(crate) fn ensure_trtx_loaded() -> Result<(), GraphError> {
-    #[cfg(feature = "trtx-runtime")]
-    {
-        let mut result = Ok(());
-        TRTX_INIT.call_once(|| {
-            result = trtx::dynamically_load_tensorrt(None::<&str>).map_err(|e| {
-                GraphError::TrtxRuntimeFailed {
-                    reason: format!("failed to load TensorRT library: {e}"),
-                }
-            });
-            if result.is_ok() {
-                result = trtx::dynamically_load_tensorrt_onnxparser(None::<&str>).map_err(|e| {
-                    GraphError::TrtxRuntimeFailed {
-                        reason: format!("failed to load TensorRT ONNX parser library: {e}"),
-                    }
-                });
-            }
-        });
-        result
-    }
-    #[cfg(not(feature = "trtx-runtime"))]
-    {
-        TRTX_INIT.call_once(|| {});
-        Ok(())
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -150,8 +118,6 @@ pub fn run_trtx_zeroed(
     model_bytes: &[u8],
     inputs: &HashMap<String, OperandDescriptor>,
 ) -> Result<Vec<TrtxOutput>, GraphError> {
-    ensure_trtx_loaded()?;
-
     if is_onnx_format(model_bytes) {
         // ONNX path: trtx crate expects f32 inputs
         let mut input_tensors = Vec::new();
@@ -308,7 +274,6 @@ pub fn run_trtx_with_inputs(
     engine_bytes: &[u8],
     inputs: Vec<TrtxInput>,
 ) -> Result<Vec<TrtxOutputWithData>, GraphError> {
-    ensure_trtx_loaded()?;
     if is_onnx_format(engine_bytes) {
         return Err(GraphError::TrtxRuntimeFailed {
             reason: "run_trtx_with_inputs expects a serialized TensorRT engine, not ONNX bytes"


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

trtx now loads TensorRT RTX on-demand. Users can still load their own TensorRT library from custom path before using RustNN if they want.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

