### PR TITLE
Add support to save a graph from the MLGraphBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ort = { version = "=2.0.0-rc.12", optional = true, features = [
     "api-24",
 ] }
 half = "2.4"
+safetensors = "0.7"
 trtx = { version = "0.7.1", optional = true }
 litert = { version = "0.2.1", optional = true }
 litert-sys = { version = "0.2.1", optional = true }
@@ -87,7 +88,6 @@ seahash = "4.1.0"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 tempfile = "3.8"
 half = "2.4"
-safetensors = "0.7"
 insta = { version = "1.47.2", features = ["yaml"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 dirs = "6.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -158,6 +158,14 @@ pub enum GraphBuilderError {
         source: CacheError,
     },
 
+    #[error(
+        "Failed to save: output name `{name}` conflicts with existing {operand_kind} operand (exported `.webnn` references operands by global name)"
+    )]
+    OutputNameConflictsWithOperand {
+        name: String,
+        operand_kind: &'static str,
+    },
+
     // TODO: this should not be needed, instead GraphInfo should ensure via methods to be always consistent
     // and impossible to construct invalid variants
     #[error("Internal error: inconsistent GraphInfo: {message}")]
@@ -294,6 +302,11 @@ pub enum Error {
 
     #[error("Failed to dispatch graph: {source}")]
     GraphDispatchError {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Failed to save graph: {source}")]
+    GraphSaveError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod shape_inference;
 pub mod tensor;
 pub mod validator;
 pub mod webnn_json;
+pub(crate) mod webnn_save;
 
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
 pub use executors::coreml;

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -2039,6 +2039,68 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         .ok()
     }
 
+    /// Save the in-progress graph (with `outputs` marked) as a rustnn `.webnn` text file plus a
+    /// sibling `.safetensors` weights file.
+    ///
+    /// This is a **rustnn-specific** extension (not part of the W3C WebNN API). Constants are
+    /// written to `<stem>.safetensors` next to `path` and referenced from the `.webnn` file via
+    /// `@weights(...)`, so the pair round-trips through [`crate::load_graph_from_path`].
+    ///
+    /// Like [`Self::build`], this takes the graph's `outputs` to finalize which operands are graph
+    /// outputs, but it borrows the builder read-only: the output names are handed to the exporter
+    /// as an override, so neither the graph nor its constant weight bytes are copied or mutated, and
+    /// the builder can still be built afterwards.
+    pub fn rustnn_save_webnn(
+        &self,
+        outputs: &HashMap<&str, MLOperand>,
+        path: impl AsRef<std::path::Path>,
+    ) -> crate::error::Result<()> {
+        if outputs.is_empty() {
+            return Err(GraphBuilderError::EmptyOutputHashMap.into());
+        }
+        let graph = self
+            .graph
+            .as_ref()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+
+        // Build the operand-id -> output-name override for the exporter, validating as we go.
+        // Two names for the same operand (aliasing) would collide here, so we reject it like
+        // `build()` does. Output names are unique by construction (they are the `outputs` map keys).
+        let mut output_names = HashMap::<u32, String>::with_capacity(outputs.len());
+        for (name, operand) in outputs {
+            let op = graph.operands.get(operand.id).ok_or(
+                GraphBuilderError::BuildWithInvalidOperand {
+                    operand: *operand,
+                    name: name.to_string(),
+                },
+            )?;
+            if op.kind == OperandKind::Input {
+                return Err(GraphBuilderError::RequestedInputAsOutput {
+                    operand: op.clone(),
+                    id: operand.id,
+                }
+                .into());
+            } else if op.kind == OperandKind::Constant {
+                return Err(GraphBuilderError::RequestedConstantAsOutput {
+                    operand: op.clone(),
+                    id: operand.id,
+                }
+                .into());
+            }
+            if let Some(first_name) = output_names.insert(operand.id as u32, name.to_string()) {
+                return Err(GraphBuilderError::DuplicateOutput {
+                    operand: *operand,
+                    first_name,
+                    second_name: name.to_string(),
+                }
+                .into());
+            }
+        }
+
+        crate::webnn_save::validate_save_output_names(graph, &output_names)?;
+        crate::webnn_save::write_webnn_and_safetensors(graph, &output_names, path.as_ref())
+    }
+
     /*async*/
     pub fn build(
         &mut self,
@@ -3284,5 +3346,177 @@ mod test {
         let mut outputs = HashMap::new();
         outputs.insert("out", dq);
         builder.build(&outputs).unwrap();
+    }
+
+    #[test]
+    fn rustnn_save_webnn_round_trips_through_loader() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
+            return;
+        };
+        let mut context = context.unwrap();
+
+        let mat_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let a = builder.input("a", &mat_desc).unwrap();
+        let b = builder
+            .constant_from_slice(&mat_desc, &[1.0f32, 2.0, 3.0, 4.0])
+            .unwrap();
+        let sum = builder.add(a, b).unwrap();
+
+        let mut outputs = HashMap::new();
+        outputs.insert("sum", sum);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let webnn_path = temp_dir.path().join("model.webnn");
+        builder.rustnn_save_webnn(&outputs, &webnn_path).unwrap();
+
+        let webnn_text = std::fs::read_to_string(&webnn_path).unwrap();
+        assert!(webnn_text.contains("@weights("));
+        assert!(!webnn_text.contains("@bytes("));
+
+        let st_path = webnn_path.with_extension("safetensors");
+        assert!(st_path.exists());
+
+        // Saving does not consume the builder: it can still be built.
+        builder.build(&outputs).unwrap();
+
+        let loaded = crate::load_graph_from_path(&webnn_path).expect("reload saved graph");
+        assert_eq!(loaded.input_operands.len(), 1);
+        assert_eq!(loaded.output_operands.len(), 1);
+        assert_eq!(loaded.constant_operand_ids_to_handles.len(), 1);
+
+        let constant = loaded
+            .constant_operand_ids_to_handles
+            .values()
+            .next()
+            .unwrap();
+        let expected: Vec<u8> = [1.0f32, 2.0, 3.0, 4.0]
+            .iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+        assert_eq!(constant.data, expected);
+    }
+
+    #[test]
+    fn rustnn_save_webnn_emits_named_constant_weight_ref() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
+            return;
+        };
+        let mut context = context.unwrap();
+
+        let scalar_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [].to_vec(),
+        );
+        let mat_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let a = builder.input("a", &mat_desc).unwrap();
+        let scale = builder
+            .constant_from_slice(&scalar_desc, &[0.5f32])
+            .unwrap();
+        let out = builder.mul(a, scale).unwrap();
+
+        let mut outputs = HashMap::new();
+        outputs.insert("out", out);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let webnn_path = temp_dir.path().join("scaled.webnn");
+        builder.rustnn_save_webnn(&outputs, &webnn_path).unwrap();
+
+        let text = std::fs::read_to_string(&webnn_path).unwrap();
+        // unnamed constants get operand_<id> names
+        assert!(text.contains("@weights(\"operand_"));
+    }
+
+    #[test]
+    fn rustnn_save_webnn_rejects_output_name_colliding_with_input() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
+            return;
+        };
+        let mut context = context.unwrap();
+
+        let mat_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let a = builder.input("a", &mat_desc).unwrap();
+        let b = builder
+            .constant_from_slice(&mat_desc, &[1.0f32, 2.0, 3.0, 4.0])
+            .unwrap();
+        let sum = builder.add(a, b).unwrap();
+
+        let mut outputs = HashMap::new();
+        outputs.insert("a", sum);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let webnn_path = temp_dir.path().join("collision.webnn");
+        let err = builder
+            .rustnn_save_webnn(&outputs, &webnn_path)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::GraphBuilderError {
+                source: crate::error::GraphBuilderError::OutputNameConflictsWithOperand {
+                    name,
+                    operand_kind: "input",
+                }
+            } if name == "a"
+        ));
+        assert!(!webnn_path.exists());
+    }
+
+    #[test]
+    fn rustnn_save_webnn_rejects_duplicate_output_operand() {
+        let _ = pretty_env_logger::try_init();
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
+            return;
+        };
+        let mut context = context.unwrap();
+
+        let mat_desc = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            [2, 2].to_vec(),
+        );
+
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let a = builder.input("x", &mat_desc).unwrap();
+        let b = builder
+            .constant_from_slice(&mat_desc, &[1.0f32, 2.0, 3.0, 4.0])
+            .unwrap();
+        let sum = builder.add(a, b).unwrap();
+
+        let mut outputs = HashMap::new();
+        outputs.insert("out1", sum);
+        outputs.insert("out2", sum);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let webnn_path = temp_dir.path().join("dup.webnn");
+        let err = builder
+            .rustnn_save_webnn(&outputs, &webnn_path)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::GraphBuilderError {
+                source: crate::error::GraphBuilderError::DuplicateOutput { .. }
+            }
+        ));
+        assert!(!webnn_path.exists());
     }
 }

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -27,6 +27,37 @@ use crate::operators::Operation;
 use std::collections::{BTreeMap, HashMap};
 use webnn_graph::ast::{ConstDecl, ConstInit, GraphJson, Node, OperandDesc};
 
+/// The name used for an operand in the exported AST (and, for constants, as the safetensors tensor
+/// key and `@weights(...)` reference). Falls back to `operand_<idx>` when the operand is unnamed.
+///
+/// Shared by the AST builder and the `.webnn`/`.safetensors` exporter so both agree on the scheme.
+pub(crate) fn operand_export_name(operand: &Operand, idx: usize) -> String {
+    operand
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("operand_{}", idx))
+}
+
+/// Maps operand id -> the name it should be exported under, overriding [`operand_export_name`].
+///
+/// Used by the builder's save path to name graph outputs without mutating the operands: the same
+/// override must apply everywhere the operand is referenced (node inputs, node outputs, and the
+/// graph `outputs` section) so all references stay consistent.
+pub(crate) type OutputNameOverrides = HashMap<u32, String>;
+
+/// Like [`operand_export_name`], but consults `overrides` first so callers can rename operands
+/// (e.g. mark them as named graph outputs) without touching the `GraphInfo`.
+fn operand_export_name_with_overrides(
+    operand: &Operand,
+    idx: usize,
+    overrides: Option<&OutputNameOverrides>,
+) -> String {
+    if let Some(name) = overrides.and_then(|o| o.get(&(idx as u32))) {
+        return name.clone();
+    }
+    operand_export_name(operand, idx)
+}
+
 /// Convert our DataType to webnn-graph DataType
 fn to_webnn_datatype(dt: &DataType) -> webnn_graph::ast::DataType {
     match dt {
@@ -88,6 +119,16 @@ pub fn graph_operation_to_webnn_node(
     graph: &GraphInfo,
     op_index: usize,
 ) -> Result<Node, GraphError> {
+    graph_operation_to_webnn_node_with_overrides(graph, op_index, None)
+}
+
+/// Same as [`graph_operation_to_webnn_node`], but operand names can be overridden (see
+/// [`OutputNameOverrides`]). Used by the save path to name graph outputs without mutating operands.
+fn graph_operation_to_webnn_node_with_overrides(
+    graph: &GraphInfo,
+    op_index: usize,
+    overrides: Option<&OutputNameOverrides>,
+) -> Result<Node, GraphError> {
     let operation = graph
         .operations
         .get(op_index)
@@ -101,10 +142,11 @@ pub fn graph_operation_to_webnn_node(
         .input_operands()
         .iter()
         .map(|&idx| {
-            graph.operands[idx as usize]
-                .name
-                .clone()
-                .unwrap_or_else(|| format!("operand_{}", idx))
+            operand_export_name_with_overrides(
+                &graph.operands[idx as usize],
+                idx as usize,
+                overrides,
+            )
         })
         .collect();
 
@@ -116,10 +158,11 @@ pub fn graph_operation_to_webnn_node(
             output_operands
                 .iter()
                 .map(|&idx| {
-                    graph.operands[idx as usize]
-                        .name
-                        .clone()
-                        .unwrap_or_else(|| format!("operand_{}", idx))
+                    operand_export_name_with_overrides(
+                        &graph.operands[idx as usize],
+                        idx as usize,
+                        overrides,
+                    )
                 })
                 .collect(),
         )
@@ -141,8 +184,37 @@ pub fn graph_operation_to_webnn_node(
     })
 }
 
-/// Convert GraphInfo to GraphJson
+/// Controls how constant operands are represented when building the AST.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConstExport {
+    /// Embed constant bytes directly in the AST as `ConstInit::InlineBytes` (clones the data).
+    Inline,
+    /// Emit a `ConstInit::Weights { ref }` reference instead, leaving the bytes out of the AST.
+    /// Callers are responsible for writing the weights out (e.g. to a sidecar safetensors file).
+    ExternalWeights,
+}
+
+/// Convert GraphInfo to GraphJson, embedding constant data inline.
 pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, GraphError> {
+    to_graph_json_with_consts(graph, quantized, ConstExport::Inline, None)
+}
+
+/// Convert GraphInfo to GraphJson, choosing how constants are represented.
+///
+/// With [`ConstExport::ExternalWeights`] the constant bytes are not copied into the AST; each
+/// constant becomes a `@weights(...)` reference keyed by the same name used here (`operand.name`,
+/// else `operand_<idx>`). This is the zero-copy path used by the `.webnn`/`.safetensors` exporter.
+///
+/// When `output_override` is `Some`, the graph `outputs` section (and the corresponding operand
+/// names in nodes) is taken from the override map instead of `graph.output_operands`. This lets the
+/// builder export a graph's outputs without mutating operand kinds/names first. When `None`, outputs
+/// are read from `graph.output_operands` using each operand's own name.
+pub(crate) fn to_graph_json_with_consts(
+    graph: &GraphInfo,
+    quantized: bool,
+    const_export: ConstExport,
+    output_override: Option<&OutputNameOverrides>,
+) -> Result<GraphJson, GraphError> {
     let mut inputs = BTreeMap::new();
     let mut consts = BTreeMap::new();
     let mut nodes = Vec::new();
@@ -150,10 +222,7 @@ pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, Gr
 
     // Process operands - separate inputs and constants
     for (idx, operand) in graph.operands.iter().enumerate() {
-        let name = operand
-            .name
-            .clone()
-            .unwrap_or_else(|| format!("operand_{}", idx));
+        let name = operand_export_name(operand, idx);
 
         match &operand.kind {
             OperandKind::Input => {
@@ -184,8 +253,13 @@ pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, Gr
                                     operand.name.as_deref().unwrap_or("unknown")
                                 ),
                             })?;
-                    let init = ConstInit::InlineBytes {
-                        bytes: constant.data.clone(),
+                    let init = match const_export {
+                        ConstExport::Inline => ConstInit::InlineBytes {
+                            bytes: constant.data.clone(),
+                        },
+                        ConstExport::ExternalWeights => ConstInit::Weights {
+                            r#ref: name.clone(),
+                        },
                     };
 
                     consts.insert(
@@ -209,17 +283,30 @@ pub fn to_graph_json(graph: &GraphInfo, quantized: bool) -> Result<GraphJson, Gr
 
     // Process operations
     for op_idx in 0..graph.operations.len() {
-        nodes.push(graph_operation_to_webnn_node(graph, op_idx)?);
+        nodes.push(graph_operation_to_webnn_node_with_overrides(
+            graph,
+            op_idx,
+            output_override,
+        )?);
     }
 
-    // Process outputs from graph.output_operands
-    for &operand_idx in &graph.output_operands {
-        if let Some(operand) = graph.operands.get(operand_idx as usize) {
-            let name = operand
-                .name
-                .clone()
-                .unwrap_or_else(|| format!("operand_{}", operand_idx));
-            outputs.insert(name.clone(), name);
+    // Process outputs. Prefer the caller-supplied override (builder save path) so we don't need to
+    // mutate operands; otherwise read the finalized `graph.output_operands`.
+    match output_override {
+        Some(override_names) => {
+            for (&operand_idx, name) in override_names {
+                if graph.operands.get(operand_idx as usize).is_some() {
+                    outputs.insert(name.clone(), name.clone());
+                }
+            }
+        }
+        None => {
+            for &operand_idx in &graph.output_operands {
+                if let Some(operand) = graph.operands.get(operand_idx as usize) {
+                    let name = operand_export_name(operand, operand_idx as usize);
+                    outputs.insert(name.clone(), name);
+                }
+            }
         }
     }
 

--- a/src/webnn_save.rs
+++ b/src/webnn_save.rs
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Save a rustnn source graph to the `.webnn` text format plus a sibling `.safetensors`
+//! weights file.
+//!
+//! This is a **rustnn-specific** extension, not part of the W3C WebNN API. Constants are written
+//! as external `@weights(...)` references so the emitted `.webnn` file stays compact and the pair
+//! round-trips through [`crate::load_graph_from_path`].
+//!
+//! The exporter operates on a backend-agnostic [`GraphInfo`], so it is available from
+//! [`crate::mlgraphbuilder::MLGraphBuilder`] regardless of the execution backend, as long as the
+//! constants are held in host memory (which is the case for graphs authored via the builder API).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use webnn_graph::ast::DataType as AstDataType;
+use webnn_graph::serialize::{SerializeOptions, serialize_graph_to_wg_text};
+
+use crate::error::{Error, GraphBuilderError, Result};
+use crate::graph::{GraphInfo, OperandKind};
+use crate::webnn_json::{
+    ConstExport, OutputNameOverrides, operand_export_name, to_graph_json_with_consts,
+};
+
+fn ast_dtype_to_safetensors(dt: &AstDataType) -> Option<safetensors::Dtype> {
+    use safetensors::Dtype as S;
+    Some(match dt {
+        AstDataType::Float32 => S::F32,
+        AstDataType::Float16 => S::F16,
+        AstDataType::Int32 => S::I32,
+        AstDataType::Uint32 => S::U32,
+        AstDataType::Int64 => S::I64,
+        AstDataType::Uint64 => S::U64,
+        AstDataType::Int8 => S::I8,
+        AstDataType::Uint8 => S::U8,
+        // safetensors has no 4-bit dtypes; these cannot be represented externally.
+        AstDataType::Int4 | AstDataType::Uint4 => return None,
+    })
+}
+
+fn save_err(msg: impl Into<String>) -> Error {
+    Error::GraphSaveError {
+        source: msg.into().into(),
+    }
+}
+
+/// Reject output names that collide with an exported input or constant name.
+///
+/// The `.webnn` format references operands by global name strings in nodes, so an output cannot
+/// share a name with an input or constant even though WebNN dispatch keeps inputs and outputs in
+/// separate maps at runtime.
+pub(crate) fn validate_save_output_names(
+    graph: &GraphInfo,
+    output_names: &OutputNameOverrides,
+) -> std::result::Result<(), GraphBuilderError> {
+    for (idx, operand) in graph.operands.iter().enumerate() {
+        let (operand_kind, exported) = match operand.kind {
+            OperandKind::Input => ("input", operand_export_name(operand, idx)),
+            OperandKind::Constant => ("constant", operand_export_name(operand, idx)),
+            _ => continue,
+        };
+        for out_name in output_names.values() {
+            if out_name == &exported {
+                return Err(GraphBuilderError::OutputNameConflictsWithOperand {
+                    name: out_name.clone(),
+                    operand_kind,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Serialize `graph_info` to `webnn_path` (text) and its constants to `<stem>.safetensors`.
+///
+/// `output_names` maps each output operand id to the name it should be exported under. The exporter
+/// uses it to render the graph's `outputs` section without mutating `graph_info`, so callers (e.g.
+/// the builder) can save while keeping the graph intact.
+///
+/// Constant operand names mirror [`to_graph_json`] (`operand.name`, else `operand_<idx>`), which is
+/// also the tensor key used in the safetensors archive and the `@weights(...)` reference.
+pub(crate) fn write_webnn_and_safetensors(
+    graph_info: &GraphInfo,
+    output_names: &OutputNameOverrides,
+    webnn_path: &Path,
+) -> Result<()> {
+    // `to_graph_json_with_consts` returns `webnn_graph::ast::GraphJson`, which is the typed AST
+    // (not a JSON file on disk). The name is historical; see
+    // https://github.com/rustnn/webnn-graph/issues/17
+    // Build the AST with constants emitted as external `@weights(...)` references. This avoids
+    // copying the constant bytes into the AST; we serialize them straight from `graph_info` below.
+    // The outputs section is taken from `output_names` so we never mutate `graph_info`.
+    let webnn_ast = to_graph_json_with_consts(
+        graph_info,
+        graph_info.quantized,
+        ConstExport::ExternalWeights,
+        Some(output_names),
+    )
+    .map_err(|e| Error::GraphSaveError { source: e.into() })?;
+
+    // Map constant operand name -> raw bytes, using the same naming scheme as `to_graph_json`.
+    let mut const_bytes: HashMap<String, &[u8]> = HashMap::new();
+    for (idx, operand) in graph_info.operands.iter().enumerate() {
+        if operand.kind != OperandKind::Constant {
+            continue;
+        }
+        if let Some(constant) = graph_info
+            .constant_operand_ids_to_handles
+            .get(&(idx as u32))
+        {
+            const_bytes.insert(operand_export_name(operand, idx), constant.data.as_slice());
+        }
+    }
+
+    // Build safetensors views by borrowing the bytes directly from `graph_info` (no copy). The AST
+    // already references each constant via `@weights(<name>)`, so we only need matching tensors.
+    let mut views: Vec<(String, safetensors::tensor::TensorView<'_>)> = Vec::new();
+    for (name, decl) in webnn_ast.consts.iter() {
+        let bytes = *const_bytes
+            .get(name)
+            .ok_or_else(|| save_err(format!("constant `{name}` has no data to save")))?;
+        let dtype = ast_dtype_to_safetensors(&decl.data_type).ok_or_else(|| {
+            save_err(format!(
+                "constant `{name}` has data type {:?} which cannot be stored in safetensors",
+                decl.data_type
+            ))
+        })?;
+        let shape: Vec<usize> = decl.shape.iter().map(|&d| d as usize).collect();
+        let view = safetensors::tensor::TensorView::new(dtype, shape, bytes)
+            .map_err(|e| save_err(format!("constant `{name}`: {e}")))?;
+        views.push((name.clone(), view));
+    }
+
+    let st_bytes = safetensors::serialize(views, None)
+        .map_err(|e| save_err(format!("failed to serialize safetensors: {e}")))?;
+
+    let text = serialize_graph_to_wg_text(
+        &webnn_ast,
+        SerializeOptions {
+            quantized: graph_info.quantized,
+        },
+    )
+    .map_err(|e| Error::GraphSaveError { source: e.into() })?;
+
+    std::fs::write(webnn_path, text)
+        .map_err(|e| save_err(format!("failed to write `{}`: {e}", webnn_path.display())))?;
+
+    let st_path = webnn_path.with_extension("safetensors");
+    if let Err(e) = std::fs::write(&st_path, st_bytes) {
+        let _ = std::fs::remove_file(webnn_path);
+        return Err(save_err(format!(
+            "failed to write `{}`: {e}",
+            st_path.display()
+        )));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

For exporter and debugging reasons we want to use the MLGraphBuilder interface to validate and save the graph to avoid duplicated code logic. Another benefit is that we can validate the export and safe it a single export step.

To support those use cases the function rustnn_save_webnn has been added to the MLGraphBuilder interface.

## Validation

- [x] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

