### PR TITLE
feat!: return sync handle for read_tensor/write_tensor

### DIFF
--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -21,6 +21,7 @@ use crate::executors::coreml::{
 };
 use crate::mlcontext::{
     MLBackendBuilder, MLBackendContext, MLBackendGraph, MLGraph, MLTensor, MLTensorDescriptor,
+    SyncHandle,
 };
 
 /// Number of bytes required to store a tensor described by `descriptor`.
@@ -135,7 +136,11 @@ impl<'context> MLBackendContext<'context> for CoremlContext {
         Ok(tensor)
     }
 
-    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> crate::error::Result<()> {
+    fn read_tensor(
+        &mut self,
+        tensor: &MLTensor,
+        array: &mut [u8],
+    ) -> crate::error::Result<SyncHandle> {
         let host = &self.tensors[tensor.id].memory;
         let logical = tensor_byte_len(tensor.descriptor());
         if array.len() < logical {
@@ -154,10 +159,14 @@ impl<'context> MLBackendContext<'context> for CoremlContext {
             tensor: tensor.clone(),
         })?;
         array[..logical].copy_from_slice(slice);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
-    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> crate::error::Result<()> {
+    fn write_tensor(
+        &mut self,
+        tensor: &MLTensor,
+        array: &[u8],
+    ) -> crate::error::Result<SyncHandle> {
         let host = &mut self.tensors[tensor.id].memory;
         if array.len() > host.len() {
             return Err(Error::TensorWriteError {
@@ -172,7 +181,7 @@ impl<'context> MLBackendContext<'context> for CoremlContext {
         }
         let n = array.len();
         host[..n].copy_from_slice(array);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
     fn dispatch(

--- a/src/backends/litert.rs
+++ b/src/backends/litert.rs
@@ -6,6 +6,7 @@ use crate::backend_selection::DeviceType;
 use crate::error::{Error, Result};
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
+    SyncHandle,
 };
 
 pub(crate) struct LiteRtTensor {
@@ -113,7 +114,7 @@ impl<'context> MLBackendContext<'context> for LiteRtContext {
         Ok(tensor)
     }
 
-    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<()> {
+    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<SyncHandle> {
         let host = &self.tensors[tensor.id].memory;
         let logical = tensor_byte_len(tensor.descriptor())?;
         if array.len() < logical {
@@ -132,10 +133,10 @@ impl<'context> MLBackendContext<'context> for LiteRtContext {
             tensor: tensor.clone(),
         })?;
         array[..logical].copy_from_slice(slice);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
-    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<()> {
+    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<SyncHandle> {
         let host = &mut self.tensors[tensor.id].memory;
         if array.len() > host.len() {
             return Err(Error::TensorWriteError {
@@ -149,7 +150,7 @@ impl<'context> MLBackendContext<'context> for LiteRtContext {
             });
         }
         host[..array.len()].copy_from_slice(array);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
     fn dispatch(

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -50,7 +50,7 @@ impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
         &mut self,
         _tensor: &mlcontext::MLTensor,
         _array: &mut [u8],
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<mlcontext::SyncHandle> {
         panic!("RustNN is expected to never use a disabled backend")
     }
 
@@ -58,7 +58,7 @@ impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
         &mut self,
         _tensor: &mlcontext::MLTensor,
         _array: &[u8],
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<mlcontext::SyncHandle> {
         panic!("RustNN is expected to never use a disabled backend")
     }
 

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -19,6 +19,7 @@ use crate::executors::onnx::ensure_ort_initialized;
 use crate::graph::{pack_int4, pack_uint4_from_i32, unpack_int4, unpack_uint4};
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
+    SyncHandle,
 };
 use crate::{GraphError, GraphInfo, ONNX_EXTERNAL_WEIGHTS_FILENAME};
 
@@ -695,7 +696,11 @@ impl<'context> MLBackendContext<'context> for OrtContext {
         Ok(tensor)
     }
 
-    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> crate::error::Result<()> {
+    fn read_tensor(
+        &mut self,
+        tensor: &MLTensor,
+        array: &mut [u8],
+    ) -> crate::error::Result<SyncHandle> {
         let host = &self.tensors[tensor.id].memory;
         let logical = tensor_byte_len(tensor.descriptor())?;
         if host.len() > logical {
@@ -724,10 +729,14 @@ impl<'context> MLBackendContext<'context> for OrtContext {
             tensor: tensor.clone(),
         })?;
         array[..logical].copy_from_slice(slice);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
-    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> crate::error::Result<()> {
+    fn write_tensor(
+        &mut self,
+        tensor: &MLTensor,
+        array: &[u8],
+    ) -> crate::error::Result<SyncHandle> {
         let host = &mut self.tensors[tensor.id].memory;
         if array.len() > host.len() {
             return Err(Error::TensorWriteError {
@@ -742,7 +751,7 @@ impl<'context> MLBackendContext<'context> for OrtContext {
         }
         let n = array.len();
         host[..n].copy_from_slice(array);
-        Ok(())
+        Ok(SyncHandle::Ready)
     }
 
     fn dispatch(

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -31,7 +31,7 @@ use crate::error::GraphBuilderError;
 use crate::mlcontext::MLTensor;
 use crate::mlcontext::{ListDevices, MLOperand};
 use crate::mlcontext::{MLBackendBuilder, MLGraph};
-use crate::mlcontext::{MLBackendContext, MLBackendGraph};
+use crate::mlcontext::{MLBackendContext, MLBackendGraph, SyncHandle, SynchronizationHandle};
 
 // TODO: also used in trtexec-rs. Should be part of trtx API?
 enum HostMemoryOrVec<'memory> {
@@ -527,12 +527,12 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     ) -> crate::error::Result<crate::mlcontext::MLTensor> {
         let mut tensor = self.create_tensor(descriptor)?;
         tensor.constant = true;
-        self.write_tensor(&tensor, input_data).map_err(|e| {
-            crate::error::Error::TensorCreationError {
+        self.write_tensor(&tensor, input_data)
+            .and_then(SynchronizationHandle::wait)
+            .map_err(|e| crate::error::Error::TensorCreationError {
                 source: e.into(),
                 descriptor: descriptor.clone(),
-            }
-        })?; // need to free tensor in case of error
+            })?; // need to free tensor in case of error
         Ok(tensor)
     }
 
@@ -540,7 +540,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         &mut self,
         tensor: &crate::mlcontext::MLTensor,
         array: &mut [u8],
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<SyncHandle> {
         self.try_register_host_memory(array.as_ptr(), array.len());
         let cuda_tensor = &self.tensors[tensor.id];
         let stream = &cuda_tensor.stream;
@@ -552,19 +552,30 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         stream
             .memcpy_dtoh(&cuda_tensor.memory, array)
             .to_read_tensor_result(|| tensor.clone())?;
-        stream
-            .synchronize()
+        let event = stream
+            .record_event(None)
             .to_read_tensor_result(|| tensor.clone())?;
-        Ok(())
+        Ok(SyncHandle::CudaEvent(event))
     }
 
     fn write_tensor(
         &mut self,
         tensor: &crate::mlcontext::MLTensor,
         array: &[u8],
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<SyncHandle> {
         self.try_register_host_memory(array.as_ptr(), array.len());
         let cuda_tensor = &mut self.tensors[tensor.id];
+        if array.len() > cuda_tensor.memory.len() {
+            return Err(crate::error::Error::TensorWriteError {
+                source: format!(
+                    "write exceeds tensor storage: {} bytes > {}",
+                    array.len(),
+                    cuda_tensor.memory.len()
+                )
+                .into(),
+                tensor: tensor.clone(),
+            });
+        }
         let stream = &cuda_tensor.stream;
         debug!(
             "Uploading tensor {cuda_tensor:?} to array (ptr={:?}, size={:?})",
@@ -574,7 +585,10 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         stream
             .memcpy_htod(array, &mut cuda_tensor.memory)
             .to_write_tensor_result(|| tensor.clone())?;
-        Ok(())
+        let event = stream
+            .record_event(None)
+            .to_write_tensor_result(|| tensor.clone())?;
+        Ok(SyncHandle::CudaEvent(event))
     }
 
     fn dispatch(
@@ -762,7 +776,7 @@ impl ListDevices for TrtxContext<'_> {
 #[cfg(test)]
 #[cfg(feature = "trtx-runtime")]
 mod tests {
-    use crate::mlcontext::{MLBackendContext, MLTensorDescriptor};
+    use crate::mlcontext::{MLBackendContext, MLTensorDescriptor, SynchronizationHandle};
     use crate::{backends::trtx::TrtxContext, mlcontext::ListDevices};
 
     #[test]
@@ -814,15 +828,18 @@ mod tests {
         let mut download = vec![0.0f32; 4];
         context
             .write_tensor(&tensor, bytemuck::cast_slice(&upload))
+            .unwrap()
+            .wait()
             .unwrap();
         context
             .read_tensor(&tensor, bytemuck::cast_slice_mut(&mut download))
+            .unwrap()
+            .wait()
             .unwrap();
         assert_eq!(&upload, &download);
     }
 
     #[test]
-    #[should_panic = "assertion failed: dst.len() >= src.len()"]
     fn test_write_too_large_tensor() {
         let _ = pretty_env_logger::try_init();
         let devices = TrtxContext::list_devices();
@@ -839,8 +856,12 @@ mod tests {
         desc.set_readable(true);
         desc.set_writable(true);
         let tensor = context.create_tensor(&desc).unwrap();
-        context
+        let error = context
             .write_tensor(&tensor, bytemuck::cast_slice(&too_big))
             .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Failed to write tensor: write exceeds tensor storage: 32 bytes > 16"
+        );
     }
 }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -826,16 +826,16 @@ mod tests {
 
         let upload = vec![1.0f32, 2., 3., 4.];
         let mut download = vec![0.0f32; 4];
-        context
+        let upload_handle = context
             .write_tensor(&tensor, bytemuck::cast_slice(&upload))
-            .unwrap()
-            .wait()
             .unwrap();
-        context
+        upload_handle.is_finished().unwrap();
+        upload_handle.wait().unwrap();
+        let download_handle = context
             .read_tensor(&tensor, bytemuck::cast_slice_mut(&mut download))
-            .unwrap()
-            .wait()
             .unwrap();
+        download_handle.is_finished().unwrap();
+        download_handle.wait().unwrap();
         assert_eq!(&upload, &download);
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -221,6 +221,9 @@ pub enum Error {
         tensor: MLTensor,
     },
 
+    #[error("Failed to wait for backend work: {source}")]
+    SynchronizationError { source: Box<dyn std::error::Error> },
+
     #[error(
         "Set capacity error: requested to set capacity to max shape {requested_shape:?} with {required_bytes} bytes but current shape is {current_shape:?} which needs {required_bytes} bytes"
     )]

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -32,6 +32,39 @@ pub(crate) trait ListDevices {
     fn list_devices() -> Vec<BackendDevice>;
 }
 
+#[derive(Debug)]
+pub(crate) enum SyncHandle {
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+    CudaEvent(cudarc::driver::CudaEvent),
+    Ready,
+}
+
+/// A completion handle for work submitted by a backend.
+///
+/// Unlike [`std::future::Future`], this interface waits synchronously. Backends
+/// may override `try_cancel` when they support cancellation.
+pub(crate) trait SynchronizationHandle {
+    fn wait(self) -> Result<()>;
+
+    fn try_cancel(&mut self) {}
+}
+
+impl SynchronizationHandle for SyncHandle {
+    fn wait(self) -> Result<()> {
+        match self {
+            #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+            Self::CudaEvent(event) => {
+                event
+                    .synchronize()
+                    .map_err(|source| Error::SynchronizationError {
+                        source: Box::new(source),
+                    })
+            }
+            Self::Ready => Ok(()),
+        }
+    }
+}
+
 // could make public later if interface stabilized
 pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
     fn accelerated(&self) -> bool;
@@ -53,9 +86,9 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
         input_data: &[u8],
     ) -> Result<MLTensor>;
     /*async*/
-    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<()>;
+    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<SyncHandle>;
     /*async*/
-    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<()>;
+    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<SyncHandle>;
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
@@ -628,7 +661,8 @@ impl<'context> MLContext<'context> {
             });
         }
         self.backend
-            .read_tensor(tensor, bytemuck::cast_slice_mut(array))
+            .read_tensor(tensor, bytemuck::cast_slice_mut(array))?
+            .wait()
     }
 
     //async
@@ -650,7 +684,8 @@ impl<'context> MLContext<'context> {
             });
         }
         self.backend
-            .write_tensor(tensor, bytemuck::cast_slice(array))
+            .write_tensor(tensor, bytemuck::cast_slice(array))?
+            .wait()
     }
 
     pub fn rustnn_resize_tensor(&mut self, tensor: &mut MLTensor, new_shape: &[u64]) -> Result<()> {

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -46,6 +46,8 @@ pub(crate) enum SyncHandle {
 pub(crate) trait SynchronizationHandle {
     fn wait(self) -> Result<()>;
 
+    fn is_finished(&self) -> Result<bool>;
+
     fn try_cancel(&mut self) {}
 }
 
@@ -61,6 +63,32 @@ impl SynchronizationHandle for SyncHandle {
                     })
             }
             Self::Ready => Ok(()),
+        }
+    }
+
+    fn is_finished(&self) -> Result<bool> {
+        match self {
+            #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+            Self::CudaEvent(event) => {
+                event
+                    .context()
+                    .bind_to_thread()
+                    .map_err(|source| Error::SynchronizationError {
+                        source: Box::new(source),
+                    })?;
+                match unsafe { cudarc::driver::result::event::query(event.cu_event()) } {
+                    Ok(()) => Ok(true),
+                    Err(source)
+                        if source.0 == cudarc::driver::sys::CUresult::CUDA_ERROR_NOT_READY =>
+                    {
+                        Ok(false)
+                    }
+                    Err(source) => Err(Error::SynchronizationError {
+                        source: Box::new(source),
+                    }),
+                }
+            }
+            Self::Ready => Ok(true),
         }
     }
 }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

We have three choices to implement `async` WebNN APIs:
1) just make them blocking, when they return they are finished
2) return a sync handle that can be waited on blocking or polled if finished
3) return a future to implement a proper async API (potentially by turning 2) into futures)
4) push blocking work into background thread, get notified when finished. use that to implement async

Things to consider:
- `async` traits don't play well with dynamic dispatch, backends might need to return an object from a non-async trait that the RustNN API turns into a future
- futures must be able to wake/notify when they are ready, futures can be canceled
- we likely want the `MLGraphBuilder::build` to be cancelable because it potentially takes a long time
- we likely want `read_tensor`/`write_tensor` to not be 1) because otherwise the GPU has to synchronize on each of the calls and for example for `write_tensor` the host does not know when it is safe to write 
- we can't really borrow in `read_tensor`/`write_tensor` as host could drop the arrays in the meantime. Would need to hold on the reference for a while via Arc or a different API for `read_tensor`/`write_tensor` that allows direct access to the internal handle of the tensor  


## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

