### PR TITLE
Fix issues running the webnnjs WPT-WebNN tests

### DIFF
--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -6295,22 +6295,20 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         });
                     }
                 } else {
-                    // WPT: lstmOutput1 = sequence (Y), lstmOutput2 = cell state (Y_c), lstmOutput3 = hidden state (Y_h).
+                    // WPT: lstmOutput1 = Y_h, lstmOutput2 = Y_c, lstmOutput3 = sequence (Y).
                     // Use out_id in node name so each Identity has a unique name.
                     for &out_id in output_ids.iter().take(3) {
                         let out_name = operand_name(graph, out_id);
                         let (src_name, label) = if out_name.contains("Output1") {
-                            // WebNN LSTM: outputs[0] is always the hidden state from the last time step (Y_h) [1, batch, hidden].
+                            // WPT lstmOutput1 = hidden state (Y_h).
                             (lstm_y_h_name.clone(), "y")
                         } else if out_name.contains("Output2") {
-                            // outputs[1] is always the cell state (Y_c).
+                            // WPT lstmOutput2 = cell state (Y_c).
                             (lstm_y_c_name.clone(), "y_c")
                         } else if out_name.contains("Output3")
                             || (output_ids.len() >= 3 && out_id == output_ids[2])
                         {
-                            // outputs[2] when returnSequence: sequence.
-                            // Unidirectional: seq_source is [steps, batch, hidden]; Unsqueeze(axis=1) → [steps, 1, batch, hidden].
-                            // Bidirectional: seq_source is already [steps, num_directions, batch, hidden]; use as-is (no Unsqueeze).
+                            // WPT lstmOutput3 = sequence (Y) when returnSequence is true.
                             if unidirectional {
                                 let seq_4d_name = format!("{}_y_seq_4d", op_name);
                                 nodes.push(NodeProto {
@@ -6374,13 +6372,13 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         reason: "lstmCell requires at least one output".to_string(),
                     });
                 }
+                let output_hidden_name = operand_name(graph, output_ids[0]);
+                let output_cell_name = output_ids.get(1).map(|&id| operand_name(graph, id));
                 let input_name = operand_name(graph, input_id);
                 let weight_name = operand_name(graph, weight_id);
                 let recurrent_weight_name = operand_name(graph, recurrent_weight_id);
                 let hidden_state_name = operand_name(graph, hidden_state_id);
                 let cell_state_name = operand_name(graph, cell_state_id);
-                let output_hidden_name = operand_name(graph, output_ids[0]);
-                let output_cell_name = output_ids.get(1).map(|&id| operand_name(graph, id));
                 let weight_operand = graph.operand(weight_id).ok_or_else(|| {
                     Self::invalid_operand("lstmCell weight lookup", weight_id, Some((op, idx)))
                 })?;
@@ -6786,19 +6784,25 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         ..Default::default()
                     });
 
-                    // new_hidden = output * tanh(new_cell)
-                    let tanh_cell = format!("{}_tanh_c", op_name);
-                    let new_hidden = format!("{}_new_h", op_name);
+                    // new_hidden = output * activation[2](new_cell) (default tanh)
+                    let hidden_cell_act = match &lstm_activations {
+                        Some(acts) if acts.len() > 2 => {
+                            Self::recurrent_activation_to_onnx(&acts[2])
+                        }
+                        _ => "Tanh".to_string(),
+                    };
+                    let filtered_cell = format!("{}_filt_c", op_name);
                     nodes.push(NodeProto {
                         input: vec![new_cell_name.clone()],
-                        output: vec![tanh_cell.clone()],
-                        name: tanh_cell.clone(),
-                        op_type: "Tanh".to_string(),
+                        output: vec![filtered_cell.clone()],
+                        name: filtered_cell.clone(),
+                        op_type: hidden_cell_act,
                         attribute: vec![],
                         ..Default::default()
                     });
+                    let new_hidden = format!("{}_new_h", op_name);
                     nodes.push(NodeProto {
-                        input: vec![gate_act_names[go as usize].clone(), tanh_cell],
+                        input: vec![gate_act_names[go as usize].clone(), filtered_cell],
                         output: vec![new_hidden.clone()],
                         name: format!("{}_h_mul", op_name),
                         op_type: "Mul".to_string(),
@@ -6806,26 +6810,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         ..Default::default()
                     });
 
-                    // Apply hidden activation (activations[2])
-                    let final_hidden = if let Some(acts) = &lstm_activations {
-                        if acts.len() > 2 {
-                            let act = Self::recurrent_activation_to_onnx(&acts[2]);
-                            let out = format!("{}_act_h", op_name);
-                            nodes.push(NodeProto {
-                                input: vec![new_hidden],
-                                output: vec![out.clone()],
-                                name: out.clone(),
-                                op_type: act,
-                                attribute: vec![],
-                                ..Default::default()
-                            });
-                            out
-                        } else {
-                            new_hidden
-                        }
-                    } else {
-                        new_hidden
-                    };
+                    let final_hidden = new_hidden;
 
                     // Route to outputs
                     nodes.push(NodeProto {

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -13,11 +13,10 @@ use crate::operator_options::{
     MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions, MLDimension, MLEluOptions,
     MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions,
     MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
-    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, OperandIndex,
-    MLPadOptions,
+    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, MLPadOptions,
     MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions, MLScatterOptions,
     MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions, MLTriangularOptions,
-    MLUnsqueezeOptions,
+    MLUnsqueezeOptions, OperandIndex,
 };
 use crate::shape_inference::{
     InputLayout, ReduceOptions, SplitSpec, infer_concat_shape_dimensions,
@@ -25,9 +24,9 @@ use crate::shape_inference::{
     infer_gather_shape_dimensions, infer_gemm_shape_dimensions, infer_global_pool_shape,
     infer_matmul_shape_dimensions, infer_pad_shape, infer_pool2d_shape_dimensions,
     infer_prelu_shape, infer_reduce_shape_dimensions, infer_resample2d_shape,
-    infer_scatter_elements_shape, infer_scatter_nd_shape, infer_slice_shape, infer_split_shapes, infer_squeeze_shape,
-    infer_tile_shape, infer_transpose_shape_dimensions, infer_triangular_shape,
-    infer_unsqueeze_shape_dimensions,
+    infer_scatter_elements_shape, infer_scatter_nd_shape, infer_slice_shape, infer_split_shapes,
+    infer_squeeze_shape, infer_tile_shape, infer_transpose_shape_dimensions,
+    infer_triangular_shape, infer_unsqueeze_shape_dimensions,
 };
 use crate::webnn_json::to_graph_json;
 use crate::{DataType, Operand, OperandDescriptor, OperandKind, Operation};
@@ -1354,10 +1353,7 @@ fn gru_cell_shape(
     if input_shape.len() == 2 && hidden_size > 0 {
         return Ok(OperandDescriptor {
             data_type: graph.operands[input.id].descriptor.data_type,
-            shape: to_dimension_vector(&[
-                get_static_or_max_size(&input_shape[0]),
-                hidden_size,
-            ]),
+            shape: to_dimension_vector(&[get_static_or_max_size(&input_shape[0]), hidden_size]),
             pending_permutation: vec![],
         });
     }

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -11,9 +11,11 @@ use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{
     MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
     MLConv2dOptions, MLConvTranspose2dOptions, MLCumulativeSumOptions, MLDimension, MLEluOptions,
-    MLGatherOptions, MLGemmOptions, MLHardSigmoidOptions, MLInstanceNormalizationOptions,
-    MLLayerNormalizationOptions, MLLeakyReluOptions, MLLinearOptions, MLOperatorOptions,
-    MLPadOptions, MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions,
+    MLGatherOptions, MLGemmOptions, MLGruCellOptions, MLGruOptions, MLHardSigmoidOptions,
+    MLInstanceNormalizationOptions, MLLayerNormalizationOptions, MLLeakyReluOptions,
+    MLLinearOptions, MLLstmCellOptions, MLLstmOptions, MLOperatorOptions, OperandIndex,
+    MLPadOptions,
+    MLPool2dOptions, MLReduceOptions, MLResample2dOptions, MLReverseOptions, MLScatterOptions,
     MLSliceOptions, MLSplitOptions, MLSqueezeOptions, MLTransposeOptions, MLTriangularOptions,
     MLUnsqueezeOptions,
 };
@@ -22,9 +24,10 @@ use crate::shape_inference::{
     infer_conv_transpose2d_shape, infer_conv2d_shape, infer_expand_shape_dimensions,
     infer_gather_shape_dimensions, infer_gemm_shape_dimensions, infer_global_pool_shape,
     infer_matmul_shape_dimensions, infer_pad_shape, infer_pool2d_shape_dimensions,
-    infer_prelu_shape, infer_reduce_shape_dimensions, infer_scatter_nd_shape, infer_split_shapes,
-    infer_squeeze_shape, infer_tile_shape, infer_transpose_shape_dimensions,
-    infer_triangular_shape, infer_unsqueeze_shape_dimensions,
+    infer_prelu_shape, infer_reduce_shape_dimensions, infer_resample2d_shape,
+    infer_scatter_elements_shape, infer_scatter_nd_shape, infer_slice_shape, infer_split_shapes, infer_squeeze_shape,
+    infer_tile_shape, infer_transpose_shape_dimensions, infer_triangular_shape,
+    infer_unsqueeze_shape_dimensions,
 };
 use crate::webnn_json::to_graph_json;
 use crate::{DataType, Operand, OperandDescriptor, OperandKind, Operation};
@@ -93,7 +96,7 @@ fn slice_shape(
     operation: &Operation,
     starts: &[u32],
     sizes: &[MLDimension],
-    _options: &Option<MLSliceOptions>, // strides in options, doesn't affect shape
+    options: &Option<MLSliceOptions>,
     graph: &GraphInfo,
 ) -> Result<OperandDescriptor> {
     let operand = get_operand(input, graph)?;
@@ -107,11 +110,25 @@ fn slice_shape(
         .into());
     }
 
-    let mut desc = operand.descriptor.clone();
-    for (i, sz) in sizes.iter().enumerate() {
-        desc.shape[i] = sz.clone().into();
-    }
-    Ok(desc)
+    let sizes_u32: Vec<u32> = sizes.iter().map(|d| d.static_or_max()).collect();
+    let strides = options.as_ref().map(|o| o.strides.as_slice());
+    let shape = infer_shape_err(
+        "slice",
+        operation,
+        infer_slice_shape(
+            &shape_dims_u32(&operand.descriptor.shape),
+            starts,
+            &sizes_u32,
+            strides,
+        )
+        .map(|v| to_dimension_vector(&v)),
+    )?;
+
+    Ok(OperandDescriptor {
+        data_type: operand.descriptor.data_type,
+        shape,
+        pending_permutation: vec![],
+    })
 }
 
 fn concat_shape(
@@ -346,10 +363,18 @@ fn gather_shape(
 
 fn gather_elements_shape(
     input: MLOperand,
+    indices: MLOperand,
     operation: &Operation,
     graph: &GraphInfo,
 ) -> Result<OperandDescriptor> {
-    preserve_input_shape(input, operation, graph)
+    let input_op = get_operand(input, graph)?;
+    let indices_op = get_operand(indices, graph)?;
+    let _ = operation;
+    Ok(OperandDescriptor {
+        data_type: input_op.descriptor.data_type,
+        shape: indices_op.descriptor.shape.clone(),
+        pending_permutation: vec![],
+    })
 }
 
 fn gather_nd_shape(
@@ -441,6 +466,75 @@ fn scatter_nd_shape(
     Ok(input_op.descriptor.clone())
 }
 
+fn scatter_elements_shape(
+    input: MLOperand,
+    indices: MLOperand,
+    updates: MLOperand,
+    operation: &Operation,
+    options: Option<&MLScatterOptions>,
+    graph: &GraphInfo,
+) -> Result<OperandDescriptor> {
+    let input_op = get_operand(input, graph)?;
+    let indices_op = get_operand(indices, graph)?;
+    let updates_op = get_operand(updates, graph)?;
+
+    check_same_data_type(&[input, updates], operation, &[input_op, updates_op])?;
+
+    let fully_static =
+        |shape: &[Dimension]| shape.iter().all(|d| matches!(d, Dimension::Static(_)));
+    if fully_static(&input_op.descriptor.shape)
+        && fully_static(&indices_op.descriptor.shape)
+        && fully_static(&updates_op.descriptor.shape)
+    {
+        let axis = options.map(|o| o.axis).unwrap_or(0);
+        let _validated = infer_shape_err(
+            "scatterElements",
+            operation,
+            infer_scatter_elements_shape(
+                &shape_dims_u32(&input_op.descriptor.shape),
+                &shape_dims_u32(&indices_op.descriptor.shape),
+                &shape_dims_u32(&updates_op.descriptor.shape),
+                axis,
+            )
+            .map(|shape| to_dimension_vector(&shape)),
+        )?;
+    }
+
+    Ok(input_op.descriptor.clone())
+}
+
+fn resample2d_shape(
+    input: MLOperand,
+    operation: &Operation,
+    options: Option<&MLResample2dOptions>,
+    graph: &GraphInfo,
+) -> Result<OperandDescriptor> {
+    let input_op = get_operand(input, graph)?;
+    let default_opts = MLResample2dOptions::default();
+    let opts = options.unwrap_or(&default_opts);
+    let rank = input_op.descriptor.shape.len();
+    let axes: [usize; 2] = if opts.axes.len() == 2 {
+        [opts.axes[0] as usize, opts.axes[1] as usize]
+    } else {
+        [rank.saturating_sub(2), rank.saturating_sub(1)]
+    };
+    let shape = infer_shape_err(
+        "resample2d",
+        operation,
+        infer_resample2d_shape(
+            &input_op.descriptor.shape,
+            axes,
+            opts.sizes.as_deref(),
+            &opts.scales,
+        ),
+    )?;
+    Ok(OperandDescriptor {
+        data_type: input_op.descriptor.data_type,
+        shape,
+        pending_permutation: vec![],
+    })
+}
+
 fn argminmax_shape(
     input: MLOperand,
     operation: &Operation,
@@ -474,8 +568,13 @@ fn reduce_shape(
 ) -> Result<OperandDescriptor> {
     let operand = get_operand(input, graph)?;
     let opts = options.cloned().unwrap_or_default();
+    let rank = operand.descriptor.shape.len() as u32;
     let reduce_opts = ReduceOptions {
-        axes: opts.axes.unwrap_or_default(),
+        // WebNN: omitted `axes` reduces all dimensions; explicit `axes: []` reduces none.
+        axes: match &opts.axes {
+            None => (0..rank).collect(),
+            Some(axes) => axes.clone(),
+        },
         keep_dimensions: opts.keep_dimensions,
     };
     let shape = infer_shape_err(
@@ -739,13 +838,6 @@ fn split_shape(
     let spec = if let Some(n) = split_equal_parts {
         SplitSpec::Count(n)
     } else {
-        if splits.is_empty() || operand.descriptor.shape.len() % splits.len() != 0 {
-            return Err(Box::new(ShapeInferenceError::InvalidSplitSizes {
-                input: (input, operand.clone()),
-                operation: operation.clone(),
-            })
-            .into());
-        }
         SplitSpec::Sizes(splits.to_vec())
     };
     let mut output_shapes =
@@ -901,6 +993,43 @@ fn cast_shape(
     Ok(OperandDescriptor {
         data_type: data_type.into(),
         shape: operand.descriptor.shape.clone(),
+        pending_permutation: vec![],
+    })
+}
+
+/// WebNN: output descriptor uses zeroPoint's dataType and input's shape.
+fn quantize_linear_shape(
+    input: MLOperand,
+    zero_point: Option<u32>,
+    graph: &GraphInfo,
+) -> Result<OperandDescriptor> {
+    let input_op = get_operand(input, graph)?;
+    let data_type = match zero_point {
+        Some(zp) => {
+            get_operand(MLOperand { id: zp as usize }, graph)?
+                .descriptor
+                .data_type
+        }
+        None => DataType::Uint8,
+    };
+    Ok(OperandDescriptor {
+        data_type,
+        shape: input_op.descriptor.shape.clone(),
+        pending_permutation: vec![],
+    })
+}
+
+/// WebNN: output descriptor uses scale's dataType and input's shape.
+fn dequantize_linear_shape(
+    input: MLOperand,
+    scale: MLOperand,
+    graph: &GraphInfo,
+) -> Result<OperandDescriptor> {
+    let input_op = get_operand(input, graph)?;
+    let scale_op = get_operand(scale, graph)?;
+    Ok(OperandDescriptor {
+        data_type: scale_op.descriptor.data_type,
+        shape: input_op.descriptor.shape.clone(),
         pending_permutation: vec![],
     })
 }
@@ -1122,6 +1251,127 @@ macro_rules! impl_ternary_optional_op {
     };
 }
 
+fn recurrent_num_directions(direction: &str) -> u32 {
+    if direction == "both" { 2 } else { 1 }
+}
+
+fn recurrent_batch_size(input_shape: &[Dimension]) -> u32 {
+    match input_shape.len() {
+        2 => get_static_or_max_size(&input_shape[0]),
+        3 => get_static_or_max_size(&input_shape[1]),
+        _ => 1,
+    }
+}
+
+fn gru_output_shapes(
+    input: OperandIndex,
+    steps: u32,
+    hidden_size: u32,
+    options: Option<&MLGruOptions>,
+    graph: &GraphInfo,
+) -> Result<Vec<OperandDescriptor>> {
+    let input_operand = &graph.operands[input as usize];
+    let dtype = input_operand.descriptor.data_type;
+    let opts = options.cloned().unwrap_or_default();
+    let num_dir = recurrent_num_directions(&opts.direction);
+    let batch = recurrent_batch_size(&input_operand.descriptor.shape);
+    let h = hidden_size;
+
+    let mut shapes = vec![OperandDescriptor {
+        data_type: dtype,
+        shape: to_dimension_vector(&[num_dir, batch, h]),
+        pending_permutation: vec![],
+    }];
+    if opts.return_sequence {
+        shapes.push(OperandDescriptor {
+            data_type: dtype,
+            shape: to_dimension_vector(&[steps, num_dir, batch, h]),
+            pending_permutation: vec![],
+        });
+    }
+    Ok(shapes)
+}
+
+fn lstm_output_shapes(
+    input: OperandIndex,
+    steps: u32,
+    hidden_size: u32,
+    options: Option<&MLLstmOptions>,
+    graph: &GraphInfo,
+) -> Result<Vec<OperandDescriptor>> {
+    let input_operand = &graph.operands[input as usize];
+    let dtype = input_operand.descriptor.data_type;
+    let opts = options.cloned().unwrap_or_default();
+    let num_dir = recurrent_num_directions(&opts.direction);
+    let batch = recurrent_batch_size(&input_operand.descriptor.shape);
+    let h = hidden_size;
+
+    let mut shapes = Vec::new();
+    shapes.push(OperandDescriptor {
+        data_type: dtype,
+        shape: to_dimension_vector(&[num_dir, batch, h]),
+        pending_permutation: vec![],
+    });
+    shapes.push(OperandDescriptor {
+        data_type: dtype,
+        shape: to_dimension_vector(&[num_dir, batch, h]),
+        pending_permutation: vec![],
+    });
+    if opts.return_sequence {
+        shapes.push(OperandDescriptor {
+            data_type: dtype,
+            shape: to_dimension_vector(&[steps, num_dir, batch, h]),
+            pending_permutation: vec![],
+        });
+    }
+    Ok(shapes)
+}
+
+fn lstm_cell_output_shapes(
+    hidden_state: OperandIndex,
+    cell_state: OperandIndex,
+    graph: &GraphInfo,
+) -> Result<Vec<OperandDescriptor>> {
+    Ok(vec![
+        graph.operands[hidden_state as usize].descriptor.clone(),
+        graph.operands[cell_state as usize].descriptor.clone(),
+    ])
+}
+
+fn gru_cell_shape(
+    input: MLOperand,
+    hidden_state: MLOperand,
+    hidden_size: u32,
+    operation: &Operation,
+    graph: &GraphInfo,
+) -> Result<OperandDescriptor> {
+    let hidden_state_desc = &graph.operands[hidden_state.id].descriptor;
+    if !hidden_state_desc.shape.is_empty() {
+        return Ok(hidden_state_desc.clone());
+    }
+
+    let input_shape = &graph.operands[input.id].descriptor.shape;
+    if input_shape.len() == 2 && hidden_size > 0 {
+        return Ok(OperandDescriptor {
+            data_type: graph.operands[input.id].descriptor.data_type,
+            shape: to_dimension_vector(&[
+                get_static_or_max_size(&input_shape[0]),
+                hidden_size,
+            ]),
+            pending_permutation: vec![],
+        });
+    }
+
+    Err(Box::new(ShapeInferenceError::InferError {
+        op_name: "gruCell",
+        operation: operation.clone(),
+        source: GraphError::ShapeInferenceFailed {
+            reason: "unable to infer gruCell output shape".to_string(),
+        },
+    })
+    .into())
+}
+
 fn shape_inference_multi_output(
     operation: &Operation,
     graph: &GraphInfo,
@@ -1143,6 +1393,25 @@ fn shape_inference_multi_output(
             options.as_ref(),
             graph,
         ),
+        Operation::Gru {
+            input,
+            steps,
+            hidden_size,
+            options,
+            ..
+        } => gru_output_shapes(*input, *steps, *hidden_size, options.as_ref(), graph),
+        Operation::Lstm {
+            input,
+            steps,
+            hidden_size,
+            options,
+            ..
+        } => lstm_output_shapes(*input, *steps, *hidden_size, options.as_ref(), graph),
+        Operation::LstmCell {
+            hidden_state,
+            cell_state,
+            ..
+        } => lstm_cell_output_shapes(*hidden_state, *cell_state, graph),
         op => Ok(vec![shape_inference_single_output(op, graph)?]),
     }
 }
@@ -1409,9 +1678,12 @@ fn shape_inference_single_output(
             options.as_ref(),
             graph,
         ),
-        Operation::GatherElements { input, .. } => gather_elements_shape(
+        Operation::GatherElements { input, indices, .. } => gather_elements_shape(
             MLOperand {
                 id: *input as usize,
+            },
+            MLOperand {
+                id: *indices as usize,
             },
             operation,
             graph,
@@ -1424,10 +1696,22 @@ fn shape_inference_single_output(
             graph,
         ),
         // TODO: verify data type of non-input operands
-        Operation::Gru { .. }
-        | Operation::GruCell { .. }
-        | Operation::Lstm { .. }
-        | Operation::LstmCell { .. } => todo!(),
+        Operation::GruCell {
+            input,
+            hidden_state,
+            hidden_size,
+            ..
+        } => gru_cell_shape(
+            MLOperand {
+                id: *input as usize,
+            },
+            MLOperand {
+                id: *hidden_state as usize,
+            },
+            *hidden_size,
+            operation,
+            graph,
+        ),
         Operation::HardSigmoid { input, .. }
         | Operation::HardSwish { input, .. }
         | Operation::InstanceNormalization { input, .. }
@@ -1533,22 +1817,34 @@ fn shape_inference_single_output(
             new_shape,
             graph,
         ),
-        Operation::Resample2d { input, options, .. } => todo!(),
-        //resample2d_shape(
-        //MLOperand {
-        //id: *input as usize,
-        //},
-        //operation,
-        //options.as_ref(),
-        //graph,
-        //),
+        Operation::Resample2d { input, options, .. } => resample2d_shape(
+            MLOperand {
+                id: *input as usize,
+            },
+            operation,
+            options.as_ref(),
+            graph,
+        ),
         Operation::ScatterElements {
             input,
             indices,
             updates,
             options,
             ..
-        } => todo!(),
+        } => scatter_elements_shape(
+            MLOperand {
+                id: *input as usize,
+            },
+            MLOperand {
+                id: *indices as usize,
+            },
+            MLOperand {
+                id: *updates as usize,
+            },
+            operation,
+            options.as_ref(),
+            graph,
+        ),
         Operation::Slice {
             input,
             starts,
@@ -1631,15 +1927,24 @@ fn shape_inference_single_output(
             operation,
             graph,
         ),
-        Operation::QuantizeLinear { input, .. } | Operation::DequantizeLinear { input, .. } => {
-            preserve_input_shape(
-                MLOperand {
-                    id: *input as usize,
-                },
-                operation,
-                graph,
-            )
-        }
+        Operation::QuantizeLinear {
+            input, zero_point, ..
+        } => quantize_linear_shape(
+            MLOperand {
+                id: *input as usize,
+            },
+            *zero_point,
+            graph,
+        ),
+        Operation::DequantizeLinear { input, scale, .. } => dequantize_linear_shape(
+            MLOperand {
+                id: *input as usize,
+            },
+            MLOperand {
+                id: *scale as usize,
+            },
+            graph,
+        ),
         Operation::Shape { input, .. } => shape_op_shape(
             MLOperand {
                 id: *input as usize,
@@ -1680,6 +1985,9 @@ fn shape_inference_single_output(
             operation,
             graph,
         ),
+        Operation::Gru { .. } | Operation::Lstm { .. } | Operation::LstmCell { .. } => {
+            panic!("This method only supports single output ops. Use shape_inference_multi_output")
+        }
     }
 }
 
@@ -2111,6 +2419,15 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         indices,
         updates
     );
+    impl_ternary_op!(
+        scatter_elements,
+        scatter_elements_with_options,
+        ScatterElements,
+        MLScatterOptions,
+        input,
+        indices,
+        updates
+    );
     impl_ternary_optional_op!(
         quantize_linear,
         quantize_linear_with_zeropoint,
@@ -2514,8 +2831,115 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         Ok(output)
     }
 
-    // TODO:
-    // gru, gruCell, constant, lstm, lstmCell, scatter_nd, scatter_elements
+    pub fn gru_with_options(
+        &mut self,
+        input: MLOperand,
+        weight: MLOperand,
+        recurrent_weight: MLOperand,
+        steps: u32,
+        hidden_size: u32,
+        options: MLGruOptions,
+    ) -> Result<Vec<MLOperand>> {
+        let output_count = if options.return_sequence { 2 } else { 1 };
+        let graph = self
+            .graph
+            .as_mut()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+        let base = graph.operands.len() as u32;
+        let output_ids: Vec<u32> = (0..output_count as u32).map(|i| base + i).collect();
+        let operation = Operation::Gru {
+            input: input.id as u32,
+            weight: weight.id as u32,
+            recurrence: recurrent_weight.id as u32,
+            steps,
+            hidden_size,
+            options: Some(options),
+            outputs: output_ids,
+        };
+        self.add_multi_output_operation(operation)
+    }
+
+    pub fn gru_cell_with_options(
+        &mut self,
+        input: MLOperand,
+        weight: MLOperand,
+        recurrent_weight: MLOperand,
+        hidden_state: MLOperand,
+        hidden_size: u32,
+        options: MLGruCellOptions,
+    ) -> Result<MLOperand> {
+        let graph = self
+            .graph
+            .as_mut()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+        let output_id = graph.operands.len() as u32;
+        self.add_single_output_operation(Operation::GruCell {
+            input: input.id as u32,
+            weight: weight.id as u32,
+            recurrence: recurrent_weight.id as u32,
+            hidden_state: hidden_state.id as u32,
+            hidden_size,
+            options: Some(options),
+            outputs: vec![output_id],
+        })
+    }
+
+    pub fn lstm_with_options(
+        &mut self,
+        input: MLOperand,
+        weight: MLOperand,
+        recurrent_weight: MLOperand,
+        steps: u32,
+        hidden_size: u32,
+        options: MLLstmOptions,
+    ) -> Result<Vec<MLOperand>> {
+        let output_count = if options.return_sequence { 3 } else { 2 };
+        let graph = self
+            .graph
+            .as_mut()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+        let base = graph.operands.len() as u32;
+        let output_ids: Vec<u32> = (0..output_count as u32).map(|i| base + i).collect();
+        let operation = Operation::Lstm {
+            input: input.id as u32,
+            weight: weight.id as u32,
+            recurrence: recurrent_weight.id as u32,
+            steps,
+            hidden_size,
+            options: Some(options),
+            outputs: output_ids,
+        };
+        self.add_multi_output_operation(operation)
+    }
+
+    pub fn lstm_cell_with_options(
+        &mut self,
+        input: MLOperand,
+        weight: MLOperand,
+        recurrent_weight: MLOperand,
+        hidden_state: MLOperand,
+        cell_state: MLOperand,
+        hidden_size: u32,
+        options: MLLstmCellOptions,
+    ) -> Result<Vec<MLOperand>> {
+        let graph = self
+            .graph
+            .as_mut()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+        let base = graph.operands.len() as u32;
+        let output_ids = vec![base, base + 1];
+        let operation = Operation::LstmCell {
+            input: input.id as u32,
+            weight: weight.id as u32,
+            recurrence: recurrent_weight.id as u32,
+            hidden_state: hidden_state.id as u32,
+            cell_state: cell_state.id as u32,
+            hidden_size,
+            options: Some(options),
+            outputs: output_ids,
+        };
+        self.add_multi_output_operation(operation)
+    }
 }
 
 #[cfg(test)]
@@ -2710,5 +3134,56 @@ mod test {
         context.dispatch(&mut graph2, &inputs, &outputs).unwrap();
         context.read_tensor(&output, &mut output_cpu).unwrap();
         assert_eq!(output_cpu, &[4.0f32, 5., 6., 7.]);
+    }
+
+    #[test]
+    fn quantize_dequantize_linear_output_dtype() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvialable)) {
+            return;
+        }
+
+        let mut context = context.unwrap();
+        let float_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 3].to_vec(),
+        );
+        let int_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Uint8,
+            [2, 3].to_vec(),
+        );
+        let scalar_f32 = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [].to_vec(),
+        );
+        let scalar_u8 =
+            MLOperandDescriptor::new(crate::operator_enums::MLOperandDataType::Uint8, [].to_vec());
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let x = builder.input("x", &float_desc).unwrap();
+        let scale = builder.constant_from_slice(&scalar_f32, &[0.5f32]).unwrap();
+        let zero_point = builder.constant_from_slice(&scalar_u8, &[128u8]).unwrap();
+        let q = builder
+            .quantize_linear_with_zeropoint(x, scale, zero_point)
+            .unwrap();
+        assert_eq!(
+            builder.rustnn_operand_data_type(q).unwrap(),
+            crate::operator_enums::MLOperandDataType::Uint8
+        );
+        assert_eq!(builder.rustnn_operand_shape(q).unwrap(), float_desc.shape());
+
+        let dq = builder
+            .dequantize_linear_with_zeropoint(q, scale, zero_point)
+            .unwrap();
+        assert_eq!(
+            builder.rustnn_operand_data_type(dq).unwrap(),
+            crate::operator_enums::MLOperandDataType::Float32
+        );
+        assert_eq!(builder.rustnn_operand_shape(dq).unwrap(), int_desc.shape());
+
+        let mut outputs = HashMap::new();
+        outputs.insert("out", dq);
+        builder.build(&outputs).unwrap();
     }
 }

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -234,15 +234,29 @@ pub struct MLOperatorOptions {
 /// MLArgMinMaxOptions. argMin / argMax (axis is a builder method parameter, not in this dictionary).
 ///
 /// WebNN: <https://www.w3.org/TR/webnn/#dictdef-mlargminmaxoptions>
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct MLArgMinMaxOptions {
     #[serde(default)]
     pub label: String,
     #[serde(default)]
     pub keep_dimensions: bool,
-    #[serde(default)]
+    #[serde(default = "default_arg_min_max_output_data_type")]
     pub output_data_type: MLOperandDataType,
+}
+
+fn default_arg_min_max_output_data_type() -> MLOperandDataType {
+    MLOperandDataType::Int32
+}
+
+impl Default for MLArgMinMaxOptions {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            keep_dimensions: false,
+            output_data_type: MLOperandDataType::Int32,
+        }
+    }
 }
 
 fn default_batch_norm_axis() -> u32 {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -512,6 +512,8 @@ pub enum Operation {
         input: OperandIndex,
         weight: OperandIndex,
         recurrence: OperandIndex,
+        steps: u32,
+        hidden_size: u32,
         options: Option<MLLstmOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -522,6 +524,7 @@ pub enum Operation {
         recurrence: OperandIndex,
         hidden_state: OperandIndex,
         cell_state: OperandIndex,
+        hidden_size: u32,
         options: Option<MLLstmCellOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -1527,6 +1530,15 @@ impl Operation {
                 obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
             }
             Operation::GruCell { hidden_size, .. } => {
+                obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
+            }
+            Operation::Lstm {
+                steps, hidden_size, ..
+            } => {
+                obj.insert("steps".to_string(), serde_json::json!(steps));
+                obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
+            }
+            Operation::LstmCell { hidden_size, .. } => {
                 obj.insert("hiddenSize".to_string(), serde_json::json!(hidden_size));
             }
             Operation::Pad {
@@ -2665,6 +2677,8 @@ impl Operation {
                 input: at(input_operands, 0)?,
                 weight: at(input_operands, 1)?,
                 recurrence: at(input_operands, 2)?,
+                steps: extras.steps.unwrap_or(0),
+                hidden_size: extras.hidden_size.unwrap_or(0),
                 options: attributes.as_lstm().cloned(),
                 outputs: outputs.to_vec(),
             }),
@@ -2674,6 +2688,7 @@ impl Operation {
                 recurrence: at(input_operands, 2)?,
                 hidden_state: at(input_operands, 3)?,
                 cell_state: at(input_operands, 4)?,
+                hidden_size: extras.hidden_size.unwrap_or(0),
                 options: attributes.as_lstm_cell().cloned(),
                 outputs: outputs.to_vec(),
             }),

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -1008,12 +1008,8 @@ pub fn infer_reduce_shape(
     input_shape: &[u32],
     options: &ReduceOptions,
 ) -> Result<Vec<u32>, GraphError> {
-    // If axes is empty, reduce all dimensions
-    let axes_to_reduce: Vec<u32> = if options.axes.is_empty() {
-        (0..input_shape.len() as u32).collect()
-    } else {
-        options.axes.clone()
-    };
+    // `axes` lists dimensions to reduce; an empty list reduces over no dimensions.
+    let axes_to_reduce = options.axes.clone();
 
     // Validate that all axes are within bounds
     for &axis in &axes_to_reduce {
@@ -1062,11 +1058,7 @@ pub fn infer_reduce_shape_dimensions(
     input_shape: &[Dimension],
     options: &ReduceOptions,
 ) -> Result<Vec<Dimension>, GraphError> {
-    let axes_to_reduce: Vec<u32> = if options.axes.is_empty() {
-        (0..input_shape.len() as u32).collect()
-    } else {
-        options.axes.clone()
-    };
+    let axes_to_reduce = options.axes.clone();
 
     for &axis in &axes_to_reduce {
         if axis >= input_shape.len() as u32 {
@@ -1483,13 +1475,15 @@ pub fn infer_concat_shape_dimensions(
     Ok(output_shape)
 }
 
-/// Infer output shape for slice operation
+/// Infer output shape for slice operation.
 ///
-/// Extracts a contiguous sub-tensor from the input.
+/// WebNN `sizes` are window lengths in input index space along each axis; with `strides`
+/// greater than 1 the output extent is `ceil(sizes[i] / strides[i])`.
 pub fn infer_slice_shape(
     input_shape: &[u32],
     starts: &[u32],
     sizes: &[u32],
+    strides: Option<&[u32]>,
 ) -> Result<Vec<u32>, GraphError> {
     let rank = input_shape.len();
 
@@ -1516,9 +1510,34 @@ pub fn infer_slice_shape(
         });
     }
 
+    let strides: Vec<u32> = match strides {
+        None | Some([]) => vec![1; rank],
+        Some(s) => {
+            if s.len() != rank {
+                return Err(GraphError::ShapeInferenceFailed {
+                    reason: format!(
+                        "Slice strides length {} must match input rank {}, input shape: {:?}",
+                        s.len(),
+                        rank,
+                        input_shape
+                    ),
+                });
+            }
+            s.to_vec()
+        }
+    };
+
     // Validate starts and sizes are within bounds
+    let mut output_shape = Vec::with_capacity(rank);
     for (dim_idx, (&start, &size)) in starts.iter().zip(sizes.iter()).enumerate() {
         let input_dim = input_shape[dim_idx];
+        let stride = strides[dim_idx];
+
+        if stride == 0 {
+            return Err(GraphError::ShapeInferenceFailed {
+                reason: format!("Slice stride for dimension {dim_idx} must be > 0"),
+            });
+        }
 
         if start >= input_dim {
             return Err(GraphError::ShapeInferenceFailed {
@@ -1541,10 +1560,16 @@ pub fn infer_slice_shape(
                 ),
             });
         }
+
+        let out_dim = if stride == 1 {
+            size
+        } else {
+            (size + stride - 1) / stride
+        };
+        output_shape.push(out_dim);
     }
 
-    // Output shape is simply the sizes
-    Ok(sizes.to_vec())
+    Ok(output_shape)
 }
 
 /// Infer output shape for expand operation
@@ -2101,6 +2126,67 @@ pub fn infer_scatter_elements_shape(
     Ok(input_shape.to_vec())
 }
 
+/// Infer output shape for resample2d.
+///
+/// Resizes the two spatial axes given by `axes` (default last two). `sizes` takes precedence
+/// over `scales` when both are set (WebNN semantics).
+pub fn infer_resample2d_shape(
+    input_shape: &[Dimension],
+    axes: [usize; 2],
+    sizes: Option<&[u32]>,
+    scales: &[f32],
+) -> Result<Vec<Dimension>, GraphError> {
+    let rank = input_shape.len();
+    if rank == 0 {
+        return Ok(input_shape.to_vec());
+    }
+    if axes[0] >= rank || axes[1] >= rank {
+        return Err(GraphError::ShapeInferenceFailed {
+            reason: format!("Resample2d axes {:?} out of bounds for rank {}", axes, rank),
+        });
+    }
+
+    let mut output = input_shape.to_vec();
+
+    if let Some(sizes) = sizes {
+        if sizes.len() != 2 {
+            return Err(GraphError::ShapeInferenceFailed {
+                reason: format!("Resample2d sizes must have length 2, got {:?}", sizes),
+            });
+        }
+        output[axes[0]] = Dimension::Static(sizes[0]);
+        output[axes[1]] = Dimension::Static(sizes[1]);
+        return Ok(output);
+    }
+
+    let scale_pair: [f32; 2] = if scales.len() >= 2 {
+        [scales[0], scales[1]]
+    } else {
+        [1.0, 1.0]
+    };
+
+    for (axis_idx, scale) in scale_pair.iter().enumerate() {
+        let axis = axes[axis_idx];
+        output[axis] = match &input_shape[axis] {
+            Dimension::Static(in_dim) => {
+                Dimension::Static(((*in_dim).max(1) as f32 * scale).round().max(1.0) as u32)
+            }
+            Dimension::Dynamic(d) => {
+                if (*scale - 1.0).abs() < f32::EPSILON {
+                    Dimension::Dynamic(d.clone())
+                } else {
+                    Dimension::Dynamic(DynamicDimension {
+                        name: d.name.clone(),
+                        max_size: ((d.max_size.max(1) as f32) * scale).round().max(1.0) as u32,
+                    })
+                }
+            }
+        };
+    }
+
+    Ok(output)
+}
+
 /// Infer output shape for scatterND operation
 /// Output shape equals input shape
 pub fn infer_scatter_nd_shape(
@@ -2227,44 +2313,10 @@ pub fn infer_leakyrelu_shape(input_shape: &[u32]) -> Result<Vec<u32>, GraphError
     Ok(input_shape.to_vec())
 }
 
-/// Infer output shape for prelu operation
-/// prelu has input and slope tensors; slope must be unidirectionally broadcastable to input
+/// Infer output shape for prelu operation.
+/// Output shape is the NumPy broadcast of `input` and `slope`.
 pub fn infer_prelu_shape(input_shape: &[u32], slope_shape: &[u32]) -> Result<Vec<u32>, GraphError> {
-    // Validate that slope is unidirectionally broadcastable to input
-    // This means slope can be broadcast to input, but not vice versa
-
-    let input_rank = input_shape.len();
-    let slope_rank = slope_shape.len();
-
-    // Slope must have at most the same rank as input
-    if slope_rank > input_rank {
-        return Err(GraphError::ShapeInferenceFailed {
-            reason: format!(
-                "PReLU slope rank {} cannot exceed input rank {}",
-                slope_rank, input_rank
-            ),
-        });
-    }
-
-    // Check if slope can be broadcast to input
-    // Prepend 1s to slope to match input rank
-    let mut extended_slope = vec![1u32; input_rank - slope_rank];
-    extended_slope.extend_from_slice(slope_shape);
-
-    // Check each dimension
-    for (i, (&input_dim, &slope_dim)) in input_shape.iter().zip(extended_slope.iter()).enumerate() {
-        if slope_dim != 1 && slope_dim != input_dim {
-            return Err(GraphError::ShapeInferenceFailed {
-                reason: format!(
-                    "PReLU slope dimension {} (value {}) must be 1 or match input dimension {} (value {})",
-                    i, slope_dim, i, input_dim
-                ),
-            });
-        }
-    }
-
-    // Output shape equals input shape
-    Ok(input_shape.to_vec())
+    broadcast_shapes(input_shape, slope_shape)
 }
 
 /// Infer output shape for clamp operation
@@ -3025,7 +3077,7 @@ mod tests {
     #[test]
     fn test_reduce_all_axes() {
         let options = ReduceOptions {
-            axes: vec![],
+            axes: vec![0, 1, 2],
             keep_dimensions: false,
         };
         // [2, 3, 4] reduce all axes -> [] (scalar)
@@ -3036,12 +3088,23 @@ mod tests {
     #[test]
     fn test_reduce_all_axes_keep_dims() {
         let options = ReduceOptions {
-            axes: vec![],
+            axes: vec![0, 1, 2],
             keep_dimensions: true,
         };
         // [2, 3, 4] reduce all axes keep_dims -> [1, 1, 1]
         let output = infer_reduce_shape(&[2, 3, 4], &options).unwrap();
         assert_eq!(output, vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn test_reduce_empty_axes() {
+        let options = ReduceOptions {
+            axes: vec![],
+            keep_dimensions: false,
+        };
+        // Explicit empty axes: reduce over no dimensions -> same shape as input
+        let output = infer_reduce_shape(&[2, 3, 4], &options).unwrap();
+        assert_eq!(output, vec![2, 3, 4]);
     }
 
     #[test]
@@ -3219,34 +3282,40 @@ mod tests {
     #[test]
     fn test_slice_basic() {
         // 1D slice
-        assert_eq!(infer_slice_shape(&[24], &[12], &[12]).unwrap(), vec![12]);
+        assert_eq!(infer_slice_shape(&[24], &[12], &[12], None).unwrap(), vec![12]);
 
         // 2D slice
         assert_eq!(
-            infer_slice_shape(&[4, 6], &[2, 2], &[2, 4]).unwrap(),
+            infer_slice_shape(&[4, 6], &[2, 2], &[2, 4], None).unwrap(),
             vec![2, 4]
         );
 
         // 3D slice
         assert_eq!(
-            infer_slice_shape(&[4, 3, 2], &[1, 1, 1], &[3, 2, 1]).unwrap(),
+            infer_slice_shape(&[4, 3, 2], &[1, 1, 1], &[3, 2, 1], None).unwrap(),
             vec![3, 2, 1]
+        );
+
+        // 2D slice with strides
+        assert_eq!(
+            infer_slice_shape(&[2, 12], &[0, 2], &[2, 10], Some(&[1, 4])).unwrap(),
+            vec![2, 3]
         );
     }
 
     #[test]
     fn test_slice_invalid() {
         // starts length mismatch
-        assert!(infer_slice_shape(&[4, 6], &[2], &[2, 4]).is_err());
+        assert!(infer_slice_shape(&[4, 6], &[2], &[2, 4], None).is_err());
 
         // sizes length mismatch
-        assert!(infer_slice_shape(&[4, 6], &[2, 2], &[2]).is_err());
+        assert!(infer_slice_shape(&[4, 6], &[2, 2], &[2], None).is_err());
 
         // start out of bounds
-        assert!(infer_slice_shape(&[4, 6], &[5, 2], &[1, 4]).is_err());
+        assert!(infer_slice_shape(&[4, 6], &[5, 2], &[1, 4], None).is_err());
 
         // end out of bounds
-        assert!(infer_slice_shape(&[4, 6], &[2, 2], &[3, 4]).is_err());
+        assert!(infer_slice_shape(&[4, 6], &[2, 2], &[3, 4], None).is_err());
     }
 
     // Expand tests
@@ -3621,6 +3690,40 @@ mod tests {
         assert!(infer_scatter_elements_shape(&[3, 4], &[2, 4], &[2, 4], 2).is_err());
     }
 
+    #[test]
+    fn test_resample2d_shape() {
+        let input = vec![
+            Dimension::Static(1),
+            Dimension::Static(3),
+            Dimension::Static(224),
+            Dimension::Static(224),
+        ];
+        let out = infer_resample2d_shape(&input, [2, 3], Some(&[112, 112]), &[]).unwrap();
+        assert_eq!(
+            out,
+            vec![
+                Dimension::Static(1),
+                Dimension::Static(3),
+                Dimension::Static(112),
+                Dimension::Static(112),
+            ]
+        );
+
+        let out = infer_resample2d_shape(&input, [2, 3], None, &[0.5, 2.0]).unwrap();
+        assert_eq!(
+            out,
+            vec![
+                Dimension::Static(1),
+                Dimension::Static(3),
+                Dimension::Static(112),
+                Dimension::Static(448),
+            ]
+        );
+
+        let out = infer_resample2d_shape(&input, [2, 3], None, &[]).unwrap();
+        assert_eq!(out, input);
+    }
+
     // ScatterND tests
     #[test]
     fn test_scatter_nd_basic() {
@@ -3847,9 +3950,8 @@ mod tests {
 
     #[test]
     fn test_prelu_invalid_rank() {
-        // Slope rank exceeds input rank
         assert!(infer_prelu_shape(&[2, 3], &[1, 2, 3, 4]).is_err());
-        assert!(infer_prelu_shape(&[5], &[2, 5]).is_err());
+        assert_eq!(infer_prelu_shape(&[5], &[2, 5]).unwrap(), vec![2, 5]);
     }
 
     #[test]

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -3282,7 +3282,10 @@ mod tests {
     #[test]
     fn test_slice_basic() {
         // 1D slice
-        assert_eq!(infer_slice_shape(&[24], &[12], &[12], None).unwrap(), vec![12]);
+        assert_eq!(
+            infer_slice_shape(&[24], &[12], &[12], None).unwrap(),
+            vec![12]
+        );
 
         // 2D slice
         assert_eq!(

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -739,21 +739,20 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                         _ => None,
                     };
                     let (axes_raw, keep_dimensions) = opts
-                        .map(|o| {
-                            (
-                                o.axes.as_ref().cloned().unwrap_or_default(),
-                                o.keep_dimensions,
-                            )
-                        })
-                        .unwrap_or((Vec::new(), false));
+                        .map(|o| (o.axes.clone(), o.keep_dimensions))
+                        .unwrap_or((None, false));
 
                     if let Some(input_shape) = input_shapes.first() {
                         let rank = input_shape.len() as u32;
-                        if axes_raw.iter().any(|&axis| axis >= rank) {
+                        let axes = match &axes_raw {
+                            None => (0..rank).collect(),
+                            Some(v) => v.clone(),
+                        };
+                        if axes.iter().any(|&axis| axis >= rank) {
                             None
                         } else {
                             let options = ReduceOptions {
-                                axes: axes_raw,
+                                axes,
                                 keep_dimensions,
                             };
                             infer_reduce_shape_dimensions(input_shape, &options).ok()
@@ -844,20 +843,38 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                 "slice" => {
                     if let Some(input_shape) = input_shapes.first() {
                         match &op {
-                            Operation::Slice { starts, sizes, .. } => {
+                            Operation::Slice {
+                                starts,
+                                sizes,
+                                options,
+                                ..
+                            } => {
                                 if starts.is_empty()
                                     || sizes.is_empty()
                                     || starts.len() != sizes.len()
                                 {
                                     None
                                 } else {
-                                    let mut output = input_shape.clone();
-                                    for (i, sz) in sizes.iter().enumerate() {
-                                        if i < output.len() {
-                                            output[i] = Dimension::Static(sz.static_or_max());
-                                        }
-                                    }
-                                    Some(output)
+                                    let sizes_u32: Vec<u32> =
+                                        sizes.iter().map(|d| d.static_or_max()).collect();
+                                    let strides = options.as_ref().map(|o| o.strides.as_slice());
+                                    let input_dims: Vec<u32> = input_shape
+                                        .iter()
+                                        .map(crate::graph::get_static_or_max_size)
+                                        .collect();
+                                    infer_slice_shape(
+                                        &input_dims,
+                                        starts,
+                                        &sizes_u32,
+                                        strides,
+                                    )
+                                    .ok()
+                                    .map(|shape| {
+                                        shape
+                                            .into_iter()
+                                            .map(Dimension::Static)
+                                            .collect::<Vec<_>>()
+                                    })
                                 }
                             }
                             _ => None,


### PR DESCRIPTION
## Summary

Fix MLGraphBuilder shape inference for quantize, slice, reduce, and RNN ops.

Align builder and webnn_json inference with WebNN semantics: quantize/dequantize output dtypes, slice strides, reduce axes (omitted vs empty), gatherElements output shape, resample2d/scatterElements, and GRU/LSTM multi-output shapes. Update ONNX LSTM conversion for WPT output ordering and cell activation.

## Validation

- [ ] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

