### PR TITLE
Unify panic messages for disabled backends

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -11,6 +11,12 @@ pub mod trtx;
 #[derive(Debug)]
 pub(crate) struct DisabledContext {}
 
+impl DisabledContext {
+    pub(crate) fn new_from_device_idx(_device_idx: usize) -> crate::error::Result<Self> {
+        panic!("Tried to create disabled backend");
+    }
+}
+
 impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
     fn accelerated(&self) -> bool {
         panic!("RustNN is expected to never use a disabled backend")
@@ -84,23 +90,10 @@ impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
 
 #[cfg(not(feature = "onnx-runtime"))]
 pub mod ort {
-
     pub(crate) use crate::backends::DisabledContext as OrtContext;
-
-    impl OrtContext {
-        pub(crate) fn new_from_ep_idx(_device_idx: usize) -> crate::error::Result<Self> {
-            panic!("Tried to create disabled ONNX backend");
-        }
-    }
 }
 
 #[cfg(not(any(feature = "trtx-runtime", feature = "trtx-runtime-mock")))]
 pub mod trtx {
     pub(crate) use crate::backends::DisabledContext as TrtxContext;
-
-    impl TrtxContext {
-        pub(crate) fn new(_cuda_device_idx: u32) -> crate::error::Result<Self> {
-            panic!("Tried to create disabled Trtx backend");
-        }
-    }
 }

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -488,7 +488,7 @@ pub(crate) struct OrtContext {
 }
 
 impl OrtContext {
-    pub(crate) fn new_from_ep_idx(device_idx: usize) -> crate::error::Result<Self> {
+    pub(crate) fn new_from_device_idx(device_idx: usize) -> crate::error::Result<Self> {
         ensure_ort_initialized().map_err(|e| Error::ContextCreationError { source: e.into() })?;
         let env =
             Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })?;

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -192,9 +192,9 @@ static LOGGER: std::sync::LazyLock<trtx::Logger> =
     std::sync::LazyLock::new(|| trtx::Logger::log_crate().unwrap());
 
 impl<'context> TrtxContext<'context> {
-    pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
+    pub(crate) fn new_from_device_idx(cuda_device_idx: usize) -> TrtxResult<Self> {
         // this retains the primary context
-        let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
+        let cuda_ctx = CudaContext::new(cuda_device_idx)?;
         let mut builder = trtx::Builder::new(&LOGGER)?;
         let mut config = builder.create_config()?;
         // Strip marked weights weights from engine and makes them refittable, keeps other weights

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -468,10 +468,10 @@ impl<'context> MLContext<'context> {
         info!("Backend selected: {desc:?}");
         let backend: Box<dyn MLBackendContext<'context> + 'context> = match desc {
             crate::backend_selection::BackendDevice::Onnx { ep_device_idx, .. } => {
-                Box::new(OrtContext::new_from_ep_idx(ep_device_idx)?)
+                Box::new(OrtContext::new_from_device_idx(ep_device_idx)?)
             }
             crate::backend_selection::BackendDevice::Trtx { cuda_device_idx } => Box::new(
-                TrtxContext::new(cuda_device_idx)
+                TrtxContext::new_from_device_idx(cuda_device_idx as usize)
                     .map_err(|e| Error::ContextCreationError { source: e.into() })?,
             ),
             crate::backend_selection::BackendDevice::Coreml { device_type } => todo!(),


### PR DESCRIPTION
## Summary

It makes adding new backends easy. 
Earlier requirs per-module DisabledContext impl blocks with matching signatures that could conflict.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

