### PR TITLE
onnx: fix imported graph conversion semantics

### DIFF
--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -97,7 +97,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for OrtBuilder<'co
             .map_err(|e| GraphError::OnnxRuntimeFailed {
                 reason: format!("session builder failed: {e}"),
             })?
-            .with_optimization_level(GraphOptimizationLevel::Disable)
+            .with_optimization_level(GraphOptimizationLevel::All)
             .map_err(|e| GraphError::OnnxRuntimeFailed {
                 reason: format!("set opt level failed: {e}"),
             })?;
@@ -114,7 +114,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for OrtBuilder<'co
 
         ensure_ort_initialized().map_err(|e| Error::GraphBuildError { source: e.into() })?;
         let session = builder
-            .with_optimization_level(GraphOptimizationLevel::Disable)
+            .with_optimization_level(GraphOptimizationLevel::All)
             .map_err(|e| Error::GraphBuildError { source: e.into() })?
             .commit_from_memory(&converted.data)
             .map_err(|e| Error::GraphBuildError { source: e.into() })?;

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -2386,6 +2386,40 @@ impl crate::converters::GraphConverter for OnnxConverter {
         }
 
         for op in &graph.operations {
+            // For Cast, track the output type explicitly from the Cast's target type.
+            if let Operation::Cast { data_type: to, .. } = &op
+                && let Some(output_id) = op.output_operand()
+            {
+                let dt = DataType::from(*to);
+                type_overrides.insert(output_id, dt);
+            }
+
+            // Propagate Float16: if any input to this op is Float16 (from type_overrides or
+            // descriptor), mark the output as Float16.  This keeps fp16 models coherent through
+            // ops like Mul, Add, MatMul that inherit their dtype from inputs.
+            // Exclude Cast: its output type is determined by the `to` attribute, not inputs.
+            if !matches!(&op, Operation::Cast { .. })
+                && let Some(output_id) = op.output_operand()
+            {
+                let any_input_f16 = op.input_operands().iter().any(|&in_id| {
+                    type_overrides
+                        .get(&in_id)
+                        .copied()
+                        .or_else(|| graph.operand(in_id).map(|o| o.descriptor.data_type))
+                        == Some(DataType::Float16)
+                });
+                if any_input_f16 && !type_overrides.contains_key(&output_id) {
+                    let current = graph.operand(output_id).map(|o| o.descriptor.data_type);
+                    if current != Some(DataType::Int64)
+                        && current != Some(DataType::Int32)
+                        && current != Some(DataType::Uint8)
+                        && current != Some(DataType::Int8)
+                    {
+                        type_overrides.insert(output_id, DataType::Float16);
+                    }
+                }
+            }
+
             // Preserve input type for shape-only transforms regardless of shape inference success.
             if (matches!(&op, Operation::Unsqueeze { .. } | Operation::Squeeze { .. }))
                 && let (Some(output_id), Some(&input_id)) =
@@ -2590,6 +2624,9 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     | Operation::Pow { .. }
                     | Operation::Max { .. }
                     | Operation::Min { .. }
+                    | Operation::LogicalAnd { .. }
+                    | Operation::LogicalOr { .. }
+                    | Operation::LogicalXor { .. }
             ) {
                 // Track binary element-wise operation output shapes (use broadcasting)
                 if let Some(output_id) = op.output_operand()
@@ -2759,9 +2796,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 {
                     let axes_i64: Vec<i64> = axes_opts.axes.iter().map(|&u| u as i64).collect();
 
-                    if !axes_i64.is_empty() {
+                    if !axes_i64.is_empty() && !input_shape.is_empty() {
                         let axes_u32: Vec<u32> = axes_i64.iter().map(|&a| a as u32).collect();
-
                         let out_shape = infer_unsqueeze_shape(input_shape, &axes_u32)?;
                         shape_overrides.insert(output_id, out_shape.clone());
                         operand_shapes.insert(output_id, out_shape);
@@ -2861,6 +2897,15 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
             // Handle zero-length constants by creating zero-filled tensors
             // This is a defensive measure for malformed models where constants have no data
+            if data.data.is_empty() && std::env::var("RUSTNN_DEBUG").is_ok() {
+                eprintln!(
+                    "[ONNX DEBUG] constant operand {} ('{}') has empty data! dtype={:?} shape={:?}",
+                    id,
+                    operand_name(graph, *id),
+                    operand.descriptor.data_type,
+                    operand.descriptor.static_or_max_shape()
+                );
+            }
             let tensor_proto = if data.data.is_empty() {
                 let dtype = Self::data_type_code(operand.descriptor.data_type);
 
@@ -5010,52 +5055,48 @@ impl crate::converters::GraphConverter for OnnxConverter {
                 ));
                 inputs[0] = cast_name;
 
-                // Ensure both value inputs have identical dtype for ONNX Where.
+                if graph.operand(*true_id).is_none() {
+                    return Err(Self::invalid_operand(
+                        "where true input",
+                        *true_id,
+                        Some((op, idx)),
+                    ));
+                }
+                if graph.operand(*false_id).is_none() {
+                    return Err(Self::invalid_operand(
+                        "where false input",
+                        *false_id,
+                        Some((op, idx)),
+                    ));
+                }
+
+                // Track the output type from false value (the data tensor).
                 {
-                    let target_type = graph
-                        .operand(*true_id)
-                        .map(|operand| {
-                            type_overrides
-                                .get(true_id)
-                                .copied()
-                                .unwrap_or(operand.descriptor.data_type)
-                        })
-                        .ok_or_else(|| {
-                            Self::invalid_operand("where true input", *true_id, Some((op, idx)))
-                        })?;
-
-                    let true_cast_name = format!("{}_true_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_true_{}", op_name, cast_counter),
-                        inputs[1].clone(),
-                        true_cast_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs[1] = true_cast_name;
-
-                    // Validate false operand exists for clearer converter errors.
-                    if graph.operand(*false_id).is_none() {
-                        return Err(Self::invalid_operand(
-                            "where false input",
-                            *false_id,
-                            Some((op, idx)),
-                        ));
-                    }
-
-                    let false_cast_name = format!("{}_false_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_false_{}", op_name, cast_counter),
-                        inputs[2].clone(),
-                        false_cast_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs[2] = false_cast_name;
-
+                    let false_type = graph.operand(*false_id).map(|operand| {
+                        type_overrides
+                            .get(false_id)
+                            .copied()
+                            .unwrap_or(operand.descriptor.data_type)
+                    });
+                    let true_type = graph.operand(*true_id).map(|operand| {
+                        type_overrides
+                            .get(true_id)
+                            .copied()
+                            .unwrap_or(operand.descriptor.data_type)
+                    });
+                    let target_type = match (true_type, false_type) {
+                        (_, Some(DataType::Float16)) | (Some(DataType::Float16), _) => {
+                            DataType::Float16
+                        }
+                        (_, Some(ft)) => ft,
+                        (Some(tt), _) => tt,
+                        _ => DataType::Float32,
+                    };
                     if let Some(output_id) = op.output_operand() {
                         type_overrides.insert(output_id, target_type);
                     }
+                    // Do NOT insert explicit casts for true/false — ORT handles type alignment
+                    // internally and rejects explicit same-type casts as "InsertedPrecisionFreeCast".
                 }
 
                 let attributes = Self::create_operation_attributes(op);
@@ -7609,15 +7650,26 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     _ => None,
                 };
                 if let Some(new_shape_attr) = new_shape_attr {
-                    if let Some(shape_dims) = Self::parse_dimension_array(&new_shape_attr) {
-                        // Case 1: newShape is an array (static or dynamic)
-                        let has_dynamic = shape_dims
-                            .iter()
-                            .any(|d| matches!(d, Dimension::Dynamic(_)));
-                        if has_dynamic {
+                    // Try to extract i64 values directly (handles -1 "infer" markers from ONNX).
+                    let literal_i64s: Option<Vec<i64>> = new_shape_attr
+                        .as_array()
+                        .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
+                        .filter(|v: &Vec<i64>| {
+                            v.len() == new_shape_attr.as_array().map_or(0, |a| a.len())
+                        });
+
+                    if let Some(shape_values) = literal_i64s {
+                        // Contains literals (possibly including -1 for ONNX infer-dim).
+                        let has_dynamic_positive = shape_values.iter().all(|&v| v >= 0)
+                            && Self::parse_dimension_array(&new_shape_attr)
+                                .map(|dims| dims.iter().any(|d| matches!(d, Dimension::Dynamic(_))))
+                                .unwrap_or(false);
+                        if has_dynamic_positive {
+                            let dims: Vec<Dimension> =
+                                Self::parse_dimension_array(&new_shape_attr).unwrap();
                             let runtime_shape_name = Self::build_runtime_shape_input(
                                 &format!("{}_shape", op_name),
-                                &shape_dims,
+                                &dims,
                                 graph,
                                 op,
                                 &mut nodes,
@@ -7625,13 +7677,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             );
                             inputs.push(runtime_shape_name);
                         } else {
-                            let shape_values: Vec<i64> = shape_dims
-                                .iter()
-                                .map(|d| get_static_or_max_size(d) as i64)
-                                .collect();
                             let shape_name = format!("{}_shape", op_name);
                             inputs.push(shape_name.clone());
-
                             initializers.push(TensorProto {
                                 name: shape_name,
                                 data_type: ProtoDataType::Int64 as i32,
@@ -8765,21 +8812,14 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     _ => 0,
                 };
 
-                let attributes = vec![AttributeProto {
-                    name: "axis".to_string(),
-                    r#type: AttributeType::Int as i32,
-                    i: axis_attr as i64,
-                    ..Default::default()
-                }];
+                let axis = axis_attr as usize;
+                let num_outputs = op.output_operands().len();
 
                 let mut inputs: Vec<String> = op
                     .input_operands()
                     .iter()
                     .map(|id| operand_name(graph, *id))
                     .collect();
-
-                let axis = axis_attr as usize;
-                let num_outputs = op.output_operands().len();
                 let input_id = op.input_operands().first().copied().ok_or_else(|| {
                     GraphError::ConversionFailed {
                         format: "onnx".to_string(),
@@ -8790,36 +8830,49 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     Self::invalid_operand("split input lookup", input_id, Some((op, idx)))
                 })?;
                 let input_dtype = Self::data_type_code(input_operand.descriptor.data_type);
-                let input_shape = input_operand.descriptor.static_or_max_shape();
-                let rank = input_shape.len();
-                if axis >= rank {
-                    Self::eprintln_failed_operation_webnn_json(graph, idx);
-                    return Err(GraphError::ConversionFailed {
-                        format: "onnx".to_string(),
-                        reason: format!("split axis {} out of bounds for rank {}", axis_attr, rank),
+                // Prefer runtime-tracked shape (operand_shapes) over descriptor (may be empty).
+                let input_shape_opt: Option<Vec<u32>> = operand_shapes
+                    .get(&input_id)
+                    .filter(|s| !s.is_empty())
+                    .cloned()
+                    .or_else(|| {
+                        let s = input_operand.descriptor.static_or_max_shape();
+                        (!s.is_empty()).then_some(s)
                     });
-                }
-                let dim_at_axis: i64 = input_shape[axis] as i64;
 
-                let equal_sizes = || {
-                    (0..num_outputs)
-                        .map(|i| {
-                            let base = dim_at_axis / num_outputs as i64;
-                            let rem = dim_at_axis % num_outputs as i64;
-                            if (i as i64) < rem { base + 1 } else { base }
-                        })
-                        .collect::<Vec<i64>>()
+                let explicit_splits: Vec<i64> = match &op {
+                    Operation::Split { splits, .. } if !splits.is_empty() => {
+                        splits.iter().map(|&u| u as i64).collect()
+                    }
+                    _ => vec![],
                 };
 
-                let split_sizes: Vec<i64> = match &op {
-                    Operation::Split { splits, .. } => {
-                        if !splits.is_empty() {
-                            splits.iter().map(|&u| u as i64).collect()
-                        } else {
-                            equal_sizes()
-                        }
+                let split_sizes: Vec<i64> = if !explicit_splits.is_empty() {
+                    explicit_splits
+                } else if let Some(ref input_shape) = input_shape_opt {
+                    if axis >= input_shape.len() {
+                        Self::eprintln_failed_operation_webnn_json(graph, idx);
+                        return Err(GraphError::ConversionFailed {
+                            format: "onnx".to_string(),
+                            reason: format!(
+                                "split axis {} out of bounds for rank {}",
+                                axis_attr,
+                                input_shape.len()
+                            ),
+                        });
                     }
-                    _ => equal_sizes(),
+                    let dim = input_shape[axis] as i64;
+                    (0..num_outputs as i64)
+                        .map(|i| {
+                            let base = dim / num_outputs as i64;
+                            let rem = dim % num_outputs as i64;
+                            if i < rem { base + 1 } else { base }
+                        })
+                        .collect()
+                } else {
+                    // Unknown input shape and no explicit splits: omit split input,
+                    // use num_outputs attribute (ONNX opset 18 requires it in this case).
+                    vec![]
                 };
 
                 if !split_sizes.is_empty() {
@@ -8828,10 +8881,26 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         name: splits_name.clone(),
                         data_type: ProtoDataType::Int64 as i32,
                         dims: vec![split_sizes.len() as i64],
-                        int64_data: split_sizes,
+                        int64_data: split_sizes.clone(),
                         ..Default::default()
                     });
                     inputs.push(splits_name);
+                }
+
+                // Build attributes: axis always; num_outputs when split sizes are omitted (opset 18).
+                let mut attributes = vec![AttributeProto {
+                    name: "axis".to_string(),
+                    r#type: AttributeType::Int as i32,
+                    i: axis_attr as i64,
+                    ..Default::default()
+                }];
+                if split_sizes.is_empty() {
+                    attributes.push(AttributeProto {
+                        name: "num_outputs".to_string(),
+                        r#type: AttributeType::Int as i32,
+                        i: num_outputs as i64,
+                        ..Default::default()
+                    });
                 }
 
                 // ONNX Split may return float; wire Cast to float16 when graph expects float16.
@@ -9600,17 +9669,13 @@ impl crate::converters::GraphConverter for OnnxConverter {
 
                     inputs.push(operand_name(graph, cond_id));
 
-                    let true_type = graph
-                        .operand(true_id)
-                        .map(|operand| {
-                            type_overrides
-                                .get(&true_id)
-                                .copied()
-                                .unwrap_or(operand.descriptor.data_type)
-                        })
-                        .ok_or_else(|| {
-                            Self::invalid_operand("where true input", true_id, Some((op, idx)))
-                        })?;
+                    if graph.operand(true_id).is_none() {
+                        return Err(Self::invalid_operand(
+                            "where true input",
+                            true_id,
+                            Some((op, idx)),
+                        ));
+                    }
                     if graph.operand(false_id).is_none() {
                         return Err(Self::invalid_operand(
                             "where false input",
@@ -9619,29 +9684,31 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         ));
                     }
 
-                    let target_type = true_type;
+                    let true_type = graph.operand(true_id).map(|operand| {
+                        type_overrides
+                            .get(&true_id)
+                            .copied()
+                            .unwrap_or(operand.descriptor.data_type)
+                    });
+                    let false_type = graph.operand(false_id).map(|operand| {
+                        type_overrides
+                            .get(&false_id)
+                            .copied()
+                            .unwrap_or(operand.descriptor.data_type)
+                    });
 
-                    let true_input_name = operand_name(graph, true_id);
-                    let true_cast_output_name = format!("{}_true_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_true_{}", op_name, cast_counter),
-                        true_input_name,
-                        true_cast_output_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs.push(true_cast_output_name);
+                    let target_type = match (true_type, false_type) {
+                        (_, Some(DataType::Float16)) | (Some(DataType::Float16), _) => {
+                            DataType::Float16
+                        }
+                        (_, Some(ft)) => ft,
+                        (Some(tt), _) => tt,
+                        _ => DataType::Float32,
+                    };
 
-                    let false_input_name = operand_name(graph, false_id);
-                    let false_cast_output_name = format!("{}_false_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_false_{}", op_name, cast_counter),
-                        false_input_name,
-                        false_cast_output_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs.push(false_cast_output_name);
+                    // Pass inputs directly — no explicit casts to avoid ORT's InsertedPrecisionFreeCast issue.
+                    inputs.push(operand_name(graph, true_id));
+                    inputs.push(operand_name(graph, false_id));
 
                     let output_operand_id = op
                         .output_operand()
@@ -10343,6 +10410,29 @@ mod tests {
         crate::graph::to_dimension_vector(shape)
     }
 
+    fn value_info_elem_type(info: &ValueInfoProto) -> i32 {
+        match info
+            .r#type
+            .as_ref()
+            .and_then(|ty| ty.value.as_ref())
+            .expect("value info type")
+        {
+            crate::protos::onnx::type_proto::Value::TensorType(tensor_type) => {
+                tensor_type.elem_type
+            }
+            other => panic!("expected tensor value info, got {other:?}"),
+        }
+    }
+
+    fn output_elem_type(graph: &GraphProto, name: &str) -> i32 {
+        let info = graph
+            .output
+            .iter()
+            .find(|info| info.name == name)
+            .unwrap_or_else(|| panic!("missing graph output {name}"));
+        value_info_elem_type(info)
+    }
+
     #[test]
     fn test_data_type_code_int4() {
         let code = OnnxConverter::data_type_code(DataType::Int4);
@@ -10861,6 +10951,187 @@ mod tests {
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
         result.unwrap();
+    }
+
+    #[test]
+    fn test_cast_to_float16_declares_cast_output_type() {
+        let graph = GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("input".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        // This deliberately disagrees with the Cast target. The converter should
+                        // use the Cast's target type for ONNX output typing.
+                        data_type: DataType::Float32,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("output".to_string()),
+                },
+            ],
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operations: vec![Operation::Cast {
+                input: 0,
+                data_type: MLOperandDataType::Float16,
+                options: None,
+                outputs: vec![1],
+            }],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model = ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice())
+            .expect("decode model");
+        let graph_proto = model.graph.expect("graph");
+        assert_eq!(
+            output_elem_type(&graph_proto, "output"),
+            ProtoDataType::Float16 as i32
+        );
+    }
+
+    #[test]
+    fn test_float16_input_type_propagates_through_elementwise_output() {
+        let graph = GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float16,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("a".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float16,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("b".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        // Imported graphs can carry a stale/default descriptor here.
+                        data_type: DataType::Float32,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("sum".to_string()),
+                },
+            ],
+            input_operands: vec![0, 1],
+            output_operands: vec![2],
+            operations: vec![Operation::Add {
+                a: 0,
+                b: 1,
+                options: None,
+                outputs: vec![2],
+            }],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model = ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice())
+            .expect("decode model");
+        let graph_proto = model.graph.expect("graph");
+        assert_eq!(
+            output_elem_type(&graph_proto, "sum"),
+            ProtoDataType::Float16 as i32
+        );
+    }
+
+    #[test]
+    fn test_where_preserves_value_inputs_without_precision_free_casts() {
+        let graph = GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Uint8,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("cond".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float16,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("true_value".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float16,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("false_value".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        // Converter should infer this from the Where value inputs.
+                        data_type: DataType::Float32,
+                        shape: s(&[2]),
+                        pending_permutation: vec![],
+                    },
+                    name: Some("selected".to_string()),
+                },
+            ],
+            input_operands: vec![0, 1, 2],
+            output_operands: vec![3],
+            operations: vec![Operation::Where {
+                condition: 0,
+                true_value: 1,
+                false_value: 2,
+                options: None,
+                outputs: vec![3],
+            }],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model = ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice())
+            .expect("decode model");
+        let graph_proto = model.graph.expect("graph");
+        let where_node = graph_proto
+            .node
+            .iter()
+            .find(|node| node.op_type == "Where")
+            .expect("Where node");
+        assert_eq!(where_node.input[1], "true_value");
+        assert_eq!(where_node.input[2], "false_value");
+        assert!(
+            !graph_proto
+                .node
+                .iter()
+                .any(|node| node.name.contains("cast_true") || node.name.contains("cast_false")),
+            "Where value inputs should not receive explicit same-type casts"
+        );
+        assert_eq!(
+            output_elem_type(&graph_proto, "selected"),
+            ProtoDataType::Float16 as i32
+        );
     }
 
     #[cfg(not(feature = "dynamic-inputs"))]

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -2657,9 +2657,21 @@ impl Operation {
                 })
             }
             "layerNormalization" if !input_operands.is_empty() => {
+                let base_opts = attributes.as_layer_normalization().cloned();
+                // Positional args: (input, scale?, bias?) — merge into options.
+                let options = Some({
+                    let mut opts = base_opts.unwrap_or_default();
+                    if opts.scale.is_none() && input_operands.len() > 1 {
+                        opts.scale = Some(input_operands[1]);
+                    }
+                    if opts.bias.is_none() && input_operands.len() > 2 {
+                        opts.bias = Some(input_operands[2]);
+                    }
+                    opts
+                });
                 Some(Operation::LayerNormalization {
                     input: at(input_operands, 0)?,
-                    options: attributes.as_layer_normalization().cloned(),
+                    options,
                     outputs: outputs.to_vec(),
                 })
             }
@@ -2962,5 +2974,64 @@ impl Operation {
             &[],
             OperationExtras::default(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_normalization_uses_positional_scale_and_bias() {
+        let op = Operation::from_json_attributes(
+            "layerNormalization",
+            &[0, 1, 2],
+            &[3],
+            &serde_json::json!({
+                "axes": [1],
+                "epsilon": 0.00001
+            }),
+        )
+        .expect("layerNormalization from JSON");
+
+        match op {
+            Operation::LayerNormalization {
+                input,
+                options: Some(options),
+                outputs,
+            } => {
+                assert_eq!(input, 0);
+                assert_eq!(options.scale, Some(1));
+                assert_eq!(options.bias, Some(2));
+                assert_eq!(options.axes, Some(vec![1]));
+                assert_eq!(outputs, vec![3]);
+            }
+            other => panic!("expected layerNormalization, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn layer_normalization_keeps_explicit_scale_and_bias_options() {
+        let op = Operation::from_json_attributes(
+            "layerNormalization",
+            &[0, 1, 2],
+            &[3],
+            &serde_json::json!({
+                "scale": 7,
+                "bias": 8
+            }),
+        )
+        .expect("layerNormalization from JSON");
+
+        match op {
+            Operation::LayerNormalization {
+                options: Some(options),
+                ..
+            } => {
+                assert_eq!(options.scale, Some(7));
+                assert_eq!(options.bias, Some(8));
+            }
+            other => panic!("expected layerNormalization, got {other:?}"),
+        }
     }
 }

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -1593,23 +1593,29 @@ pub fn infer_expand_shape(input_shape: &[u32], new_shape: &[u32]) -> Result<Vec<
     // Align shapes from the right (trailing dimensions)
     let offset = output_rank - input_rank;
 
+    let mut output_shape = new_shape.to_vec();
     for i in 0..input_rank {
         let input_dim = input_shape[i];
-        let output_dim = new_shape[offset + i];
+        let new_dim = new_shape[offset + i];
 
-        // Input dimension must be 1 or match output dimension
-        if input_dim != 1 && input_dim != output_dim {
+        // ONNX Expand: output[i] = max(input[i], new_shape[i]) via broadcast rules:
+        // - if new_shape[i] == 1: output[i] = input[i] (keep)
+        // - if input[i] == 1:     output[i] = new_shape[i] (expand)
+        // - if input[i] == new_shape[i]: output[i] = input[i]
+        // - otherwise: error
+        if new_dim == 1 {
+            output_shape[offset + i] = input_dim;
+        } else if input_dim != 1 && input_dim != new_dim {
             return Err(GraphError::ShapeInferenceFailed {
                 reason: format!(
                     "Expand dimension {} mismatch: input {} can only expand if it's 1, but new_shape specifies {}, input shape: {:?}, new_shape: {:?}",
-                    i, input_dim, output_dim, input_shape, new_shape
+                    i, input_dim, new_dim, input_shape, new_shape
                 ),
             });
         }
     }
 
-    // Output shape is the new_shape
-    Ok(new_shape.to_vec())
+    Ok(output_shape)
 }
 
 fn propagate_expand_dimension(input_dim: &Dimension, target_dim: &Dimension) -> Dimension {
@@ -1667,15 +1673,24 @@ pub fn infer_expand_shape_dimensions(
 
         if let (Dimension::Static(in_static), Dimension::Static(out_static)) =
             (input_dim, target_dim)
-            && *in_static != 1
-            && *in_static != *out_static
         {
-            return Err(GraphError::ShapeInferenceFailed {
-                reason: format!(
-                    "Expand dimension {} mismatch: input {} can only expand if it's 1, but new_shape specifies {}, input shape: {:?}, new_shape: {:?}",
-                    i, in_static, out_static, input_shape, new_shape
-                ),
-            });
+            if *out_static == 1 {
+                // new_shape=1 means keep the input dimension (numpy broadcast rule)
+                output[offset + i] = input_dim.clone();
+                continue;
+            } else if *in_static != 1 && *in_static != *out_static {
+                return Err(GraphError::ShapeInferenceFailed {
+                    reason: format!(
+                        "Expand dimension {} mismatch: input {} can only expand if it's 1, but new_shape specifies {}, input shape: {:?}, new_shape: {:?}",
+                        i, in_static, out_static, input_shape, new_shape
+                    ),
+                });
+            }
+        }
+
+        if matches!(target_dim, Dimension::Static(1)) {
+            output[offset + i] = input_dim.clone();
+            continue;
         }
 
         if let (Dimension::Static(in_static), Dimension::Dynamic(_)) = (input_dim, target_dim)
@@ -1950,9 +1965,9 @@ pub fn infer_unsqueeze_shape(input_shape: &[u32], axes: &[u32]) -> Result<Vec<u3
     let input_rank = input_shape.len();
     let output_rank = input_rank + axes.len();
 
-    // Validate axes: must be in range [0, output_rank]
+    // Validate axes: must be in range [0, output_rank)
     for &axis in axes {
-        if axis > output_rank as u32 {
+        if axis >= output_rank as u32 {
             return Err(GraphError::ShapeInferenceFailed {
                 reason: format!(
                     "Unsqueeze axis {} out of bounds for output rank {}, input shape: {:?}",
@@ -1998,7 +2013,7 @@ pub fn infer_unsqueeze_shape_dimensions(
     let output_rank = input_rank + axes.len();
 
     for &axis in axes {
-        if axis > output_rank as u32 {
+        if axis >= output_rank as u32 {
             return Err(GraphError::ShapeInferenceFailed {
                 reason: format!(
                     "Unsqueeze axis {} out of bounds for output rank {}, input shape: {:?}",
@@ -3336,6 +3351,15 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_new_shape_one_keeps_input_dimension() {
+        assert_eq!(infer_expand_shape(&[2, 3], &[1, 3]).unwrap(), vec![2, 3]);
+        assert_eq!(
+            infer_expand_shape(&[4, 1, 8], &[1, 5, 1]).unwrap(),
+            vec![4, 5, 8]
+        );
+    }
+
+    #[test]
     fn test_expand_scalar() {
         // 0D (scalar) to various shapes
         assert_eq!(infer_expand_shape(&[], &[24]).unwrap(), vec![24]);
@@ -3383,6 +3407,16 @@ mod tests {
         .unwrap();
         assert_eq!(output[0], d("seq", 128));
         assert_eq!(output[1], Dimension::Static(32));
+    }
+
+    #[test]
+    fn test_expand_shape_dimensions_new_shape_one_keeps_dynamic_input() {
+        let output = infer_expand_shape_dimensions(
+            &[d("batch", 16), Dimension::Static(64)],
+            &[Dimension::Static(1), Dimension::Static(1)],
+        )
+        .unwrap();
+        assert_eq!(output, vec![d("batch", 16), Dimension::Static(64)]);
     }
 
     // Gather tests


### PR DESCRIPTION
Tighten imported graph behavior for model conversion by fixing Expand shape semantics, accepting `LayerNormalization` scale/bias as positional inputs, preserving fp16/logical ONNX conversion details, and keeping ORT optimization enabled. This is the generic correctness base for the later AOT/CoreML work, with the final goal of running all the models from the Parakeet family, to do ASR.

## Summary

- [x] Describe the user-visible and code-level changes.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks (N/A)

## Documentation

- [x] Updated docs if behavior changed (N/A)
- [x] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`
    - `python3 scripts/generate_backend_operator_report.py --check` reports `docs/development/backend-operator-support.md is up to date`. 

