### PR TITLE
Synchronize in trtx::writeTensor to avoid race conditions.

### DIFF
--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -574,7 +574,9 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         stream
             .memcpy_htod(array, &mut cuda_tensor.memory)
             .to_write_tensor_result(|| tensor.clone())?;
-        stream.synchronize().to_write_tensor_result(|| tensor.clone())?;
+        stream
+            .synchronize()
+            .to_write_tensor_result(|| tensor.clone())?;
         Ok(())
     }
 

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -574,6 +574,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         stream
             .memcpy_htod(array, &mut cuda_tensor.memory)
             .to_write_tensor_result(|| tensor.clone())?;
+        stream.synchronize().to_write_tensor_result(|| tensor.clone())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The async host->device memcpy did not synchronize returning before the actual copy was done. This led to a race condition where the memory copied to the device had been freed and/or modified during the operation. A stream synchronize has been added to prevent this race condition until we get a true async interface.

## Validation

- [ ] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

