### PR TITLE
Zstd compressed cache for trtx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ dependencies = [
  "trtx",
  "webnn-graph",
  "webnn-onnx-utils",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -4118,7 +4119,7 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -4133,7 +4134,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -4143,6 +4153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ default = []
 dynamic-inputs = []
 coreml-runtime = ["objc", "block", "dep:tempfile"]
 onnx-runtime = ["ort", "ndarray", "dep:tempfile"]
-trtx-runtime = ["trtx", "cudarc"]
+trtx-runtime = ["trtx", "cudarc", "zstd-cache-compression"]
 trtx-runtime-mock = ["trtx/mock", "cudarc"]
 litert-runtime = ["litert", "litert-sys", "dep:flatbuffers"]
+zstd-cache-compression = ["dep:zstd"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
@@ -68,6 +69,7 @@ log = "0.4.29"
 pretty_env_logger = "0.5.0"
 seahash = "4.1.0"
 dirs = "6.0.0"
+zstd = { version = "0.13", optional = true }
 
 # The exception feature is needed to avoid undefined behavior when objc throws exceptions
 objc = { version = "0.2", optional = true, features = [] } # without "exception" it builds on Linux using https://github.com/gnustep/libobjc2

--- a/src/backends/caching.rs
+++ b/src/backends/caching.rs
@@ -81,6 +81,56 @@ impl<'cache> PersistentCache<'cache> for SimpleFileCache {
 
 pub type DefaultCache = SimpleFileCache;
 
+#[cfg(feature = "zstd-cache-compression")]
+#[derive(Debug)]
+pub struct ZstdCompressedFileCache {
+    root_path: PathBuf,
+}
+
+#[cfg(feature = "zstd-cache-compression")]
+impl ZstdCompressedFileCache {
+    fn cache_path(&self, key: &str) -> PathBuf {
+        self.root_path.join(format!("{key}.zstd"))
+    }
+}
+
+#[cfg(feature = "zstd-cache-compression")]
+impl<'cache> PersistentCache<'cache> for ZstdCompressedFileCache {
+    fn new(category: &str) -> CacheResult<Self> {
+        let root_path = dirs::cache_dir()
+            .map(|dir| dir.join("rustnn").join(category))
+            .ok_or(CacheError::FailedToDetermineCachePath)?;
+        std::fs::create_dir_all(&root_path).map_err(|e| CacheError::FailedToCreateCachePath {
+            path: root_path.clone(),
+            source: e,
+        })?;
+        Ok(Self { root_path })
+    }
+
+    fn get(&self, key: &str) -> CacheResult<Cow<'cache, [u8]>> {
+        debug!("Looking up compressed cache key: {key}");
+        let cache_path = self.cache_path(key);
+        read_zstd_cache_file(&cache_path)
+            .map_err(|e| CacheError::FailedToReadCacheFile {
+                path: cache_path.clone(),
+                source: e,
+            })
+            .map(Cow::Owned)
+    }
+
+    fn set(&self, key: &str, data: &[u8]) -> CacheResult<()> {
+        debug!(
+            "Setting compressed cache key: {key} with {} bytes",
+            data.len()
+        );
+        let cache_path = self.cache_path(key);
+        write_zstd_cache_file(&cache_path, data).map_err(|e| CacheError::FailedToWriteCacheFile {
+            path: cache_path.clone(),
+            source: e,
+        })
+    }
+}
+
 pub(crate) fn read_cache_file(cache_path: &Path) -> std::io::Result<Vec<u8>> {
     debug!("Reading cache file {cache_path:?}");
     let mut file = File::open(cache_path)?;
@@ -98,4 +148,48 @@ pub(crate) fn write_cache_file(cache_path: &Path, content: &[u8]) -> std::io::Re
     file.lock()?;
     file.write_all(content)?;
     Ok(())
+}
+
+#[cfg(feature = "zstd-cache-compression")]
+pub(crate) fn read_zstd_cache_file(cache_path: &Path) -> std::io::Result<Vec<u8>> {
+    debug!("Reading compressed cache file {cache_path:?}");
+    let file = File::open(cache_path)?;
+    let mut decoder = zstd::stream::read::Decoder::new(file)?;
+    let mut buffer = Vec::new();
+    decoder.read_to_end(&mut buffer)?;
+    Ok(buffer)
+}
+
+#[cfg(feature = "zstd-cache-compression")]
+pub(crate) fn write_zstd_cache_file(cache_path: &Path, content: &[u8]) -> std::io::Result<()> {
+    debug!(
+        "Trying to write {} bytes to compressed cache file {cache_path:?}",
+        content.len()
+    );
+    let file = File::create(cache_path)?;
+    file.lock()?;
+    let mut encoder = zstd::stream::write::Encoder::new(file, 0)?;
+    encoder.write_all(content)?;
+    encoder.finish()?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "zstd-cache-compression"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zstd_cache_round_trip_uses_zstd_file_extension() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = ZstdCompressedFileCache {
+            root_path: directory.path().to_path_buf(),
+        };
+        let content = b"repeated cache data repeated cache data repeated cache data";
+
+        cache.set("engine", content).unwrap();
+
+        assert!(!directory.path().join("engine").exists());
+        assert!(directory.path().join("engine.zstd").exists());
+        assert_eq!(cache.get("engine").unwrap().as_ref(), content);
+    }
 }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -22,8 +22,11 @@ use trtx::host_memory::HostMemory;
 
 use crate::GraphInfo;
 use crate::backends::caching::CacheResult;
-use crate::backends::caching::DefaultCache;
+#[cfg(not(feature = "zstd-cache-compression"))]
+use crate::backends::caching::DefaultCache as TrtxCache;
 use crate::backends::caching::PersistentCache;
+#[cfg(feature = "zstd-cache-compression")]
+use crate::backends::caching::ZstdCompressedFileCache as TrtxCache;
 use crate::converters::TrtxConverter;
 use crate::error::Error;
 
@@ -311,8 +314,7 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
 
 const SOURCE_HASH: &str = include_str!(concat!(env!("OUT_DIR"), "/source_hash.txt"));
 
-static ENGINE_CACHE: LazyLock<CacheResult<DefaultCache>> =
-    LazyLock::new(|| DefaultCache::new("trtx"));
+static ENGINE_CACHE: LazyLock<CacheResult<TrtxCache>> = LazyLock::new(|| TrtxCache::new("trtx"));
 static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
     format!(
         "trtx_{}.{}.{}_{}",


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

On top of #189, but with zstd compression (34MiB for whole test suite). zstd-rs and the bundled zstd library from Facebook have BSD licensed. zstd-rs has the C library from Facebook as only dependency.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

