### PR TITLE
fix(trtx): improve trtx engine caching and general cache logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ objc = { version = "0.2", optional = true, features = ["exception"] }
 [build-dependencies]
 prost-build = "0.12"
 cc = "1.0"
+seahash = "4.1.0"
 
 [dev-dependencies]
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
-#[cfg(feature = "litert-runtime")]
-use std::env;
-use std::fs;
-use std::path::Path;
+use std::hash::Hasher;
+use std::io::Read;
 #[cfg(feature = "litert-runtime")]
 use std::process::Command;
+use std::{env, fs};
+use std::{fs::File, path::Path};
+
+use seahash::SeaHasher;
 
 fn collect_protos(dir: &str) -> Vec<String> {
     let mut files = Vec::new();
@@ -69,6 +71,35 @@ fn build_coreml_protos() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn create_source_hash(source_files: &[&str]) {
+    let mut hasher = SeaHasher::new();
+    let mut buffer = Vec::new();
+
+    for file_path in source_files {
+        // Tell Cargo to rerun if ANY of these files change
+        println!("cargo:rerun-if-changed={}", file_path);
+
+        // Only hash the file if it actually exists (prevents crashing if a file is optional)
+        if Path::new(file_path).exists() {
+            let mut file = File::open(file_path).unwrap();
+            buffer.clear(); // Reuse the same buffer to save allocations
+            file.read_to_end(&mut buffer).unwrap();
+
+            // Feed this file's bytes into the running hash state
+            hasher.write(&buffer);
+        }
+    }
+
+    // 2. Finalize the combined hash
+    let total_hash = hasher.finish();
+    let hash_string = format!("{:016x}", total_hash);
+
+    // 3. Write the combined hash out
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("source_hash.txt");
+    fs::write(dest_path, hash_string).unwrap();
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Only compile CoreML protos - ONNX protos come from webnn-onnx-utils
     build_coreml_protos()?;
@@ -98,5 +129,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=protos");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=OUT_DIR");
+
+    create_source_hash(&[
+        "src/converters/trtx.rs",
+        "src/converters/trtx_gru.rs",
+        "src/converters/trtx_lstm.rs",
+        "src/converters/trtx_rnn.rs",
+    ]);
     Ok(())
 }

--- a/examples/resnet50_webnn_rust.rs
+++ b/examples/resnet50_webnn_rust.rs
@@ -343,6 +343,7 @@ fn run() -> Result<(), String> {
 }
 
 fn main() {
+    pretty_env_logger::init();
     if let Err(err) = run() {
         eprintln!("error: {err}");
         std::process::exit(1);

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -28,6 +28,7 @@ use crate::converters::TrtxConverter;
 use crate::error::Error;
 
 use crate::error::GraphBuilderError;
+use crate::graph::WeightsToHash;
 use crate::mlcontext::MLTensor;
 use crate::mlcontext::RustNNOptions;
 use crate::mlcontext::{ListDevices, MLOperand};
@@ -83,6 +84,10 @@ pub enum TrtxError {
         #[from]
         source: trtx::Error,
     },
+    #[error(
+        "Engine cache miss: cache_key={cache_key:?}. Failed engine build because TrtxOptions::fail_on_cache_miss options was enabled"
+    )]
+    TrtxEngineCacheMiss { cache_key: Option<String> },
 }
 pub type TrtxResult<T> = std::result::Result<T, TrtxError>;
 
@@ -295,6 +300,7 @@ pub(crate) struct TrtxBuilder<'builder> {
     operands: HashMap<String, MLOperand>,
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
+    fail_on_cache_miss: bool,
 }
 
 impl std::fmt::Debug for TrtxBuilder<'_> {
@@ -303,14 +309,17 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
     }
 }
 
+const SOURCE_HASH: &str = include_str!(concat!(env!("OUT_DIR"), "/source_hash.txt"));
+
 static ENGINE_CACHE: LazyLock<CacheResult<DefaultCache>> =
     LazyLock::new(|| DefaultCache::new("trtx"));
 static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "trtx_{}.{}.{}",
+        "trtx_{}.{}.{}_{}",
         unsafe { trtx::trtx_sys::get_tensorrt_major_version() },
         unsafe { trtx::trtx_sys::get_tensorrt_minor_version() },
-        unsafe { trtx::trtx_sys::get_tensorrt_patch_version() }
+        unsafe { trtx::trtx_sys::get_tensorrt_patch_version() },
+        SOURCE_HASH
     )
 });
 
@@ -323,8 +332,12 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         let mut engine_bytes: Option<HostMemoryOrVec> = None;
         let mut hash_key: Option<String> = None;
 
+        let non_refittable_constants =
+            crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
+
         if self.caching_enabled {
-            let key = graph.hash_identifier_without_weights(&TRTX_SUFFIX);
+            let key =
+                graph.hash_identifier(&TRTX_SUFFIX, WeightsToHash::Some(&non_refittable_constants));
             if let Ok(cache) = ENGINE_CACHE.as_ref()
                 && let Ok(engine) = cache.get(&key)
             {
@@ -337,6 +350,12 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         }
 
         if engine_bytes.is_none() {
+            if self.fail_on_cache_miss && self.caching_enabled {
+                return Err(TrtxError::TrtxEngineCacheMiss {
+                    cache_key: hash_key,
+                }
+                .into());
+            }
             let mut network = self
                 .network
                 .lock()
@@ -370,9 +389,6 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         let engine_bytes =
             engine_bytes.expect("already got cached engine or tried building engine");
 
-        let non_refittable_constants =
-            crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
-
         self.cuda_context.bind_to_thread()?;
         let mut engine = self
             .runtime
@@ -382,7 +398,14 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
 
         if let Ok(dump_dir) = std::env::var(TRTX_JSON_DUMP_PATH_ENV_VAR) {
-            let mut key = graph.hash_identifier_without_weights(&TRTX_SUFFIX);
+            let mut key = graph.hash_identifier(
+                &format!(
+                    "{}_{:x}",
+                    TRTX_SUFFIX.as_str(),
+                    self.config.lock().unwrap().flags()
+                ),
+                WeightsToHash::Some(&non_refittable_constants),
+            );
             key.push_str(".json");
             let inspector = engine.create_engine_inspector()?;
             let engine_layer_info_json =
@@ -509,6 +532,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             // e.g. if you change trtx converter, changes might not be visible, since cache skips conversion
             // maybe the build hash of certain trtx related files could be included in hash
             caching_enabled: self.options.engine_caching,
+            fail_on_cache_miss: self.options.fail_on_cache_miss,
         }))
     }
 

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -335,9 +335,14 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         let non_refittable_constants =
             crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
 
-        if self.caching_enabled {
+        // no caching for non_refittable_constants for now, non_refittable_constants will end up in
+        // the engine and potentially grow our cache to much. We should only consider including
+        // weights into engines for very small constants
+        if self.caching_enabled && non_refittable_constants.is_empty() {
             let key =
-                graph.hash_identifier(&TRTX_SUFFIX, WeightsToHash::Some(&non_refittable_constants));
+                // if deciding to do hashing for non_refittable_constants
+                //graph.hash_identifier(&TRTX_SUFFIX, WeightsToHash::Some(&non_refittable_constants));
+                graph.hash_identifier(&TRTX_SUFFIX, WeightsToHash::None);
             if let Ok(cache) = ENGINE_CACHE.as_ref()
                 && let Ok(engine) = cache.get(&key)
             {

--- a/src/error.rs
+++ b/src/error.rs
@@ -305,6 +305,13 @@ pub enum Error {
     },
 
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
+    #[error("An error in the Trtx backend: {source}")]
+    TrtxBackendError {
+        #[from]
+        source: crate::backends::trtx::TrtxError,
+    },
+
+    #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     #[error("An CUDA error occurred: {source}")]
     CudaError {
         #[from]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
@@ -267,7 +267,7 @@ pub struct Operand {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash)]
 pub struct ConstantData {
     #[serde_as(as = "Base64")]
     pub data: Vec<u8>,
@@ -333,6 +333,12 @@ impl GraphInfo {
     }
 }
 
+pub enum WeightsToHash<'a> {
+    None,
+    All,
+    Some(&'a HashSet<u32>),
+}
+
 /// Named input/output operands for `MLGraph` dispatch.
 pub type IoBindingMaps = (
     HashMap<String, OperandDescriptor>,
@@ -392,12 +398,36 @@ impl GraphInfo {
         Ok((inputs, outputs))
     }
 
-    pub fn hash_identifier_without_weights(&self, suffix: &str) -> String {
+    pub fn hash_identifier<'a>(&self, suffix: &str, weights_to_hash: WeightsToHash<'a>) -> String {
         let mut hasher = seahash::SeaHasher::new();
         self.input_operands.hash(&mut hasher);
         self.output_operands.hash(&mut hasher);
         self.operands.hash(&mut hasher);
         self.operations.hash(&mut hasher);
+        match weights_to_hash {
+            WeightsToHash::None => (),
+            WeightsToHash::All => {
+                for (constant_id, _) in self
+                    .operands
+                    .iter()
+                    .enumerate()
+                    .filter(|(_id, op)| op.kind == OperandKind::Constant)
+                {
+                    self.constant_operand_ids_to_handles
+                        .get(&(constant_id as u32))
+                        .hash(&mut hasher);
+                }
+            }
+            WeightsToHash::Some(items) => {
+                let mut items: Vec<u32> = items.iter().copied().collect();
+                items.sort_unstable();
+                for constant_id in items.iter() {
+                    self.constant_operand_ids_to_handles
+                        .get(&constant_id)
+                        .hash(&mut hasher);
+                }
+            }
+        }
         let reproduciable_hash_64bit = hasher.finish();
         format!(
             "{reproduciable_hash_64bit:x}_{}_{suffix}",

--- a/src/mlcontextoptions.rs
+++ b/src/mlcontextoptions.rs
@@ -85,7 +85,13 @@ pub struct RustNNOptions {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[non_exhaustive]
 pub struct TrtxOptions {
+    /// Caches built engines from GraphInfos to skip compilation for already built engines
     pub engine_caching: bool,
+    /// Create a MLContext that does not build TRT engines and only uses already pre-built
+    /// AOT engines from cache or user provided. Useful for debugging cache or for AOT only
+    /// workflows
+    pub fail_on_cache_miss: bool,
+    /// Lower CPU overhead using CUDA graphs
     pub cuda_graphs: bool,
 }
 
@@ -93,13 +99,9 @@ pub struct TrtxOptions {
 impl Default for TrtxOptions {
     fn default() -> Self {
         Self {
-            // disabled for now, since feature experimental.
-            // can be enabled with more test coverage, but will remain a double-sided sword
-            // e.g. if you change trtx converter, changes might not be visible, since cache skips conversion
-            // maybe the build hash of certain trtx related files could be included in hash
-            engine_caching: false,
-            // Lower CPU overhead using CUDA graphs
+            engine_caching: true,
             cuda_graphs: true,
+            fail_on_cache_miss: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.


- turn engine caching for TRT on (so we feel all its bugs)
- invalidate cache key when we edit certain converter files
- hash weights when necessary (non-refittable constants)
- add option to fail on cache failures

The issue that the same graph with constant created in different order has
different hashes persists. JIT caching (helps with engine load times) is still not performed.


## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

