### PR TITLE
deps: bump thiserror to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokenizers",
  "tokio",
  "trtx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.8", features = ["base64"] }
-thiserror = "1.0"
+thiserror = "2.0"
 base64 = "0.22"
 prost = "0.12"
 prost-types = "0.12"


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Bump from 1.0 to 2.0. Seems to be no visible change for us. Most of our deps except webnn-graph and webnn-onnx-utils already use 2.0

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

