### PR TITLE
Fix cuda graphs

### DIFF
--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -671,7 +671,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                 }
                 let cuda_graph =
                     CapturedCudaGraph::finish_capture(inference_stream).to_dispatch_result()?;
-                // enqueue_v3 already ran during capture; only replay on later cache hits.
+                cuda_graph.launch().to_dispatch_result()?;
                 graph.cuda_graphs.insert(io_pointers, cuda_graph);
             }
         } else {

--- a/src/mlcontextoptions.rs
+++ b/src/mlcontextoptions.rs
@@ -99,7 +99,7 @@ impl Default for TrtxOptions {
             // maybe the build hash of certain trtx related files could be included in hash
             engine_caching: false,
             // Lower CPU overhead using CUDA graphs
-            cuda_graphs: false,
+            cuda_graphs: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Two line change to fix CUDA graph (they were not executed after being captured)  and make them the default.

on top of #181

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

All WPT tests pass. The following tests fail for trtx before and after change
```
    tests::test_equal_execution
    tests::test_gemm_basic_execution
    tests::test_gemm_beta_execution
    tests::test_greater_execution
    tests::test_greater_or_equal_execution
    tests::test_hard_swish_execution
    tests::test_is_infinite
    tests::test_is_nan
    tests::test_l2_pool2d
    tests::test_lesser_execution
    tests::test_lesser_or_equal_execution
    tests::test_logical_and_execution
    tests::test_logical_not_execution
    tests::test_logical_or_execution
    tests::test_logical_xor_execution
    tests::test_not_equal_execution
    tests::test_slice_with_stride_execution

```

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

