### PR TITLE
Backend selection

### DIFF
--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -17,7 +17,7 @@ use crate::mlcontext::ListDevices;
 
 // this is a concept of pywebnn
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub(crate) enum DeviceType {
+pub enum DeviceType {
     Cpu,
     Gpu,
     Npu,
@@ -34,12 +34,19 @@ impl From<ort::memory::DeviceType> for DeviceType {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Backend {
+    Onnx,
+    Trtx,
+    Coreml,
+    Litert,
+}
+
 /// we currently only consider internal backends,
 /// might allow to register external backends in future
 /// like with converter registry
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[allow(dead_code)]
-pub(crate) enum BackendDevice {
+pub enum BackendDevice {
     Onnx {
         ep_device_idx: usize,
         device_type: DeviceType,
@@ -60,34 +67,35 @@ pub(crate) enum BackendDevice {
     //ExternalBackend,
 }
 
-#[allow(dead_code)]
 impl BackendDevice {
-    fn is_npu(&self) -> bool {
+    pub fn backend(&self) -> Backend {
         match self {
-            BackendDevice::Onnx { device_type, .. }
-            | BackendDevice::Coreml { device_type }
-            | BackendDevice::LiteRt { device_type } => *device_type == DeviceType::Npu,
-            BackendDevice::Trtx { .. } => false,
+            BackendDevice::Onnx { .. } => Backend::Onnx,
+            BackendDevice::Trtx { .. } => Backend::Trtx,
+            BackendDevice::Coreml { .. } => Backend::Coreml,
+            BackendDevice::LiteRt { .. } => Backend::Litert,
         }
     }
 
-    fn is_gpu(&self) -> bool {
+    pub fn device_type(&self) -> DeviceType {
         match self {
+            BackendDevice::Trtx { .. } => DeviceType::Gpu,
             BackendDevice::Onnx { device_type, .. }
             | BackendDevice::Coreml { device_type }
-            | BackendDevice::LiteRt { device_type } => *device_type == DeviceType::Gpu,
-            BackendDevice::Trtx { .. } => true,
+            | BackendDevice::LiteRt { device_type } => *device_type,
         }
     }
 
-    #[allow(dead_code)]
-    fn is_cpu(&self) -> bool {
-        match self {
-            BackendDevice::Onnx { device_type, .. }
-            | BackendDevice::Coreml { device_type }
-            | BackendDevice::LiteRt { device_type } => *device_type == DeviceType::Cpu,
-            BackendDevice::Trtx { .. } => false,
-        }
+    pub fn is_npu(&self) -> bool {
+        self.device_type() == DeviceType::Npu
+    }
+
+    pub fn is_gpu(&self) -> bool {
+        self.device_type() == DeviceType::Gpu
+    }
+
+    pub fn is_cpu(&self) -> bool {
+        self.device_type() == DeviceType::Cpu
     }
 
     #[cfg(feature = "trtx-runtime")]
@@ -101,31 +109,22 @@ impl BackendDevice {
     }
 }
 
-//#[cfg(feature = "web")]
-//pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice> {
-//BackendDevice::WebNN {
-//options: options.clone(),
-//}
-//}
-
-// TODO: pywebnn has device_type, and we could have backend preference for user to overwrite
-// autoselection
-//#[cfg(not(feature = "web"))]
 pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice> {
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let have_trtx = cfg!(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"));
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
-    let want_trtx = true;
+    let want_trtx = options.backend_hint.is_none() || options.backend_hint == Some(Backend::Trtx);
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let trtx_devices = TrtxContext::list_devices();
 
     #[cfg(feature = "onnx-runtime")]
     let have_onnx = cfg!(feature = "onnx-runtime");
     #[cfg(feature = "onnx-runtime")]
-    let want_onnx = true;
+    let want_onnx = options.backend_hint.is_none() || options.backend_hint == Some(Backend::Onnx);
 
     let have_coreml = cfg!(all(target_os = "macos", feature = "coreml-runtime"));
-    let want_coreml = true;
+    let want_coreml =
+        options.backend_hint.is_none() || options.backend_hint == Some(Backend::Coreml);
 
     #[cfg(feature = "litert-runtime")]
     let have_litert = cfg!(feature = "litert-runtime");
@@ -134,13 +133,10 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
     #[cfg(feature = "litert-runtime")]
     let litert_devices = LiteRtContext::list_devices();
 
-    // TODO: also check whether WebNN is available
-    //#[cfg(target_arch = "wasm32")]
-    //{
-    //let window = window().expect("no global `window` exists");
-    //let navigator = window.navigator();
-    //let ml = navigator.ml();
-    //}
+    if let Some(device_hint) = options.device_hint {
+        // No fallbacks for now. We could check if device is available
+        return Ok(device_hint);
+    }
 
     Ok(match (options.power_preference, options.accelerated) {
         // Trtx

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -483,6 +483,18 @@ impl MLTensorDescriptor {
     pub fn set_operand_descriptor(&mut self, operand_descriptor: MLOperandDescriptor) {
         self.operand_descriptor = operand_descriptor;
     }
+
+    pub fn to_writable(&self) -> Self {
+        let mut copy = self.clone();
+        copy.writable = true;
+        copy
+    }
+
+    pub fn to_readable(&self) -> Self {
+        let mut copy = self.clone();
+        copy.readable = true;
+        copy
+    }
 }
 
 // TODO: this is wrong. must be 'context and `for <'builder>` to be valid for each builder lifetime (multiple children!)
@@ -695,11 +707,9 @@ webnn_graph "sample_graph" v1 {
     }
 
     fn rw_tensor_desc(shape: Vec<u64>) -> MLTensorDescriptor {
-        let mut desc =
-            MLTensorDescriptor::new(crate::operator_enums::MLOperandDataType::Float32, shape);
-        desc.set_readable(true);
-        desc.set_writable(true);
-        desc
+        MLTensorDescriptor::new(crate::operator_enums::MLOperandDataType::Float32, shape)
+            .to_writable()
+            .to_readable()
     }
 
     #[test]

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -2,14 +2,16 @@
 
 use log::{debug, info};
 
+use crate::GraphInfo;
 use crate::OperandDescriptor;
+pub use crate::backend_selection::{Backend, BackendDevice, DeviceType};
 #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
 use crate::backends::trtx::TrtxGraph;
 use crate::error::Error;
+use crate::error::Result;
 use crate::graph::{DataType, Dimension, Operand, get_static_or_max_size};
 use crate::mlgraphbuilder::get_operand;
 use crate::runtime_checks::{RuntimeShapeState, TensorKind};
-use crate::{GraphInfo, backend_selection::BackendDevice, error::Result};
 
 use crate::backends::coreml::CoremlContext;
 use crate::backends::litert::LiteRtContext;
@@ -348,7 +350,8 @@ pub struct MLContextOptions {
     // ideas for possible rustnn specific options
     // - backend preference
     // - device_type (CPU, NPU, GPU) like pywebnn
-    pub(crate) backend_hint: Option<BackendDevice>,
+    pub(crate) device_hint: Option<BackendDevice>,
+    pub(crate) backend_hint: Option<Backend>,
 }
 
 impl MLContextOptions {
@@ -356,6 +359,7 @@ impl MLContextOptions {
         Self {
             power_preference,
             accelerated,
+            device_hint: None,
             backend_hint: None,
         }
     }
@@ -374,6 +378,16 @@ impl MLContextOptions {
 
     pub fn set_accelerated(&mut self, accelerated: bool) {
         self.accelerated = accelerated;
+    }
+
+    pub fn with_rustnn_backend_hint(mut self, backend: Backend) -> Self {
+        self.backend_hint = Some(backend);
+        self
+    }
+
+    pub fn with_rustnn_device_hint(mut self, device: BackendDevice) -> Self {
+        self.device_hint = Some(device);
+        self
     }
 }
 
@@ -475,15 +489,16 @@ impl MLTensorDescriptor {
 #[derive(Debug)]
 pub struct MLContext<'context> {
     pub(crate) backend: Box<dyn MLBackendContext<'context> + 'context>,
+    pub(crate) device: BackendDevice,
 }
 
 impl<'context> MLContext<'context> {
     // those are methods on `create_context`
     //pub async
     pub fn create(options: &MLContextOptions) -> Result<Self> {
-        let desc = select_backend(options)?;
-        info!("Backend selected: {desc:?}");
-        let backend: Box<dyn MLBackendContext<'context> + 'context> = match desc {
+        let device = select_backend(options)?;
+        info!("Backend selected: {device:?}");
+        let backend: Box<dyn MLBackendContext<'context> + 'context> = match device {
             crate::backend_selection::BackendDevice::Onnx { ep_device_idx, .. } => {
                 Box::new(OrtContext::new_from_ep_idx(ep_device_idx)?)
             }
@@ -498,19 +513,19 @@ impl<'context> MLContext<'context> {
                 Box::new(LiteRtContext::new_from_device_type(device_type)?)
             }
         };
-        Ok(Self { backend })
+        Ok(Self { backend, device })
     }
 
     #[expect(unreachable_code)]
     pub async fn create_from_gpu_device(gpu_device: &GpuDevice) -> Result<Self> {
-        let desc = select_backend_by_gpu(gpu_device)?;
-        let backend = match desc {
+        let device = select_backend_by_gpu(gpu_device)?;
+        let backend = match device {
             crate::backend_selection::BackendDevice::Onnx { .. } => todo!(),
             crate::backend_selection::BackendDevice::Trtx { cuda_device_idx } => todo!(),
             crate::backend_selection::BackendDevice::Coreml { device_type } => todo!(),
             crate::backend_selection::BackendDevice::LiteRt { .. } => todo!(),
         };
-        Ok(Self { backend })
+        Ok(Self { backend, device })
     }
     pub fn accelerated(&self) -> bool {
         self.backend.accelerated()
@@ -536,6 +551,18 @@ impl<'context> MLContext<'context> {
     // omit destroy()? We're not JS, objects can be destroyed via drop, we could do destroy stuff in Drop
     pub fn destroy(self) {
         todo!()
+    }
+
+    pub fn rustnn_backend(&self) -> Backend {
+        self.device.backend()
+    }
+
+    pub fn rustnn_device(&self) -> BackendDevice {
+        self.device
+    }
+
+    pub fn rustnn_device_type(&self) -> DeviceType {
+        self.device.device_type()
     }
 
     pub fn dispatch(
@@ -697,6 +724,18 @@ webnn_graph "sample_graph" v1 {
         assert_eq!(*desc.operand_descriptor(), op_desc);
     }
 
+    #[test]
+    fn test_backend_hint() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(
+            &MLContextOptions::new(MLPowerPreference::Default, true)
+                .with_rustnn_backend_hint(Backend::Onnx),
+        );
+        if matches!(context, Err(crate::error::Error::NoBackendAvialable)) {
+            return;
+        };
+        assert_eq!(context.unwrap().rustnn_backend(), Backend::Onnx);
+    }
     #[test]
     fn test_create_context() {
         let _ = pretty_env_logger::try_init();


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Allow to set backend or device hint and get the selected device. Inspired by #85. Listing of available device not yet exposed

Also set builder methods for readable/writeable to MLTensorDescriptor

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

