### PR TITLE
feat: introduce RustNNOptions

### DIFF
--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -20,6 +20,7 @@ use crate::executors::coreml::{
     CompiledCoremlModel, CoremlByteInput, compile_model, run_coreml_bytes,
 };
 use crate::graph::DataType;
+use crate::mlcontext::RustNNOptions;
 use crate::mlcontext::{
     MLBackendBuilder, MLBackendContext, MLBackendGraph, MLGraph, MLTensor, MLTensorDescriptor,
 };
@@ -107,7 +108,10 @@ pub(crate) struct CoremlContext {
 }
 
 impl CoremlContext {
-    pub(crate) fn new_from_device_type(device_type: DeviceType) -> crate::error::Result<Self> {
+    pub(crate) fn new_from_device_type(
+        device_type: DeviceType,
+        _options: Option<&RustNNOptions>,
+    ) -> crate::error::Result<Self> {
         Ok(Self {
             device_type,
             tensors: Vec::new(),

--- a/src/backends/litert.rs
+++ b/src/backends/litert.rs
@@ -4,13 +4,14 @@ use std::fmt;
 use std::ptr::NonNull;
 use std::sync::OnceLock;
 
-use litert_sys as sys;
+use litert_sys::{self as sys};
 
 use crate::backend_selection::DeviceType;
 use crate::converters::{GraphConverter, LiteRtConverter};
 use crate::error::{Error, Result};
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
+    RustNNOptions,
 };
 
 use crate::operator_enums::MLOperandDataType;
@@ -284,7 +285,10 @@ impl fmt::Debug for LiteRtContext {
 }
 
 impl LiteRtContext {
-    pub(crate) fn new_from_device_type(device_type: DeviceType) -> Result<Self> {
+    pub(crate) fn new_from_device_type(
+        device_type: DeviceType,
+        _rustnn_options: Option<&RustNNOptions>,
+    ) -> Result<Self> {
         let _ = litert::set_global_log_severity(litert::LogSeverity::Warning);
         LiteRt::env();
         Ok(Self {
@@ -488,13 +492,13 @@ mod tests {
 
     #[test]
     fn test_context_new() {
-        let ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu).unwrap();
+        let ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu, None).unwrap();
         assert_eq!(ctx.tensors.len(), 0);
     }
 
     #[test]
     fn test_create_tensor() {
-        let mut ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu).unwrap();
+        let mut ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu, None).unwrap();
         let desc = make_desc(MLOperandDataType::Float32, vec![1, 4]);
         let tensor = ctx.create_tensor(&desc).unwrap();
         assert_eq!(tensor.id, 0);
@@ -504,7 +508,7 @@ mod tests {
 
     #[test]
     fn test_write_and_read_tensor() {
-        let mut ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu).unwrap();
+        let mut ctx = LiteRtContext::new_from_device_type(DeviceType::Cpu, None).unwrap();
         let desc = make_desc(MLOperandDataType::Float32, vec![2]);
         let tensor = ctx.create_tensor(&desc).unwrap();
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,4 +1,4 @@
-use crate::mlcontext;
+use crate::mlcontext::{self, RustNNOptions};
 
 pub mod caching;
 
@@ -24,6 +24,7 @@ impl DisabledContext {
     #[allow(dead_code)]
     pub(crate) fn new_from_device_type(
         _device_type: crate::backend_selection::DeviceType,
+        _options: Option<&RustNNOptions>,
     ) -> crate::error::Result<Self> {
         panic!("Tried to create a disabled device-typed backend");
     }
@@ -104,9 +105,13 @@ impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
 pub mod ort {
 
     pub(crate) use crate::backends::DisabledContext as OrtContext;
+    use crate::mlcontext::RustNNOptions;
 
     impl OrtContext {
-        pub(crate) fn new_from_ep_idx(_device_idx: usize) -> crate::error::Result<Self> {
+        pub(crate) fn new_from_ep_idx(
+            _device_idx: usize,
+            _options: Option<&RustNNOptions>,
+        ) -> crate::error::Result<Self> {
             panic!("Tried to create disabled ONNX backend");
         }
     }
@@ -115,9 +120,13 @@ pub mod ort {
 #[cfg(not(any(feature = "trtx-runtime", feature = "trtx-runtime-mock")))]
 pub mod trtx {
     pub(crate) use crate::backends::DisabledContext as TrtxContext;
+    use crate::mlcontext::RustNNOptions;
 
     impl TrtxContext {
-        pub(crate) fn new(_cuda_device_idx: u32) -> crate::error::Result<Self> {
+        pub(crate) fn new(
+            _cuda_device_idx: u32,
+            _options: Option<&RustNNOptions>,
+        ) -> crate::error::Result<Self> {
             panic!("Tried to create disabled Trtx backend");
         }
     }

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -19,6 +19,7 @@ use crate::executors::onnx::ensure_ort_initialized;
 use crate::graph::{pack_int4, pack_uint4_from_i32, unpack_int4, unpack_uint4};
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
+    RustNNOptions,
 };
 use crate::{GraphError, GraphInfo, ONNX_EXTERNAL_WEIGHTS_FILENAME};
 
@@ -572,7 +573,10 @@ pub(crate) struct OrtContext {
 }
 
 impl OrtContext {
-    pub(crate) fn new_from_ep_idx(device_idx: usize) -> crate::error::Result<Self> {
+    pub(crate) fn new_from_ep_idx(
+        device_idx: usize,
+        _options: Option<&RustNNOptions>,
+    ) -> crate::error::Result<Self> {
         ensure_ort_initialized().map_err(|e| Error::ContextCreationError { source: e.into() })?;
         let env =
             Environment::current().map_err(|e| Error::ContextCreationError { source: e.into() })?;
@@ -586,6 +590,7 @@ impl OrtContext {
     #[allow(dead_code)]
     pub(crate) fn new_from_ty(
         device_type: crate::backend_selection::DeviceType,
+        _options: Option<&RustNNOptions>,
     ) -> crate::error::Result<Self> {
         ensure_ort_initialized().map_err(|e| Error::ContextCreationError { source: e.into() })?;
         let env =

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -14,7 +14,7 @@ use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use trtx::CudaEngine;
 use trtx::ExecutionContext;
 use trtx::Refitter;
@@ -29,9 +29,11 @@ use crate::error::Error;
 
 use crate::error::GraphBuilderError;
 use crate::mlcontext::MLTensor;
+use crate::mlcontext::RustNNOptions;
 use crate::mlcontext::{ListDevices, MLOperand};
 use crate::mlcontext::{MLBackendBuilder, MLGraph};
 use crate::mlcontext::{MLBackendContext, MLBackendGraph};
+use crate::mlcontextoptions::TrtxOptions;
 
 const TRTX_JSON_DUMP_PATH_ENV_VAR: &str = "TRTX_JSON_DUMP_PATH";
 
@@ -196,18 +198,6 @@ impl Drop for CapturedCudaGraph {
     }
 }
 
-/// CUDA graph capture/replay around `enqueue_v3`. Disabled by default.
-/// Set `RUSTNN_TRTX_CUDA_GRAPHS=1` or `true` to enable.
-static TRTX_CUDA_GRAPHS_ENABLED: OnceLock<bool> = OnceLock::new();
-
-fn trtx_cuda_graphs_enabled() -> bool {
-    *TRTX_CUDA_GRAPHS_ENABLED.get_or_init(|| {
-        std::env::var("RUSTNN_TRTX_CUDA_GRAPHS")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    })
-}
-
 fn enqueue_inference_v3(
     exec: &mut ExecutionContext<'_>,
     inference_stream: &CudaStream,
@@ -249,6 +239,7 @@ pub(crate) struct TrtxContext<'context> {
     runtime: Arc<Mutex<trtx::Runtime<'context>>>,
     config: Arc<Mutex<trtx::BuilderConfig<'context>>>, // needs to be destroyed before builder
     builder: Arc<Mutex<trtx::Builder<'context>>>,
+    options: TrtxOptions,
 }
 
 impl std::fmt::Debug for TrtxContext<'_> {
@@ -267,7 +258,7 @@ static LOGGER: std::sync::LazyLock<trtx::Logger> =
     std::sync::LazyLock::new(|| trtx::Logger::log_crate().unwrap());
 
 impl<'context> TrtxContext<'context> {
-    pub(crate) fn new(cuda_device_idx: u32) -> TrtxResult<Self> {
+    pub(crate) fn new(cuda_device_idx: u32, options: Option<&RustNNOptions>) -> TrtxResult<Self> {
         // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
         let mut builder = trtx::Builder::new(&LOGGER)?;
@@ -289,6 +280,7 @@ impl<'context> TrtxContext<'context> {
             runtime,
             builder: Arc::new(builder.into()),
             config,
+            options: options.unwrap_or(&RustNNOptions::default()).trtx.clone(),
         })
     }
 }
@@ -519,7 +511,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             // can be enabled with more test coverage, but will remain a double-sided sword
             // e.g. if you change trtx converter, changes might not be visible, since cache skips conversion
             // maybe the build hash of certain trtx related files could be included in hash
-            caching_enabled: false,
+            caching_enabled: self.options.engine_caching,
         }))
     }
 
@@ -616,7 +608,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
 
         // TODO: set shape for dynamic networks and validate shape of input/output
         // tensors with what the network expect (done automatically by setting io_shapes?)
-        let cuda_graphs_enabled = trtx_cuda_graphs_enabled();
+        let cuda_graphs_enabled = self.options.cuda_graphs;
         let mut io_pointers = if cuda_graphs_enabled {
             Vec::with_capacity(inputs.len() + outputs.len())
         } else {
@@ -808,7 +800,7 @@ mod tests {
         use crate::{backends::trtx::TrtxContext, mlcontext::ListDevices};
         let devices = TrtxContext::list_devices();
         let context = if let [first, ..] = devices.as_slice() {
-            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+            TrtxContext::new(*first.as_trtx_device().unwrap(), None).unwrap()
         } else {
             return;
         };
@@ -821,7 +813,7 @@ mod tests {
         let _ = pretty_env_logger::try_init();
         let devices = TrtxContext::list_devices();
         let mut context = if let [first, ..] = devices.as_slice() {
-            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+            TrtxContext::new(*first.as_trtx_device().unwrap(), None).unwrap()
         } else {
             return;
         };
@@ -834,7 +826,7 @@ mod tests {
         let _ = pretty_env_logger::try_init();
         let devices = TrtxContext::list_devices();
         let mut context = if let [first, ..] = devices.as_slice() {
-            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+            TrtxContext::new(*first.as_trtx_device().unwrap(), None).unwrap()
         } else {
             return;
         };
@@ -864,7 +856,7 @@ mod tests {
         let _ = pretty_env_logger::try_init();
         let devices = TrtxContext::list_devices();
         let mut context = if let [first, ..] = devices.as_slice() {
-            TrtxContext::new(*first.as_trtx_device().unwrap()).unwrap()
+            TrtxContext::new(*first.as_trtx_device().unwrap(), None).unwrap()
         } else {
             return;
         };

--- a/src/executors/onnx.rs
+++ b/src/executors/onnx.rs
@@ -39,9 +39,7 @@ pub(crate) fn ensure_ort_initialized() -> Result<(), GraphError> {
             result = Err(e);
             return;
         }
-        let env = env.unwrap();
-        env.set_log_level(ort::logging::LogLevel::Verbose);
-        info!("Loaded");
+        info!("Loaded ONNX runtime");
     });
     result
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod graph;
 pub mod graphviz;
 pub mod loader;
 pub mod mlcontext;
+pub mod mlcontextoptions;
 pub mod mlgraphbuilder;
 pub mod operator_enums;
 pub mod operator_options;

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -19,6 +19,10 @@ use crate::backends::ort::OrtContext;
 use crate::backends::trtx::TrtxContext;
 use std::{collections::HashMap, fmt::Display, marker::PhantomData};
 
+pub use crate::mlcontextoptions::{
+    CoremlOptions, LiteRtOptions, MLContextOptions, MLPowerPreference, OrtOptions, RustNNOptions,
+    TrtxOptions,
+};
 pub use crate::mlgraphbuilder::MLGraphBuilder;
 use crate::{
     backend_selection::{select_backend, select_backend_by_gpu},
@@ -327,67 +331,6 @@ impl MLOperandDescriptor {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
-pub enum MLPowerPreference {
-    #[default]
-    Default,
-    HighPerformance,
-    LowPower,
-}
-
-/// https://www.w3.org/TR/webnn/#dictdef-mlcontextoptions
-/// https://www.w3.org/TR/webnn/#api-ml
-///
-/// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct MLContextOptions {
-    pub(crate) power_preference: MLPowerPreference,
-    pub(crate) accelerated: bool,
-
-    // ideas for possible rustnn specific options
-    // - backend preference
-    // - device_type (CPU, NPU, GPU) like pywebnn
-    pub(crate) device_hint: Option<BackendDevice>,
-    pub(crate) backend_hint: Option<Backend>,
-}
-
-impl MLContextOptions {
-    pub fn new(power_preference: MLPowerPreference, accelerated: bool) -> Self {
-        Self {
-            power_preference,
-            accelerated,
-            device_hint: None,
-            backend_hint: None,
-        }
-    }
-
-    pub fn power_preference(&self) -> MLPowerPreference {
-        self.power_preference
-    }
-
-    pub fn set_power_preference(&mut self, power_preference: MLPowerPreference) {
-        self.power_preference = power_preference;
-    }
-
-    pub fn accelerated(&self) -> bool {
-        self.accelerated
-    }
-
-    pub fn set_accelerated(&mut self, accelerated: bool) {
-        self.accelerated = accelerated;
-    }
-
-    pub fn with_rustnn_backend_hint(mut self, backend: Backend) -> Self {
-        self.backend_hint = Some(backend);
-        self
-    }
-
-    pub fn with_rustnn_device_hint(mut self, device: BackendDevice) -> Self {
-        self.device_hint = Some(device);
-        self
-    }
-}
-
 /// https://www.w3.org/TR/webnn/#dictdef-mltensordescriptor
 #[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct MLTensorDescriptor {
@@ -509,19 +452,19 @@ impl<'context> MLContext<'context> {
             .inspect_err(|e| log::warn!("Error selecting backend: {e:?}"))?;
         info!("Backend selected: {device:?}");
         let backend: Box<dyn MLBackendContext<'context> + 'context> = match device {
-            crate::backend_selection::BackendDevice::Onnx { ep_device_idx, .. } => {
-                Box::new(OrtContext::new_from_ep_idx(ep_device_idx)?)
-            }
+            crate::backend_selection::BackendDevice::Onnx { ep_device_idx, .. } => Box::new(
+                OrtContext::new_from_ep_idx(ep_device_idx, Some(&options.rustnn_options))?,
+            ),
             crate::backend_selection::BackendDevice::Trtx { cuda_device_idx } => Box::new(
-                TrtxContext::new(cuda_device_idx)
+                TrtxContext::new(cuda_device_idx, Some(&options.rustnn_options))
                     .map_err(|e| Error::ContextCreationError { source: e.into() })?,
             ),
-            crate::backend_selection::BackendDevice::Coreml { device_type } => {
-                Box::new(CoremlContext::new_from_device_type(device_type)?)
-            }
-            crate::backend_selection::BackendDevice::LiteRt { device_type } => {
-                Box::new(LiteRtContext::new_from_device_type(device_type)?)
-            }
+            crate::backend_selection::BackendDevice::Coreml { device_type } => Box::new(
+                CoremlContext::new_from_device_type(device_type, Some(&options.rustnn_options))?,
+            ),
+            crate::backend_selection::BackendDevice::LiteRt { device_type } => Box::new(
+                LiteRtContext::new_from_device_type(device_type, Some(&options.rustnn_options))?,
+            ),
         };
         Ok(Self { backend, device })
     }

--- a/src/mlcontextoptions.rs
+++ b/src/mlcontextoptions.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Nvidia
+//
+// SPDX-License-Identifier: Apache-2
+
+use crate::mlcontext::{Backend, BackendDevice};
+
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum MLPowerPreference {
+    #[default]
+    Default,
+    HighPerformance,
+    LowPower,
+}
+
+/// https://www.w3.org/TR/webnn/#dictdef-mlcontextoptions
+/// https://www.w3.org/TR/webnn/#api-ml
+///
+/// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct MLContextOptions {
+    // WebNN options
+    pub(crate) power_preference: MLPowerPreference,
+    pub(crate) accelerated: bool,
+
+    // RustNN specific options
+    pub(crate) device_hint: Option<BackendDevice>,
+    pub(crate) backend_hint: Option<Backend>,
+    pub(crate) rustnn_options: RustNNOptions,
+}
+
+impl MLContextOptions {
+    pub fn new(power_preference: MLPowerPreference, accelerated: bool) -> Self {
+        Self {
+            power_preference,
+            accelerated,
+            device_hint: None,
+            backend_hint: None,
+            rustnn_options: RustNNOptions::default(),
+        }
+    }
+
+    pub fn power_preference(&self) -> MLPowerPreference {
+        self.power_preference
+    }
+
+    pub fn set_power_preference(&mut self, power_preference: MLPowerPreference) {
+        self.power_preference = power_preference;
+    }
+
+    pub fn accelerated(&self) -> bool {
+        self.accelerated
+    }
+
+    pub fn set_accelerated(&mut self, accelerated: bool) {
+        self.accelerated = accelerated;
+    }
+
+    pub fn with_rustnn_backend_hint(mut self, backend: Backend) -> Self {
+        self.backend_hint = Some(backend);
+        self
+    }
+
+    pub fn with_rustnn_device_hint(mut self, device: BackendDevice) -> Self {
+        self.device_hint = Some(device);
+        self
+    }
+
+    pub fn with_rustnn_options(mut self, options: RustNNOptions) -> Self {
+        self.rustnn_options = options;
+        self
+    }
+}
+
+/// Options that steer backend or RustNN internals, experiments
+/// Could be replaced later by a proper API for RustNN options, internals and for backends
+#[derive(PartialEq, Eq, Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct RustNNOptions {
+    pub coreml: CoremlOptions,
+    pub litert: LiteRtOptions,
+    pub ort: OrtOptions,
+    pub trtx: TrtxOptions,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
+pub struct TrtxOptions {
+    pub engine_caching: bool,
+    pub cuda_graphs: bool,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for TrtxOptions {
+    fn default() -> Self {
+        Self {
+            // disabled for now, since feature experimental.
+            // can be enabled with more test coverage, but will remain a double-sided sword
+            // e.g. if you change trtx converter, changes might not be visible, since cache skips conversion
+            // maybe the build hash of certain trtx related files could be included in hash
+            engine_caching: false,
+            // Lower CPU overhead using CUDA graphs
+            cuda_graphs: false,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
+pub struct LiteRtOptions {}
+
+#[allow(clippy::derivable_impls)]
+impl Default for LiteRtOptions {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
+pub struct OrtOptions {}
+
+#[allow(clippy::derivable_impls)]
+impl Default for OrtOptions {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
+pub struct CoremlOptions {}
+
+#[allow(clippy::derivable_impls)]
+impl Default for CoremlOptions {
+    fn default() -> Self {
+        Self {}
+    }
+}


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Allows to have both global and backend-specific options.

At the moment strongly-typed with all public members. This will make adding/removing options a breaking change which we might want in the bring-up phase of RustNN.

Long-term stability could come from either:
- builder methods for options
- untyped key-value options
- strongly typed key-value options

EDIT: `#[non_exhaustive]` would also work to make adding new options or backend non-breaking


## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

