### PR TITLE
Fix clippy::type_complexity in src/graph.rs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -246,17 +246,17 @@ impl GraphInfo {
 
         Ok(())
     }
+}
 
+/// Named input/output operands for `MLGraph` dispatch.
+pub type IoBindingMaps = (
+    HashMap<String, OperandDescriptor>,
+    HashMap<String, OperandDescriptor>,
+);
+
+impl GraphInfo {
     /// Named input/output operands for `MLGraph` dispatch, after list consistency checks.
-    pub fn io_binding_maps(
-        &self,
-    ) -> Result<
-        (
-            HashMap<String, OperandDescriptor>,
-            HashMap<String, OperandDescriptor>,
-        ),
-        GraphError,
-    > {
+    pub fn io_binding_maps(&self) -> Result<IoBindingMaps, GraphError> {
         self.validate_io_operand_lists()?;
 
         let mut inputs = HashMap::new();


### PR DESCRIPTION
## Summary
- [x] Describe the user-visible and code-level changes.

Add IoBindingMaps type alias for the pair of HashMap<String, OperandDescriptor> return type.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

