### PR TITLE
feat(trtx): use jit cache

### DIFF
--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::ffi::c_void;
+use std::ffi::{CStr, c_void};
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -223,6 +223,7 @@ impl TrtxTensor {
 
 pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
+    pci_device_id: String,
     tensors: Vec<TrtxTensor>,
     events: Vec<CudaEvent>,
     attempted_host_registrations: HashSet<usize>,
@@ -251,6 +252,7 @@ impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
         // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
+        let pci_device_id = cuda_pci_device_id(&cuda_ctx)?;
         let mut builder = trtx::Builder::new(&LOGGER)?;
         let mut config = builder.create_config()?;
         // Strip marked weights weights from engine and makes them refittable, keeps other weights
@@ -262,6 +264,7 @@ impl<'context> TrtxContext<'context> {
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
+            pci_device_id,
             tensors: vec![],
             events: vec![],
             attempted_host_registrations: HashSet::new(),
@@ -294,6 +297,63 @@ impl<'context> TrtxContext<'context> {
     }
 }
 
+fn cuda_pci_device_id(cuda_ctx: &CudaContext) -> std::result::Result<String, DriverError> {
+    // CUDA documents 13 bytes as sufficient for "domain:bus:device.function". Leave some
+    // extra room so this remains robust if the representation grows in a future driver.
+    let mut buffer = [0_i8; 32];
+    unsafe {
+        sys::cuDeviceGetPCIBusId(
+            buffer.as_mut_ptr(),
+            buffer.len() as i32,
+            cuda_ctx.cu_device(),
+        )
+        .result()?;
+    }
+    Ok(unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .into_owned())
+}
+
+impl Drop for TrtxContext<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = self.cuda_ctx.bind_to_thread() {
+            warn!(
+                "Failed to bind CUDA device {} before saving its TensorRT JIT cache: {error}",
+                self.pci_device_id
+            );
+            return;
+        }
+
+        let runtime_cache = TRTX_RUNTIME_CACHES
+            .lock()
+            .unwrap()
+            .get(&self.pci_device_id)
+            .cloned();
+        let Some(runtime_cache) = runtime_cache else {
+            return;
+        };
+
+        let serialized = match runtime_cache.lock().unwrap().serialize() {
+            Ok(serialized) => serialized,
+            Err(error) => {
+                warn!(
+                    "Failed to serialize TensorRT JIT cache for CUDA device {}: {error}",
+                    self.pci_device_id
+                );
+                return;
+            }
+        };
+        if let Ok(cache) = JIT_CACHE.as_ref()
+            && let Err(error) = cache.set(&jit_cache_disk_key(&self.pci_device_id), &serialized)
+        {
+            warn!(
+                "Failed to save TensorRT JIT cache for CUDA device {}: {error}",
+                self.pci_device_id
+            );
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) struct TrtxBuilder<'builder> {
     network: Mutex<Option<trtx::NetworkDefinition<'builder>>>,
@@ -301,6 +361,7 @@ pub(crate) struct TrtxBuilder<'builder> {
     config: Arc<Mutex<trtx::BuilderConfig<'builder>>>,
     cuda_context: Arc<CudaContext>,
     runtime: Arc<Mutex<trtx::Runtime<'builder>>>,
+    pci_device_id: String,
     operands: HashMap<String, MLOperand>,
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
@@ -314,6 +375,11 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
 
 static ENGINE_CACHE: LazyLock<CacheResult<DefaultCache>> =
     LazyLock::new(|| DefaultCache::new("trtx"));
+static JIT_CACHE: LazyLock<CacheResult<DefaultCache>> =
+    LazyLock::new(|| DefaultCache::new("trtx-jit"));
+static TRTX_RUNTIME_CACHES: LazyLock<
+    Mutex<HashMap<String, Arc<Mutex<trtx::RuntimeCache<'static>>>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
     format!(
         "trtx_{}.{}.{}",
@@ -322,6 +388,26 @@ static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
         unsafe { trtx::trtx_sys::get_tensorrt_patch_version() }
     )
 });
+
+fn jit_cache_disk_key(pci_device_id: &str) -> String {
+    let filesystem_safe_device_id = pci_device_id.replace([':', '.'], "_");
+    format!("{filesystem_safe_device_id}_{}.cache", *TRTX_SUFFIX)
+}
+
+// RuntimeCache owns its TensorRT IRuntimeCache and does not borrow the engine. The lifetime in
+// trtx::RuntimeCache is represented only by PhantomData, so erase it while the cache is held in
+// the process-global map and restore the current engine lifetime when cloning it out.
+fn into_global_runtime_cache<'engine>(
+    cache: Arc<Mutex<trtx::RuntimeCache<'engine>>>,
+) -> Arc<Mutex<trtx::RuntimeCache<'static>>> {
+    unsafe { std::mem::transmute(cache) }
+}
+
+fn from_global_runtime_cache<'engine>(
+    cache: Arc<Mutex<trtx::RuntimeCache<'static>>>,
+) -> Arc<Mutex<trtx::RuntimeCache<'engine>>> {
+    unsafe { std::mem::transmute(cache) }
+}
 
 impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'context> {
     /*async */
@@ -437,6 +523,40 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         let mut runtime_config = engine
             .create_runtime_config()
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+        let runtime_cache = {
+            let mut caches = TRTX_RUNTIME_CACHES.lock().unwrap();
+            if let Some(cache) = caches.get(&self.pci_device_id) {
+                from_global_runtime_cache(Arc::clone(cache))
+            } else {
+                let mut cache = runtime_config
+                    .create_runtime_cache()
+                    .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                if let Ok(disk_cache) = JIT_CACHE.as_ref()
+                    && let Ok(serialized) = disk_cache.get(&jit_cache_disk_key(&self.pci_device_id))
+                {
+                    match cache.deserialize(&serialized) {
+                        Ok(()) => debug!(
+                            "Loaded TensorRT JIT cache for CUDA device {} ({} bytes)",
+                            self.pci_device_id,
+                            serialized.len()
+                        ),
+                        Err(error) => warn!(
+                            "Failed to deserialize TensorRT JIT cache for CUDA device {}: {error}",
+                            self.pci_device_id
+                        ),
+                    }
+                }
+                let cache = Arc::new(Mutex::new(cache));
+                caches.insert(
+                    self.pci_device_id.clone(),
+                    into_global_runtime_cache(Arc::clone(&cache)),
+                );
+                cache
+            }
+        };
+        runtime_config
+            .set_runtime_cache(runtime_cache)
+            .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
         runtime_config
             .set_cuda_graph_strategy(trtx::CudaGraphStrategy::kDISABLED)
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
@@ -489,6 +609,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             builder: Arc::clone(&self.builder),
             config: Arc::clone(&self.config),
             runtime: Arc::clone(&self.runtime),
+            pci_device_id: self.pci_device_id.clone(),
             cuda_context: Arc::clone(&self.cuda_ctx),
             operands: HashMap::new(),
             strings: vec![],


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Add JIT cache for TRTX. This helps with JIT compiling CUDA kernel. This provides smaller benefit that the caching of engines (which is still disabled at the moment). This cache is good for the specialization of an engine for a specific GPU. Building an engine is a step that can be done on CPU without needing a GPU or a GPU driver.

ONNX runtime EP has one cache per ONNX. We try with a global cache. Just to collect different experiences.

pro global cache: cache can be shared between kernels
con global cache: cache can grow too big which can have negative perf implication. TRT docs recommend to not drop cache when growing to big

Needs to be validated if useful with #151 

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

