### PR TITLE
Make TRTX backend `Send`+`Sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "trtx"
-version = "0.7.0+rtx1.5"
+version = "0.7.1+rtx1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397ddc578d48d9d4741a9fa3ba7707489552211cd15e411f378d3fc93cd21b6f"
+checksum = "d3d86c6b23c5aec1d6cec63f821d6a52f75ad2dfc1f791ac9110bb3d053258a2"
 dependencies = [
  "autocxx",
  "cudarc 0.11.9",
@@ -2526,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "trtx-sys"
-version = "0.7.0+rtx1.5"
+version = "0.7.1+rtx1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d5bd851f47488f3f17b2b793a8a9f3a8dab462a7962347f204cae58f68a86e"
+checksum = "45b6611ef5e42f89d03a7cfaf8aa8a720e274f12dbc8ae7b0ac9f409d969f93e"
 dependencies = [
  "autocxx",
  "autocxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ort = { version = "=2.0.0-rc.12", optional = true, features = [
     "api-24",
 ] }
 half = "2.4"
-trtx = { version = "0.7.0", optional = true }
+trtx = { version = "0.7.1", optional = true }
 regex = "1.11"
 webnn-graph = { git = "https://github.com/rustnn/webnn-graph", branch = "main" }
 webnn-onnx-utils = { git = "https://github.com/rustnn/webnn-onnx-utils", branch = "main" }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -177,12 +177,6 @@ pub(crate) struct TrtxContext<'context> {
     builder: Arc<Mutex<trtx::Builder<'context>>>,
 }
 
-// SAFETY: TensorRT objects are internally thread-safe. Access is serialized
-// via Arc<Mutex<>> wrappers, and CUDA operations on different streams are
-// independent per CUDA context.
-unsafe impl Send for TrtxContext<'_> {}
-unsafe impl Sync for TrtxContext<'_> {}
-
 impl std::fmt::Debug for TrtxContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TrtxContext")
@@ -234,10 +228,6 @@ pub(crate) struct TrtxBuilder<'builder> {
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
 }
-
-// SAFETY: TensorRT builder access is serialized via Arc<Mutex<>> on shared
-// components. Network definition and tensor handles are owned and not shared.
-unsafe impl Send for TrtxBuilder<'_> {}
 
 impl std::fmt::Debug for TrtxBuilder<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -12,7 +12,6 @@ use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use trtx::CudaEngine;
 use trtx::ExecutionContext;
@@ -173,10 +172,16 @@ pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
     tensors: Vec<TrtxTensor>,
     events: Vec<CudaEvent>,
-    runtime: Rc<Mutex<trtx::Runtime<'context>>>,
-    config: Rc<Mutex<trtx::BuilderConfig<'context>>>, // needs to be destroyed before builder
-    builder: Rc<Mutex<trtx::Builder<'context>>>,
+    runtime: Arc<Mutex<trtx::Runtime<'context>>>,
+    config: Arc<Mutex<trtx::BuilderConfig<'context>>>, // needs to be destroyed before builder
+    builder: Arc<Mutex<trtx::Builder<'context>>>,
 }
+
+// SAFETY: TensorRT objects are internally thread-safe. Access is serialized
+// via Arc<Mutex<>> wrappers, and CUDA operations on different streams are
+// independent per CUDA context.
+unsafe impl Send for TrtxContext<'_> {}
+unsafe impl Sync for TrtxContext<'_> {}
 
 impl std::fmt::Debug for TrtxContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -203,15 +208,15 @@ impl<'context> TrtxContext<'context> {
         // (mostly scalars)
         config.set_flag(trtx::trtx_sys::BuilderFlag::kREFIT_INDIVIDUAL);
         config.set_flag(trtx::trtx_sys::BuilderFlag::kSTRIP_PLAN);
-        let config = Rc::new(config.into());
-        let runtime = Rc::new(trtx::Runtime::new(&LOGGER)?.into());
+        let config = Arc::new(config.into());
+        let runtime = Arc::new(trtx::Runtime::new(&LOGGER)?.into());
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
             tensors: vec![],
             events: vec![],
             runtime,
-            builder: Rc::new(builder.into()),
+            builder: Arc::new(builder.into()),
             config,
         })
     }
@@ -220,15 +225,20 @@ impl<'context> TrtxContext<'context> {
 #[allow(dead_code)]
 pub(crate) struct TrtxBuilder<'builder> {
     network: Option<trtx::NetworkDefinition<'builder>>,
-    builder: Rc<Mutex<trtx::Builder<'builder>>>,
-    config: Rc<Mutex<trtx::BuilderConfig<'builder>>>,
+    builder: Arc<Mutex<trtx::Builder<'builder>>>,
+    config: Arc<Mutex<trtx::BuilderConfig<'builder>>>,
     cuda_context: Arc<CudaContext>,
-    runtime: Rc<Mutex<trtx::Runtime<'builder>>>,
+    runtime: Arc<Mutex<trtx::Runtime<'builder>>>,
     operands: HashMap<String, MLOperand>,
     tensors: Vec<Tensor<'builder>>,
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
 }
+
+// SAFETY: TensorRT builder access is serialized via Arc<Mutex<>> on shared
+// components. Network definition and tensor handles are owned and not shared.
+unsafe impl Send for TrtxBuilder<'_> {}
+
 impl std::fmt::Debug for TrtxBuilder<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TrtxBuilder").finish()
@@ -399,9 +409,9 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         //self.networks.push(network);
         Ok(Box::new(TrtxBuilder {
             network,
-            builder: Rc::clone(&self.builder),
-            config: Rc::clone(&self.config),
-            runtime: Rc::clone(&self.runtime),
+            builder: Arc::clone(&self.builder),
+            config: Arc::clone(&self.config),
+            runtime: Arc::clone(&self.runtime),
             cuda_context: Arc::clone(&self.cuda_ctx),
             operands: HashMap::new(),
             tensors: vec![],


### PR DESCRIPTION
## Summary
- [x] Describe the user-visible and code-level changes.

 Prepares the TRTX backend for future Send+Sync bounds on MLBackendContext/MLBackendBuilder traits.
TrtxContext/TrtxBuilder: Rc->Arc + unsafe impl Send/Sync

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

