### PR TITLE
fix: remove `set_cuda_graph_strategy`

### DIFF
--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -449,11 +449,8 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         }
         refitter.refit_cuda_engine()?;
 
-        let mut runtime_config = engine
+        let runtime_config = engine
             .create_runtime_config()
-            .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
-        runtime_config
-            .set_cuda_graph_strategy(trtx::CudaGraphStrategy::kDISABLED)
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
         let exec = engine
             .create_execution_context_with_config(Rc::new(runtime_config))

--- a/src/executors/trtx.rs
+++ b/src/executors/trtx.rs
@@ -186,9 +186,7 @@ fn execute_trtx_engine(
 
     // Deserialize engine
     let mut engine = runtime.deserialize_cuda_engine(engine_bytes)?;
-    let mut runtime_config = engine.create_runtime_config()?;
-    // we do graph capturing ourself
-    runtime_config.set_cuda_graph_strategy(trtx::CudaGraphStrategy::kDISABLED)?;
+    let runtime_config = engine.create_runtime_config()?;
     let mut context = engine.create_execution_context_with_config(Rc::new(runtime_config))?;
 
     // Get tensor information


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

This allows to compile trtx-rs with `enterprise` feature to check webnn graphs with enterprise.

The function call does nothing anyways since `trtx::CudaGraphStrategy::kDISABLED` is the default. Was added originally more for documentation than any effect.

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

