### PR TITLE
Add INT4/UINT4 support

### DIFF
--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -16,6 +16,7 @@ use crate::backend_selection::BackendDevice;
 use crate::converters::{GraphConverter, OnnxConverter};
 use crate::error::Error;
 use crate::executors::onnx::ensure_ort_initialized;
+use crate::graph::{pack_int4, pack_uint4_from_i32, unpack_int4, unpack_uint4};
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
 };
@@ -32,7 +33,6 @@ impl<T> ToDispatchResult<T> for ort::Result<T> {
 }
 
 fn tensor_byte_len(descriptor: &MLTensorDescriptor) -> crate::error::Result<usize> {
-    let bits = descriptor.data_type().rustnn_element_size_bits();
     let elements: usize = descriptor
         .shape()
         .iter()
@@ -40,7 +40,7 @@ fn tensor_byte_len(descriptor: &MLTensorDescriptor) -> crate::error::Result<usiz
         .ok_or_else(|| Error::GraphDispatchError {
             source: "tensor element count overflow".into(),
         })? as usize;
-    Ok(bits * elements / 8)
+    Ok(descriptor.data_type().rustnn_storage_byte_length(elements))
 }
 
 fn ort_tensor_element_size(ty: TensorElementType) -> Option<usize> {
@@ -130,7 +130,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for OrtBuilder<'co
 
 fn session_input_from_host(
     input_info: &Outlet,
-    shape: &[u64],
+    descriptor: &MLTensorDescriptor,
     bytes: &[u8],
 ) -> crate::error::Result<SessionInputValue<'static>> {
     let ValueType::Tensor { ty, .. } = input_info.dtype() else {
@@ -138,6 +138,7 @@ fn session_input_from_host(
             source: format!("input '{}' is not a tensor", input_info.name()).into(),
         });
     };
+    let shape = descriptor.shape();
     let shape_usize: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
     let Some(elem_sz) = ort_tensor_element_size(*ty) else {
         return Err(Error::GraphDispatchError {
@@ -189,8 +190,30 @@ fn session_input_from_host(
         return Ok(SessionInputValue::from(dyn_val));
     }
 
+    let shape_i64: Vec<i64> = shape.iter().map(|&d| d as i64).collect();
     let expected = elements.saturating_mul(elem_sz);
+    let host_packed = descriptor.data_type().rustnn_storage_byte_length(elements);
     if bytes.len() != expected {
+        if *ty == TensorElementType::Int32
+            && descriptor.data_type() == crate::operator_enums::MLOperandDataType::Int4
+            && bytes.len() == host_packed
+        {
+            let int32_data = unpack_int4(bytes, elements);
+            let dyn_val = Value::from_array((shape_i64.as_slice(), int32_data))
+                .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+                .into_dyn();
+            return Ok(SessionInputValue::from(dyn_val));
+        }
+        if *ty == TensorElementType::Uint8
+            && descriptor.data_type() == crate::operator_enums::MLOperandDataType::Uint4
+            && bytes.len() == host_packed
+        {
+            let uint8_data = unpack_uint4(bytes, elements);
+            let dyn_val = Value::from_array((shape_i64.as_slice(), uint8_data))
+                .map_err(|e| Error::GraphDispatchError { source: e.into() })?
+                .into_dyn();
+            return Ok(SessionInputValue::from(dyn_val));
+        }
         return Err(Error::GraphDispatchError {
             source: format!(
                 "input '{}': byte length mismatch (expected {}, got {})",
@@ -202,7 +225,6 @@ fn session_input_from_host(
         });
     }
 
-    let shape_i64: Vec<i64> = shape.iter().map(|&d| d as i64).collect();
     let dyn_val: DynValue = match ty {
         TensorElementType::Float32 => Value::from_array((
             shape_i64.as_slice(),
@@ -449,6 +471,66 @@ fn copy_dyn_value_to_buffer(
                 });
             }
             dst.copy_from_slice(sl);
+        }
+        crate::operator_enums::MLOperandDataType::Int4 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<i32>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            if sl.len() != descriptor.shape().iter().product::<u64>() as usize {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "output '{name}': ORT tensor {} elements, descriptor expects {}",
+                        sl.len(),
+                        descriptor.shape().iter().product::<u64>()
+                    )
+                    .into(),
+                });
+            }
+            let packed = pack_int4(sl);
+            if packed.len() != expected {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "output '{name}': packed int4 {} bytes, descriptor expects {}",
+                        packed.len(),
+                        expected
+                    )
+                    .into(),
+                });
+            }
+            dst.copy_from_slice(&packed);
+        }
+        crate::operator_enums::MLOperandDataType::Uint4 => {
+            let (_, sl) =
+                value
+                    .try_extract_tensor::<i32>()
+                    .map_err(|e| Error::GraphDispatchError {
+                        source: format!("output '{name}': {e}").into(),
+                    })?;
+            if sl.len() != descriptor.shape().iter().product::<u64>() as usize {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "output '{name}': ORT tensor {} elements, descriptor expects {}",
+                        sl.len(),
+                        descriptor.shape().iter().product::<u64>()
+                    )
+                    .into(),
+                });
+            }
+            let packed = pack_uint4_from_i32(sl);
+            if packed.len() != expected {
+                return Err(Error::GraphDispatchError {
+                    source: format!(
+                        "output '{name}': packed uint4 {} bytes, descriptor expects {}",
+                        packed.len(),
+                        expected
+                    )
+                    .into(),
+                });
+            }
+            dst.copy_from_slice(&packed);
         }
     }
     Ok(())
@@ -702,7 +784,7 @@ impl<'context> MLBackendContext<'context> for OrtContext {
                 logical,
                 full.len()
             );
-            let v = session_input_from_host(input_info, tensor.shape(), bytes)?;
+            let v = session_input_from_host(input_info, tensor.descriptor(), bytes)?;
             input_session_values.push(v);
         }
 
@@ -761,19 +843,16 @@ impl<'context> MLBackendContext<'context> for OrtContext {
         tensor: &mut MLTensor,
         max_shape: &[u64],
     ) -> crate::error::Result<()> {
-        let bits = tensor.data_type().rustnn_element_size_bits();
-        let elements: u64 = max_shape
-            .iter()
-            .try_fold(1u64, |acc, &d| acc.checked_mul(d))
-            .ok_or_else(|| Error::GraphDispatchError {
-                source: "rustnn_set_tensor_capacity: shape element count overflow".into(),
-            })?;
-        let new_bytes = (elements as usize)
-            .checked_mul(bits)
-            .and_then(|b| b.checked_div(8))
-            .ok_or_else(|| Error::GraphDispatchError {
-                source: "rustnn_set_tensor_capacity: byte length overflow".into(),
-            })?;
+        let new_bytes = tensor.data_type().rustnn_storage_byte_length(
+            max_shape
+                .iter()
+                .try_fold(1usize, |acc, &d| {
+                    usize::try_from(d).ok().and_then(|x| acc.checked_mul(x))
+                })
+                .ok_or_else(|| Error::GraphDispatchError {
+                    source: "rustnn_set_tensor_capacity: shape element count overflow".into(),
+                })?,
+        );
         let alloc = new_bytes.max(1);
         self.tensors[tensor.id].memory = vec![0u8; alloc];
         debug!(

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -2251,6 +2251,13 @@ impl CoremlMlProgramConverter {
                     MLOperandDataType::Uint8 => "int8",
                     MLOperandDataType::Int64 => "int64",
                     MLOperandDataType::Uint64 => "uint64",
+                    MLOperandDataType::Int4 | MLOperandDataType::Uint4 => {
+                        return Err(GraphError::ConversionFailed {
+                            format: "coreml_mlprogram".to_string(),
+                            reason: "int4/uint4 cast targets are not supported in CoreML conversion"
+                                .to_string(),
+                        });
+                    }
                 };
                 inputs.insert(
                     "dtype".to_string(),

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -19,7 +19,9 @@
 use crate::converters::{ConvertedGraph, ONNX_EXTERNAL_WEIGHTS_FILENAME, operand_name};
 use crate::debug_print;
 use crate::error::GraphError;
-use crate::graph::{DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size};
+use crate::graph::{
+    DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size, unpack_int4, unpack_uint4,
+};
 use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
 use crate::operators::Operation;
@@ -1128,6 +1130,61 @@ impl OnnxConverter {
         TensorData::scalar(utils_dtype.clone(), value).to_tensor_proto(name, utils_dtype, vec![])
     }
 
+    /// Scalar min/max tensor for ONNX Clip (WebNN clamp). Integer bounds must not go through f32:
+    /// values like 2147483645 and 4294967290 are not exactly representable as f32.
+    fn clamp_bound_scalar_tensor(name: String, input_dtype: DataType, value: f64) -> TensorProto {
+        match input_dtype {
+            DataType::Float32 => TensorProto {
+                name,
+                data_type: ProtoDataType::Float as i32,
+                dims: vec![],
+                raw_data: (value as f32).to_le_bytes().to_vec(),
+                ..Default::default()
+            },
+            DataType::Float16 => {
+                let bits = half::f16::from_f32(value as f32).to_bits();
+                TensorProto {
+                    name,
+                    data_type: ProtoDataType::Float16 as i32,
+                    dims: vec![],
+                    raw_data: bits.to_le_bytes().to_vec(),
+                    ..Default::default()
+                }
+            }
+            DataType::Int32 => TensorProto {
+                name,
+                data_type: ProtoDataType::Int32 as i32,
+                dims: vec![],
+                int32_data: vec![value as i32],
+                ..Default::default()
+            },
+            DataType::Uint32 => TensorProto {
+                name,
+                data_type: ProtoDataType::Uint32 as i32,
+                dims: vec![],
+                raw_data: (value as u32).to_le_bytes().to_vec(),
+                ..Default::default()
+            },
+            DataType::Int64 => TensorProto {
+                name,
+                data_type: ProtoDataType::Int64 as i32,
+                dims: vec![],
+                int64_data: vec![value as i64],
+                ..Default::default()
+            },
+            DataType::Uint64 => TensorProto {
+                name,
+                data_type: ProtoDataType::Uint64 as i32,
+                dims: vec![],
+                uint64_data: vec![value as u64],
+                ..Default::default()
+            },
+            other => {
+                Self::create_scalar_initializer(name, Self::data_type_code(other), value as f32)
+            }
+        }
+    }
+
     /// Create a vector initializer with proper data type handling
     fn create_vector_initializer(
         name: String,
@@ -1891,6 +1948,8 @@ impl OnnxConverter {
                 MLOperandDataType::Int8 => ProtoDataType::Int8 as i64,
                 MLOperandDataType::Uint8 => ProtoDataType::Uint8 as i64,
                 MLOperandDataType::Int64 => ProtoDataType::Int64 as i64,
+                MLOperandDataType::Int4 => Self::data_type_code(DataType::Int4) as i64,
+                MLOperandDataType::Uint4 => Self::data_type_code(DataType::Uint4) as i64,
                 _ => ProtoDataType::Undefined as i64,
             };
             attributes.push(AttributeProto {
@@ -2793,15 +2852,16 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 Self::invalid_operand("initializer lookup", *id, None)
             })?;
 
+            let element_count: usize = operand
+                .descriptor
+                .static_or_max_shape()
+                .iter()
+                .map(|&d| d as usize)
+                .product();
+
             // Handle zero-length constants by creating zero-filled tensors
             // This is a defensive measure for malformed models where constants have no data
             let tensor_proto = if data.data.is_empty() {
-                let element_count: usize = operand
-                    .descriptor
-                    .static_or_max_shape()
-                    .iter()
-                    .map(|&d| d as usize)
-                    .product();
                 let dtype = Self::data_type_code(operand.descriptor.data_type);
 
                 // For Int64, use int64_data field; for other types, use raw_data with zeros
@@ -2869,15 +2929,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         ..Default::default()
                     },
                     _ => {
-                        // For other types, create zero-filled raw_data
-                        let bytes_per_element = match operand.descriptor.data_type {
-                            DataType::Float16 => 2,
-                            DataType::Int8 | DataType::Uint8 => 1,
-                            DataType::Uint32 => 4,
-                            DataType::Uint64 => 8,
-                            _ => 4, // Default to 4 bytes
-                        };
-                        let zero_data = vec![0u8; element_count * bytes_per_element];
+                        let zero_len = operand.descriptor.byte_length().unwrap_or(0);
+                        let zero_data = vec![0u8; zero_len];
                         TensorProto {
                             name: operand_name(graph, *id),
                             data_type: dtype as i32,
@@ -2894,20 +2947,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 }
             } else {
                 // Normal case: use provided data
-                // Int4: JS sends 1 byte per element. data_type_code maps to Int32 (4 bytes/element).
-                //    Expand to int32_data to match ORT byte expectations and avoid raw_data mismatch.
-                // Uint4: JS sends 1 byte per element. data_type_code maps to Uint8 (1 byte/element).
-                //    raw_data byte count matches directly.
+                // Packed int4/uint4 host constants are expanded for ORT (int32 / uint8 tensors).
                 match operand.descriptor.data_type {
                     DataType::Int4 => {
-                        let int32_data: Vec<i32> = data
-                            .data
-                            .iter()
-                            .map(|&b| {
-                                let nibble = (b & 0x0F) as i32;
-                                if nibble >= 8 { nibble - 16 } else { nibble }
-                            })
-                            .collect();
+                        let int32_data = unpack_int4(&data.data, element_count);
                         TensorProto {
                             name: operand_name(graph, *id),
                             data_type: ProtoDataType::Int32 as i32,
@@ -2930,7 +2973,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             .iter()
                             .map(|d| *d as i64)
                             .collect(),
-                        raw_data: data.data.clone(),
+                        raw_data: unpack_uint4(&data.data, element_count),
                         ..Default::default()
                     },
                     _ => TensorProto {
@@ -7488,7 +7531,6 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     )
                 })?;
                 let input_dtype = input_operand.descriptor.data_type;
-                let onnx_dtype = Self::data_type_code(input_dtype);
 
                 let (min_value_raw, max_value_raw) = match &op {
                     Operation::Clamp { options, .. } => options
@@ -7519,43 +7561,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 if let Some(min_value) = min_value {
                     let min_name = format!("{}_min", op_name);
                     inputs.push(min_name.clone());
-                    let min_tensor = match input_dtype {
-                        DataType::Float32 => TensorProto {
-                            name: min_name,
-                            data_type: ProtoDataType::Float as i32,
-                            dims: vec![],
-                            raw_data: (min_value as f32).to_le_bytes().to_vec(),
-                            ..Default::default()
-                        },
-                        DataType::Float16 => {
-                            let bits = half::f16::from_f32(min_value as f32).to_bits();
-                            TensorProto {
-                                name: min_name,
-                                data_type: ProtoDataType::Float16 as i32,
-                                dims: vec![],
-                                raw_data: bits.to_le_bytes().to_vec(),
-                                ..Default::default()
-                            }
-                        }
-                        DataType::Int64 => TensorProto {
-                            name: min_name,
-                            data_type: ProtoDataType::Int64 as i32,
-                            dims: vec![],
-                            int64_data: vec![min_value as i64],
-                            ..Default::default()
-                        },
-                        DataType::Uint64 => TensorProto {
-                            name: min_name,
-                            data_type: ProtoDataType::Uint64 as i32,
-                            dims: vec![],
-                            uint64_data: vec![min_value as u64],
-                            ..Default::default()
-                        },
-                        _ => {
-                            Self::create_scalar_initializer(min_name, onnx_dtype, min_value as f32)
-                        }
-                    };
-                    initializers.push(min_tensor);
+                    initializers.push(Self::clamp_bound_scalar_tensor(
+                        min_name,
+                        input_dtype,
+                        min_value,
+                    ));
                 }
 
                 if max_value.is_some() && min_value.is_none() {
@@ -7565,43 +7575,11 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 if let Some(max_value) = max_value {
                     let max_name = format!("{}_max", op_name);
                     inputs.push(max_name.clone());
-                    let max_tensor = match input_dtype {
-                        DataType::Float32 => TensorProto {
-                            name: max_name,
-                            data_type: ProtoDataType::Float as i32,
-                            dims: vec![],
-                            raw_data: (max_value as f32).to_le_bytes().to_vec(),
-                            ..Default::default()
-                        },
-                        DataType::Float16 => {
-                            let bits = half::f16::from_f32(max_value as f32).to_bits();
-                            TensorProto {
-                                name: max_name,
-                                data_type: ProtoDataType::Float16 as i32,
-                                dims: vec![],
-                                raw_data: bits.to_le_bytes().to_vec(),
-                                ..Default::default()
-                            }
-                        }
-                        DataType::Int64 => TensorProto {
-                            name: max_name,
-                            data_type: ProtoDataType::Int64 as i32,
-                            dims: vec![],
-                            int64_data: vec![max_value as i64],
-                            ..Default::default()
-                        },
-                        DataType::Uint64 => TensorProto {
-                            name: max_name,
-                            data_type: ProtoDataType::Uint64 as i32,
-                            dims: vec![],
-                            uint64_data: vec![max_value as u64],
-                            ..Default::default()
-                        },
-                        _ => {
-                            Self::create_scalar_initializer(max_name, onnx_dtype, max_value as f32)
-                        }
-                    };
-                    initializers.push(max_tensor);
+                    initializers.push(Self::clamp_bound_scalar_tensor(
+                        max_name,
+                        input_dtype,
+                        max_value,
+                    ));
                 }
 
                 nodes.push(NodeProto {
@@ -10102,6 +10080,12 @@ impl crate::converters::GraphConverter for OnnxConverter {
                                 MLOperandDataType::Int8 => ProtoDataType::Int8 as i64,
                                 MLOperandDataType::Uint8 => ProtoDataType::Uint8 as i64,
                                 MLOperandDataType::Int64 => ProtoDataType::Int64 as i64,
+                                MLOperandDataType::Int4 => {
+                                    Self::data_type_code(DataType::Int4) as i64
+                                }
+                                MLOperandDataType::Uint4 => {
+                                    Self::data_type_code(DataType::Uint4) as i64
+                                }
                                 MLOperandDataType::Uint64 => {
                                     let output_dtype = graph
                                         .operand(output_id)
@@ -10810,6 +10794,26 @@ mod tests {
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
         result.unwrap();
+    }
+
+    #[test]
+    fn test_clamp_bound_scalar_tensor_preserves_large_int32_uint32() {
+        let int32_max = OnnxConverter::clamp_bound_scalar_tensor(
+            "max".to_string(),
+            DataType::Int32,
+            2_147_483_645.0,
+        );
+        assert_eq!(int32_max.int32_data, vec![2_147_483_645]);
+
+        let uint32_max = OnnxConverter::clamp_bound_scalar_tensor(
+            "max".to_string(),
+            DataType::Uint32,
+            4_294_967_290.0,
+        );
+        assert_eq!(
+            uint32_max.raw_data,
+            (4_294_967_290u32).to_le_bytes().to_vec()
+        );
     }
 
     #[test]

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -340,15 +340,16 @@ impl TrtxConverter {
                     .collect();
                 let data = Self::get_constant_data(graph, operand_id as u32)?;
 
-                // Validate that data size matches expected size
-                let expected_size: usize = operand
-                    .descriptor
-                    .shape
-                    .iter()
-                    .map(|d| get_static_or_max_size(d) as usize)
-                    .product();
-                let data_type_size = operand.descriptor.data_type.bytes_per_element();
-                let expected_bytes = expected_size * data_type_size;
+                // Validate that data size matches expected packed byte length
+                let expected_bytes = operand.descriptor.byte_length().ok_or_else(|| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Constant operand {} has invalid shape for byte length",
+                            operand_id
+                        ),
+                    }
+                })?;
 
                 if data.len() != expected_bytes {
                     return Err(GraphError::ConversionFailed {
@@ -370,7 +371,7 @@ impl TrtxConverter {
                 }
 
                 // TensorRT Constant permits kINT8 (not kUINT8). Use kINT8 for Int8/Uint8/Int4/Uint4
-                // graph constants: rustnn stores one byte per logical int4/uint4 element (unpacked).
+                // graph constants with packed int4/uint4 host bytes.
                 //
                 // Do not pass `kINT4` / sub-byte dtypes to `add_constant` / `add_small_constant_copied`:
                 // trtx-rs validates weight size as `(element_count * size_bits) / 8` with truncating

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -96,21 +96,105 @@ pub enum DataType {
 }
 
 impl DataType {
-    pub fn bytes_per_element(self) -> usize {
+    pub const fn bits_per_element(self) -> usize {
         match self {
-            // Int4/Uint4 are stored densely as one nibble; we currently treat them as one byte per element
-            // to keep tensor sizing simple. If packed storage is introduced later, this should be revisited.
-            DataType::Int4 | DataType::Uint4 => 1,
-            DataType::Float16 => 2,
-            DataType::Float32 => 4,
-            DataType::Int32 => 4,
-            DataType::Uint32 => 4,
-            DataType::Int8 => 1,
-            DataType::Uint8 => 1,
-            DataType::Int64 => 8,
-            DataType::Uint64 => 8,
+            DataType::Int4 | DataType::Uint4 => 4,
+            DataType::Int8 | DataType::Uint8 => 8,
+            DataType::Float16 => 16,
+            DataType::Float32 | DataType::Int32 | DataType::Uint32 => 32,
+            DataType::Int64 | DataType::Uint64 => 64,
         }
     }
+
+    /// Host storage bytes for `elements` values (always `ceil(elements * bits / 8)`).
+    pub fn storage_byte_length(self, elements: usize) -> Option<usize> {
+        let total_bits = elements.checked_mul(self.bits_per_element())?;
+        Some((total_bits + 7) / 8)
+    }
+
+    /// Byte size of one element when the type is whole-byte aligned (`bits % 8 == 0`).
+    pub fn bytes_per_element(self) -> usize {
+        let bits = self.bits_per_element();
+        debug_assert!(
+            bits % 8 == 0,
+            "bytes_per_element is only defined for byte-aligned types; use storage_byte_length for int4/uint4"
+        );
+        bits / 8
+    }
+}
+
+/// Packed int4/uint4 layout: even logical indices in the high nibble, odd in the low.
+pub fn unpack_int4(data: &[u8], element_count: usize) -> Vec<i32> {
+    let mut out = Vec::with_capacity(element_count);
+    for i in 0..element_count {
+        let byte = data[i / 2];
+        let nibble = if i % 2 == 0 {
+            (byte >> 4) & 0x0F
+        } else {
+            byte & 0x0F
+        };
+        out.push(if nibble >= 8 {
+            nibble as i32 - 16
+        } else {
+            nibble as i32
+        });
+    }
+    out
+}
+
+pub fn pack_int4(values: &[i32]) -> Vec<u8> {
+    let byte_len = DataType::Int4
+        .storage_byte_length(values.len())
+        .unwrap_or(0);
+    let mut out = vec![0u8; byte_len];
+    for (i, &v) in values.iter().enumerate() {
+        let nibble = ((v.clamp(-8, 7) as i8) as u8) & 0x0F;
+        if i % 2 == 0 {
+            out[i / 2] = nibble << 4;
+        } else {
+            out[i / 2] |= nibble;
+        }
+    }
+    out
+}
+
+pub fn unpack_uint4(data: &[u8], element_count: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(element_count);
+    for i in 0..element_count {
+        let byte = data[i / 2];
+        let nibble = if i % 2 == 0 {
+            (byte >> 4) & 0x0F
+        } else {
+            byte & 0x0F
+        };
+        out.push(nibble);
+    }
+    out
+}
+
+pub fn pack_uint4(values: &[u8]) -> Vec<u8> {
+    let byte_len = DataType::Uint4
+        .storage_byte_length(values.len())
+        .unwrap_or(0);
+    let mut out = vec![0u8; byte_len];
+    for (i, &v) in values.iter().enumerate() {
+        let nibble = v & 0x0F;
+        if i % 2 == 0 {
+            out[i / 2] = nibble << 4;
+        } else {
+            out[i / 2] |= nibble;
+        }
+    }
+    out
+}
+
+pub fn pack_uint4_from_i32(values: &[i32]) -> Vec<u8> {
+    pack_uint4(
+        &values
+            .iter()
+            .map(|&v| v.clamp(0, 15) as u8)
+            .collect::<Vec<_>>(),
+    )
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]
@@ -158,7 +242,7 @@ impl OperandDescriptor {
 
     pub fn byte_length(&self) -> Option<usize> {
         let elements = self.element_count()?;
-        elements.checked_mul(self.data_type.bytes_per_element())
+        self.data_type.storage_byte_length(elements)
     }
 }
 
@@ -318,9 +402,21 @@ mod tests {
     use crate::error::GraphError;
 
     #[test]
+    fn test_data_type_bits_per_element() {
+        assert_eq!(DataType::Int4.bits_per_element(), 4);
+        assert_eq!(DataType::Uint4.bits_per_element(), 4);
+        assert_eq!(DataType::Float16.bits_per_element(), 16);
+        assert_eq!(DataType::Float32.bits_per_element(), 32);
+        assert_eq!(DataType::Int32.bits_per_element(), 32);
+        assert_eq!(DataType::Uint32.bits_per_element(), 32);
+        assert_eq!(DataType::Int8.bits_per_element(), 8);
+        assert_eq!(DataType::Uint8.bits_per_element(), 8);
+        assert_eq!(DataType::Int64.bits_per_element(), 64);
+        assert_eq!(DataType::Uint64.bits_per_element(), 64);
+    }
+
+    #[test]
     fn test_data_type_bytes_per_element() {
-        assert_eq!(DataType::Int4.bytes_per_element(), 1);
-        assert_eq!(DataType::Uint4.bytes_per_element(), 1);
         assert_eq!(DataType::Float16.bytes_per_element(), 2);
         assert_eq!(DataType::Float32.bytes_per_element(), 4);
         assert_eq!(DataType::Int32.bytes_per_element(), 4);
@@ -329,6 +425,31 @@ mod tests {
         assert_eq!(DataType::Uint8.bytes_per_element(), 1);
         assert_eq!(DataType::Int64.bytes_per_element(), 8);
         assert_eq!(DataType::Uint64.bytes_per_element(), 8);
+    }
+
+    #[test]
+    fn test_data_type_storage_byte_length_int4() {
+        assert_eq!(DataType::Int4.storage_byte_length(0), Some(0));
+        assert_eq!(DataType::Int4.storage_byte_length(1), Some(1));
+        assert_eq!(DataType::Int4.storage_byte_length(2), Some(1));
+        assert_eq!(DataType::Int4.storage_byte_length(3), Some(2));
+        assert_eq!(DataType::Int4.storage_byte_length(100), Some(50));
+    }
+
+    #[test]
+    fn test_pack_unpack_int4() {
+        let values = vec![-8_i32, 7, 0, -1];
+        let packed = pack_int4(&values);
+        assert_eq!(packed, vec![0x87, 0x0F]);
+        assert_eq!(unpack_int4(&packed, values.len()), values);
+    }
+
+    #[test]
+    fn test_pack_unpack_uint4() {
+        let values = vec![0_u8, 15, 7, 1];
+        let packed = pack_uint4(&values);
+        assert_eq!(packed, vec![0x0F, 0x71]);
+        assert_eq!(unpack_uint4(&packed, values.len()), values);
     }
 
     #[test]
@@ -377,7 +498,7 @@ mod tests {
             shape: to_dimension_vector(&[10, 10]),
             pending_permutation: vec![],
         };
-        assert_eq!(desc.byte_length(), Some(100));
+        assert_eq!(desc.byte_length(), Some(50));
     }
 
     #[test]
@@ -387,7 +508,7 @@ mod tests {
             shape: to_dimension_vector(&[8, 16]),
             pending_permutation: vec![],
         };
-        assert_eq!(desc.byte_length(), Some(128));
+        assert_eq!(desc.byte_length(), Some(64));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn run() -> Result<(), GraphError> {
                         .map(|dim| get_static_or_max_size(dim) as usize)
                         .product::<usize>()
                         .max(1);
-                    let byte_len = total * desc.data_type.bytes_per_element();
+                    let byte_len = desc.byte_length().unwrap_or(total).max(1);
                     v.push(rustnn::TrtxInput {
                         name: TrtxConverter::engine_io_tensor_name(&graph, op_id),
                         data: vec![0u8; byte_len],
@@ -274,7 +274,7 @@ fn run() -> Result<(), GraphError> {
                             .map(|dim| get_static_or_max_size(dim) as usize)
                             .product::<usize>()
                             .max(1);
-                        let byte_len = total * desc.data_type.bytes_per_element();
+                        let byte_len = desc.byte_length().unwrap_or(total).max(1);
                         rustnn::TrtxInput {
                             name: name.clone(),
                             data: vec![0u8; byte_len],

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -305,9 +305,8 @@ impl MLOperandDescriptor {
     }
 
     pub(crate) fn rustnn_required_bytes(&self) -> usize {
-        let bits = self.data_type().rustnn_element_size_bits();
         let elements = (self.shape().iter().copied().product::<u64>() as usize).max(1);
-        bits * elements / 8
+        self.data_type().rustnn_storage_byte_length(elements).max(1)
     }
 }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -246,6 +246,8 @@ fn constant_shape(
         "uint64" => DataType::Uint64,
         "int8" => DataType::Int8,
         "uint8" => DataType::Uint8,
+        "int4" => DataType::Int4,
+        "uint4" => DataType::Uint4,
         _ => DataType::Float32,
     };
     Ok(OperandDescriptor {

--- a/src/operator_enums.rs
+++ b/src/operator_enums.rs
@@ -13,6 +13,8 @@ pub enum MLOperandDataType {
     Uint64,
     Int8,
     Uint8,
+    Int4,
+    Uint4,
 }
 
 impl TryFrom<DataType> for MLOperandDataType {
@@ -27,10 +29,8 @@ impl TryFrom<DataType> for MLOperandDataType {
             DataType::Uint64 => Self::Uint64,
             DataType::Int8 => Self::Int8,
             DataType::Uint8 => Self::Uint8,
-            DataType::Int4 => return Err(GraphBuilderError::InternalDataType { data_type: value }),
-            DataType::Uint4 => {
-                return Err(GraphBuilderError::InternalDataType { data_type: value });
-            }
+            DataType::Int4 => Self::Int4,
+            DataType::Uint4 => Self::Uint4,
         })
     }
 }
@@ -46,6 +46,8 @@ impl From<MLOperandDataType> for DataType {
             MLOperandDataType::Uint64 => DataType::Uint64,
             MLOperandDataType::Int8 => DataType::Int8,
             MLOperandDataType::Uint8 => DataType::Uint8,
+            MLOperandDataType::Int4 => DataType::Int4,
+            MLOperandDataType::Uint4 => DataType::Uint4,
         }
     }
 }
@@ -57,7 +59,13 @@ impl MLOperandDataType {
             MLOperandDataType::Float16 => 16,
             MLOperandDataType::Int64 | MLOperandDataType::Uint64 => 64,
             MLOperandDataType::Int8 | MLOperandDataType::Uint8 => 8,
+            MLOperandDataType::Int4 | MLOperandDataType::Uint4 => 4,
         }
+    }
+
+    pub const fn rustnn_storage_byte_length(self, elements: usize) -> usize {
+        let bits = self.rustnn_element_size_bits();
+        (bits * elements + 7) / 8
     }
 }
 
@@ -162,6 +170,8 @@ impl MLOperandDataType {
             MLOperandDataType::Uint64 => "uint64",
             MLOperandDataType::Int8 => "int8",
             MLOperandDataType::Uint8 => "uint8",
+            MLOperandDataType::Int4 => "int4",
+            MLOperandDataType::Uint4 => "uint4",
         }
     }
 }

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -466,6 +466,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             MLOperandDataType::Uint64 => DataType::Uint64,
             MLOperandDataType::Int8 => DataType::Int8,
             MLOperandDataType::Uint8 => DataType::Uint8,
+            MLOperandDataType::Int4 => DataType::Int4,
+            MLOperandDataType::Uint4 => DataType::Uint4,
         }
     }
 


### PR DESCRIPTION
## Summary

There are a few 4-bit integer WPT-webnn tests even though those datatypes have not yet added to the spec language. Add support for int4 and wire it up in the backends.

## Validation

- [ ] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

