### PR TITLE
Zstd+Runtime cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ trtx-runtime = ["trtx", "cudarc", "zstd-cache-compression"]
 trtx-runtime-mock = ["trtx/mock", "cudarc"]
 litert-runtime = ["litert", "litert-sys", "dep:flatbuffers"]
 zstd-cache-compression = ["dep:zstd"]
+# test feature for validation of RTX runtime
+trtx-enterprise = ["trtx-runtime", "trtx/enterprise"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -719,6 +719,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             array.as_ptr(),
             array.len(),
         );
+        stream.context().bind_to_thread()?;
         stream
             .memcpy_dtoh(&cuda_tensor.memory, array)
             .to_read_tensor_result(|| tensor.clone())?;
@@ -735,6 +736,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     ) -> crate::error::Result<()> {
         let cuda_tensor = &mut self.tensors[tensor.id];
         let stream = &cuda_tensor.stream;
+        stream.context().bind_to_thread()?;
         debug!(
             "Uploading tensor {cuda_tensor:?} to array (ptr={:?}, size={:?})",
             array.as_ptr(),
@@ -802,6 +804,9 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                     .set_output_tensor_address(output, ptr as *mut c_void)
                     .to_dispatch_result()?
             };
+            let event = cuda_tensor.stream.record_event(None).to_dispatch_result()?;
+            inference_stream.wait(&event).to_dispatch_result()?;
+            self.events.push(event);
         }
 
         if cuda_graphs_enabled {
@@ -809,8 +814,11 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             if let Some(cuda_graph) = graph.cuda_graphs.get(&io_pointers) {
                 cuda_graph.launch(inference_stream).to_dispatch_result()?;
             } else {
-                let capture_stream = self.cuda_ctx.new_stream()?;
-                capture_stream
+                // TensorRT-RTX performs setup and JIT work on the first enqueue. Complete that
+                // work before capturing the second enqueue so capture only contains inference.
+                enqueue_inference_v3(&mut graph.exec, inference_stream)?;
+                inference_stream.synchronize().to_dispatch_result()?;
+                inference_stream
                     .begin_capture(sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL)
                     .to_dispatch_result()?;
                 if let Err(source) = unsafe {
@@ -819,7 +827,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                         .enqueue_v3(inference_stream.cu_stream() as *mut c_void)
                 } {
                     if let Ok(captured_graph) =
-                        unsafe { result::stream::end_capture(capture_stream.cu_stream()) }
+                        unsafe { result::stream::end_capture(inference_stream.cu_stream()) }
                         && !captured_graph.is_null()
                     {
                         let _ = unsafe { result::graph::destroy(captured_graph) };
@@ -829,8 +837,8 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                     });
                 }
                 let cuda_graph =
-                    CapturedCudaGraph::finish_capture(&capture_stream).to_dispatch_result()?;
-                cuda_graph.launch(inference_stream).to_dispatch_result()?;
+                    CapturedCudaGraph::finish_capture(inference_stream).to_dispatch_result()?;
+                // The uncaptured warm-up produced this dispatch's output. Replay on cache hits.
                 graph.cuda_graphs.insert(io_pointers, cuda_graph);
             }
         } else {

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -155,6 +155,7 @@ pub(crate) struct TrtxGraph<'context> {
     _engine: CudaEngine<'context>,
     cuda_stream: Arc<CudaStream>,
     cuda_graphs: HashMap<Vec<(bool, String, usize)>, CapturedCudaGraph>,
+    inference_count: u64,
 }
 
 struct CapturedCudaGraph {
@@ -221,6 +222,7 @@ impl std::fmt::Debug for TrtxGraph<'_> {
             .field("exec", &self.exec.name())
             .field("cuda_stream", &self.cuda_stream)
             .field("cuda_graph_count", &self.cuda_graphs.len())
+            .field("inference_count", &self.inference_count)
             .finish()
     }
 }
@@ -625,6 +627,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                     .new_stream()
                     .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?,
                 cuda_graphs: HashMap::new(),
+                inference_count: 0,
             }),
             &graph,
         )
@@ -813,10 +816,11 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             io_pointers.sort_unstable();
             if let Some(cuda_graph) = graph.cuda_graphs.get(&io_pointers) {
                 cuda_graph.launch(inference_stream).to_dispatch_result()?;
-            } else {
-                // TensorRT-RTX performs setup and JIT work on the first enqueue. Complete that
-                // work before capturing the second enqueue so capture only contains inference.
+            } else if graph.inference_count == 0 {
+                // TensorRT-RTX performs setup and JIT work on the first enqueue. Run that
+                // inference normally; the next dispatch can safely capture its enqueue.
                 enqueue_inference_v3(&mut graph.exec, inference_stream)?;
+            } else {
                 inference_stream.synchronize().to_dispatch_result()?;
                 inference_stream
                     .begin_capture(sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL)
@@ -838,12 +842,13 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                 }
                 let cuda_graph =
                     CapturedCudaGraph::finish_capture(inference_stream).to_dispatch_result()?;
-                // The uncaptured warm-up produced this dispatch's output. Replay on cache hits.
+                cuda_graph.launch(inference_stream).to_dispatch_result()?;
                 graph.cuda_graphs.insert(io_pointers, cuda_graph);
             }
         } else {
             enqueue_inference_v3(&mut graph.exec, inference_stream)?;
         }
+        graph.inference_count = graph.inference_count.saturating_add(1);
         let inference_done = inference_stream.record_event(None).to_dispatch_result()?;
         for tensor in outputs.values() {
             let cuda_tensor = &mut self.tensors[tensor.id];

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ffi::CStr;
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
@@ -245,7 +244,7 @@ impl TrtxTensor {
 
 pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
-    pci_device_id: String,
+    device_cache_id: String,
     tensors: Vec<TrtxTensor>,
     events: Vec<CudaEvent>,
     runtime: Arc<Mutex<trtx::Runtime<'context>>>,
@@ -273,7 +272,7 @@ impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32, options: Option<&RustNNOptions>) -> TrtxResult<Self> {
         // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
-        let pci_device_id = cuda_pci_device_id(&cuda_ctx)?;
+        let device_cache_id = cuda_device_cache_id(&cuda_ctx)?;
         let mut builder = trtx::Builder::new(&LOGGER)?;
         let mut config = builder.create_config()?;
         // Strip marked weights weights from engine and makes them refittable, keeps other weights
@@ -288,7 +287,7 @@ impl<'context> TrtxContext<'context> {
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
-            pci_device_id,
+            device_cache_id,
             tensors: vec![],
             events: vec![],
             runtime,
@@ -299,34 +298,36 @@ impl<'context> TrtxContext<'context> {
     }
 }
 
-fn cuda_pci_device_id(cuda_ctx: &CudaContext) -> std::result::Result<String, DriverError> {
-    // CUDA documents 13 bytes as sufficient for "domain:bus:device.function". Leave some
-    // extra room so this remains robust if the representation grows in a future driver.
-    let mut buffer = [0_i8; 32];
-    unsafe {
-        sys::cuDeviceGetPCIBusId(
-            buffer.as_mut_ptr(),
-            buffer.len() as i32,
-            cuda_ctx.cu_device(),
-        )
-        .result()?;
-    }
-    Ok(unsafe { CStr::from_ptr(buffer.as_ptr()) }
-        .to_string_lossy()
-        .into_owned())
-    //// the cache would be shared among all identical CUDA GPUs with same device ID, why does this
-    //// return 0?
-    //let device_id =
-    //cuda_ctx.attribute(sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID)?;
-    //Ok(format!("{device_id:4x}"))
+fn cuda_device_cache_id(cuda_ctx: &CudaContext) -> std::result::Result<String, DriverError> {
+    let combined =
+        cuda_ctx.attribute(sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_GPU_PCI_DEVICE_ID)? as u32;
+    let compute_major = cuda_ctx
+        .attribute(sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR)?
+        as u32;
+    let compute_minor = cuda_ctx
+        .attribute(sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR)?
+        as u32;
+    Ok(format_cuda_device_cache_id(
+        combined,
+        compute_major,
+        compute_minor,
+    ))
 }
 
+fn format_cuda_device_cache_id(combined: u32, compute_major: u32, compute_minor: u32) -> String {
+    // CUDA packs the PCI device ID into the high 16 bits and the vendor ID into the low 16 bits.
+    let vendor_id = combined & 0xffff;
+    let device_id = combined >> 16;
+    format!("{vendor_id:04x}_{device_id:04x}_sm{compute_major}{compute_minor}")
+}
+
+#[cfg(not(feature = "trtx-enterprise"))]
 impl Drop for TrtxContext<'_> {
     fn drop(&mut self) {
         if let Err(error) = self.cuda_ctx.bind_to_thread() {
             warn!(
                 "Failed to bind CUDA device {} before saving its TensorRT JIT cache: {error}",
-                self.pci_device_id
+                self.device_cache_id
             );
             return;
         }
@@ -334,7 +335,7 @@ impl Drop for TrtxContext<'_> {
         let runtime_cache = TRTX_RUNTIME_CACHE
             .lock()
             .unwrap()
-            .get(&self.pci_device_id)
+            .get(&self.device_cache_id)
             .cloned();
         let Some(runtime_cache) = runtime_cache else {
             return;
@@ -345,17 +346,17 @@ impl Drop for TrtxContext<'_> {
             Err(error) => {
                 warn!(
                     "Failed to serialize TensorRT JIT cache for CUDA device {}: {error}",
-                    self.pci_device_id
+                    self.device_cache_id
                 );
                 return;
             }
         };
         if let Ok(cache) = JIT_CACHE.as_ref()
-            && let Err(error) = cache.set(&jit_cache_disk_key(&self.pci_device_id), &serialized)
+            && let Err(error) = cache.set(&jit_cache_disk_key(&self.device_cache_id), &serialized)
         {
             warn!(
                 "Failed to save TensorRT JIT cache for CUDA device {}: {error}",
-                self.pci_device_id
+                self.device_cache_id
             );
         }
     }
@@ -368,10 +369,11 @@ pub(crate) struct TrtxBuilder<'builder> {
     config: Arc<Mutex<trtx::BuilderConfig<'builder>>>,
     cuda_context: Arc<CudaContext>,
     runtime: Arc<Mutex<trtx::Runtime<'builder>>>,
-    pci_device_id: String,
+    device_cache_id: String,
     operands: HashMap<String, MLOperand>,
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
+    #[cfg(not(feature = "trtx-enterprise"))]
     runtime_cache_enabled: bool,
     fail_on_cache_miss: bool,
 }
@@ -385,8 +387,10 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
 const SOURCE_HASH: &str = include_str!(concat!(env!("OUT_DIR"), "/source_hash.txt"));
 
 static ENGINE_CACHE: LazyLock<CacheResult<TrtxCache>> = LazyLock::new(|| TrtxCache::new("trtx"));
+#[cfg(not(feature = "trtx-enterprise"))]
 static JIT_CACHE: LazyLock<CacheResult<TrtxCache>> = LazyLock::new(|| TrtxCache::new("trtx-jit"));
 
+#[cfg(not(feature = "trtx-enterprise"))]
 static TRTX_RUNTIME_CACHE: LazyLock<
     Mutex<HashMap<String, Arc<Mutex<trtx::RuntimeCache<'static>>>>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -400,20 +404,22 @@ static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
-fn jit_cache_disk_key(pci_device_id: &str) -> String {
-    let filesystem_safe_device_id = pci_device_id.replace([':', '.'], "_");
-    format!("{filesystem_safe_device_id}_{}.cache", *TRTX_SUFFIX)
+#[cfg(not(feature = "trtx-enterprise"))]
+fn jit_cache_disk_key(device_cache_id: &str) -> String {
+    format!("{device_cache_id}_{}.cache", *TRTX_SUFFIX)
 }
 
 // RuntimeCache owns its TensorRT IRuntimeCache and does not borrow the engine. The lifetime in
 // trtx::RuntimeCache is represented only by PhantomData, so erase it while the cache is held in
 // the process-global map and restore the current engine lifetime when cloning it out.
+#[cfg(not(feature = "trtx-enterprise"))]
 fn into_global_runtime_cache<'engine>(
     cache: Arc<Mutex<trtx::RuntimeCache<'engine>>>,
 ) -> Arc<Mutex<trtx::RuntimeCache<'static>>> {
     unsafe { std::mem::transmute(cache) }
 }
 
+#[cfg(not(feature = "trtx-enterprise"))]
 fn from_global_runtime_cache<'engine>(
     cache: Arc<Mutex<trtx::RuntimeCache<'static>>>,
 ) -> Arc<Mutex<trtx::RuntimeCache<'engine>>> {
@@ -574,13 +580,16 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         }
         refitter.refit_cuda_engine()?;
 
-        let mut runtime_config = engine
+        let runtime_config = engine
             .create_runtime_config()
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+        #[cfg(not(feature = "trtx-enterprise"))]
+        let mut runtime_config = runtime_config;
+        #[cfg(not(feature = "trtx-enterprise"))]
         if self.runtime_cache_enabled {
             let runtime_cache = {
                 let mut caches = TRTX_RUNTIME_CACHE.lock().unwrap();
-                if let Some(cache) = caches.get(&self.pci_device_id) {
+                if let Some(cache) = caches.get(&self.device_cache_id) {
                     from_global_runtime_cache(Arc::clone(cache))
                 } else {
                     let mut cache = runtime_config
@@ -588,23 +597,23 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                         .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
                     if let Ok(disk_cache) = JIT_CACHE.as_ref()
                         && let Ok(serialized) =
-                            disk_cache.get(&jit_cache_disk_key(&self.pci_device_id))
+                            disk_cache.get(&jit_cache_disk_key(&self.device_cache_id))
                     {
                         match cache.deserialize(&serialized) {
                             Ok(()) => debug!(
                                 "Loaded TensorRT JIT cache for CUDA device {} ({} bytes)",
-                                self.pci_device_id,
+                                self.device_cache_id,
                                 serialized.len()
                             ),
                             Err(error) => warn!(
                                 "Failed to deserialize TensorRT JIT cache for CUDA device {}: {error}",
-                                self.pci_device_id
+                                self.device_cache_id
                             ),
                         }
                     }
                     let cache = Arc::new(Mutex::new(cache));
                     caches.insert(
-                        self.pci_device_id.clone(),
+                        self.device_cache_id.clone(),
                         into_global_runtime_cache(Arc::clone(&cache)),
                     );
                     cache
@@ -664,11 +673,12 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             builder: Arc::clone(&self.builder),
             config: Arc::clone(&self.config),
             runtime: Arc::clone(&self.runtime),
-            pci_device_id: self.pci_device_id.clone(),
+            device_cache_id: self.device_cache_id.clone(),
             cuda_context: Arc::clone(&self.cuda_ctx),
             operands: HashMap::new(),
             strings: vec![],
             caching_enabled: self.options.engine_caching,
+            #[cfg(not(feature = "trtx-enterprise"))]
             runtime_cache_enabled: self.options.runtime_cache,
             fail_on_cache_miss: self.options.fail_on_cache_miss,
         }))
@@ -964,7 +974,10 @@ impl ListDevices for TrtxContext<'_> {
 #[cfg(feature = "trtx-runtime")]
 mod tests {
     use crate::mlcontext::{MLBackendContext, MLTensorDescriptor};
-    use crate::{backends::trtx::TrtxContext, mlcontext::ListDevices};
+    use crate::{
+        backends::trtx::{TrtxContext, format_cuda_device_cache_id},
+        mlcontext::ListDevices,
+    };
 
     #[test]
     fn test_context_creation() {

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::ffi::CStr;
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
@@ -242,6 +243,7 @@ impl TrtxTensor {
 
 pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
+    pci_device_id: String,
     tensors: Vec<TrtxTensor>,
     events: Vec<CudaEvent>,
     runtime: Arc<Mutex<trtx::Runtime<'context>>>,
@@ -269,6 +271,7 @@ impl<'context> TrtxContext<'context> {
     pub(crate) fn new(cuda_device_idx: u32, options: Option<&RustNNOptions>) -> TrtxResult<Self> {
         // this retains the primary context
         let cuda_ctx = CudaContext::new(cuda_device_idx as usize)?;
+        let pci_device_id = cuda_pci_device_id(&cuda_ctx)?;
         let mut builder = trtx::Builder::new(&LOGGER)?;
         let mut config = builder.create_config()?;
         // Strip marked weights weights from engine and makes them refittable, keeps other weights
@@ -283,6 +286,7 @@ impl<'context> TrtxContext<'context> {
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
+            pci_device_id,
             tensors: vec![],
             events: vec![],
             runtime,
@@ -293,6 +297,68 @@ impl<'context> TrtxContext<'context> {
     }
 }
 
+fn cuda_pci_device_id(cuda_ctx: &CudaContext) -> std::result::Result<String, DriverError> {
+    // CUDA documents 13 bytes as sufficient for "domain:bus:device.function". Leave some
+    // extra room so this remains robust if the representation grows in a future driver.
+    let mut buffer = [0_i8; 32];
+    unsafe {
+        sys::cuDeviceGetPCIBusId(
+            buffer.as_mut_ptr(),
+            buffer.len() as i32,
+            cuda_ctx.cu_device(),
+        )
+        .result()?;
+    }
+    Ok(unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .into_owned())
+    //// the cache would be shared among all identical CUDA GPUs with same device ID, why does this
+    //// return 0?
+    //let device_id =
+    //cuda_ctx.attribute(sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID)?;
+    //Ok(format!("{device_id:4x}"))
+}
+
+impl Drop for TrtxContext<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = self.cuda_ctx.bind_to_thread() {
+            warn!(
+                "Failed to bind CUDA device {} before saving its TensorRT JIT cache: {error}",
+                self.pci_device_id
+            );
+            return;
+        }
+
+        let runtime_cache = TRTX_RUNTIME_CACHE
+            .lock()
+            .unwrap()
+            .get(&self.pci_device_id)
+            .cloned();
+        let Some(runtime_cache) = runtime_cache else {
+            return;
+        };
+
+        let serialized = match runtime_cache.lock().unwrap().serialize() {
+            Ok(serialized) => serialized,
+            Err(error) => {
+                warn!(
+                    "Failed to serialize TensorRT JIT cache for CUDA device {}: {error}",
+                    self.pci_device_id
+                );
+                return;
+            }
+        };
+        if let Ok(cache) = JIT_CACHE.as_ref()
+            && let Err(error) = cache.set(&jit_cache_disk_key(&self.pci_device_id), &serialized)
+        {
+            warn!(
+                "Failed to save TensorRT JIT cache for CUDA device {}: {error}",
+                self.pci_device_id
+            );
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) struct TrtxBuilder<'builder> {
     network: Mutex<Option<trtx::NetworkDefinition<'builder>>>,
@@ -300,9 +366,11 @@ pub(crate) struct TrtxBuilder<'builder> {
     config: Arc<Mutex<trtx::BuilderConfig<'builder>>>,
     cuda_context: Arc<CudaContext>,
     runtime: Arc<Mutex<trtx::Runtime<'builder>>>,
+    pci_device_id: String,
     operands: HashMap<String, MLOperand>,
     strings: Vec<String>, //_parser: Option<OnnxParser<'builder>>,
     caching_enabled: bool,
+    runtime_cache_enabled: bool,
     fail_on_cache_miss: bool,
 }
 
@@ -315,6 +383,11 @@ impl std::fmt::Debug for TrtxBuilder<'_> {
 const SOURCE_HASH: &str = include_str!(concat!(env!("OUT_DIR"), "/source_hash.txt"));
 
 static ENGINE_CACHE: LazyLock<CacheResult<TrtxCache>> = LazyLock::new(|| TrtxCache::new("trtx"));
+static JIT_CACHE: LazyLock<CacheResult<TrtxCache>> = LazyLock::new(|| TrtxCache::new("trtx-jit"));
+
+static TRTX_RUNTIME_CACHE: LazyLock<
+    Mutex<HashMap<String, Arc<Mutex<trtx::RuntimeCache<'static>>>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
     format!(
         "trtx_{}.{}.{}_{}",
@@ -324,6 +397,26 @@ static TRTX_SUFFIX: LazyLock<String> = LazyLock::new(|| {
         SOURCE_HASH
     )
 });
+
+fn jit_cache_disk_key(pci_device_id: &str) -> String {
+    let filesystem_safe_device_id = pci_device_id.replace([':', '.'], "_");
+    format!("{filesystem_safe_device_id}_{}.cache", *TRTX_SUFFIX)
+}
+
+// RuntimeCache owns its TensorRT IRuntimeCache and does not borrow the engine. The lifetime in
+// trtx::RuntimeCache is represented only by PhantomData, so erase it while the cache is held in
+// the process-global map and restore the current engine lifetime when cloning it out.
+fn into_global_runtime_cache<'engine>(
+    cache: Arc<Mutex<trtx::RuntimeCache<'engine>>>,
+) -> Arc<Mutex<trtx::RuntimeCache<'static>>> {
+    unsafe { std::mem::transmute(cache) }
+}
+
+fn from_global_runtime_cache<'engine>(
+    cache: Arc<Mutex<trtx::RuntimeCache<'static>>>,
+) -> Arc<Mutex<trtx::RuntimeCache<'engine>>> {
+    unsafe { std::mem::transmute(cache) }
+}
 
 impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'context> {
     /*async */
@@ -479,9 +572,46 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         }
         refitter.refit_cuda_engine()?;
 
-        let runtime_config = engine
+        let mut runtime_config = engine
             .create_runtime_config()
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+        if self.runtime_cache_enabled {
+            let runtime_cache = {
+                let mut caches = TRTX_RUNTIME_CACHE.lock().unwrap();
+                if let Some(cache) = caches.get(&self.pci_device_id) {
+                    from_global_runtime_cache(Arc::clone(cache))
+                } else {
+                    let mut cache = runtime_config
+                        .create_runtime_cache()
+                        .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                    if let Ok(disk_cache) = JIT_CACHE.as_ref()
+                        && let Ok(serialized) =
+                            disk_cache.get(&jit_cache_disk_key(&self.pci_device_id))
+                    {
+                        match cache.deserialize(&serialized) {
+                            Ok(()) => debug!(
+                                "Loaded TensorRT JIT cache for CUDA device {} ({} bytes)",
+                                self.pci_device_id,
+                                serialized.len()
+                            ),
+                            Err(error) => warn!(
+                                "Failed to deserialize TensorRT JIT cache for CUDA device {}: {error}",
+                                self.pci_device_id
+                            ),
+                        }
+                    }
+                    let cache = Arc::new(Mutex::new(cache));
+                    caches.insert(
+                        self.pci_device_id.clone(),
+                        into_global_runtime_cache(Arc::clone(&cache)),
+                    );
+                    cache
+                }
+            };
+            runtime_config
+                .set_runtime_cache(runtime_cache)
+                .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+        }
         let exec = engine
             .create_execution_context_with_config(Rc::new(runtime_config))
             .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
@@ -531,14 +661,12 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             builder: Arc::clone(&self.builder),
             config: Arc::clone(&self.config),
             runtime: Arc::clone(&self.runtime),
+            pci_device_id: self.pci_device_id.clone(),
             cuda_context: Arc::clone(&self.cuda_ctx),
             operands: HashMap::new(),
             strings: vec![],
-            // disabled for now, since feature experimental.
-            // can be enabled with more test coverage, but will remain a double-sided sword
-            // e.g. if you change trtx converter, changes might not be visible, since cache skips conversion
-            // maybe the build hash of certain trtx related files could be included in hash
             caching_enabled: self.options.engine_caching,
+            runtime_cache_enabled: self.options.runtime_cache,
             fail_on_cache_miss: self.options.fail_on_cache_miss,
         }))
     }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -412,6 +412,8 @@ fn jit_cache_disk_key(device_cache_id: &str) -> String {
 // RuntimeCache owns its TensorRT IRuntimeCache and does not borrow the engine. The lifetime in
 // trtx::RuntimeCache is represented only by PhantomData, so erase it while the cache is held in
 // the process-global map and restore the current engine lifetime when cloning it out.
+//
+// Needs to be fixed next trtx release. See https://github.com/rustnn/trtx-rs/pull/129
 #[cfg(not(feature = "trtx-enterprise"))]
 fn into_global_runtime_cache<'engine>(
     cache: Arc<Mutex<trtx::RuntimeCache<'engine>>>,

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -186,9 +186,9 @@ impl CapturedCudaGraph {
         })
     }
 
-    fn launch(&self) -> std::result::Result<(), DriverError> {
-        self.stream.context().bind_to_thread()?;
-        unsafe { result::graph::launch(self.executable, self.stream.cu_stream()) }
+    fn launch(&self, cuda_stream: &CudaStream) -> std::result::Result<(), DriverError> {
+        cuda_stream.context().bind_to_thread()?;
+        unsafe { result::graph::launch(self.executable, cuda_stream.cu_stream()) }
     }
 }
 
@@ -755,6 +755,8 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         inputs: &HashMap<&str, &MLTensor>,
         outputs: &HashMap<&str, &MLTensor>,
     ) -> crate::error::Result<()> {
+        self.cuda_ctx.bind_to_thread()?;
+
         let graph = graph
             .backend
             .as_trtx_engine_mut()
@@ -805,9 +807,10 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         if cuda_graphs_enabled {
             io_pointers.sort_unstable();
             if let Some(cuda_graph) = graph.cuda_graphs.get(&io_pointers) {
-                cuda_graph.launch().to_dispatch_result()?;
+                cuda_graph.launch(inference_stream).to_dispatch_result()?;
             } else {
-                inference_stream
+                let capture_stream = self.cuda_ctx.new_stream()?;
+                capture_stream
                     .begin_capture(sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL)
                     .to_dispatch_result()?;
                 if let Err(source) = unsafe {
@@ -816,7 +819,7 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                         .enqueue_v3(inference_stream.cu_stream() as *mut c_void)
                 } {
                     if let Ok(captured_graph) =
-                        unsafe { result::stream::end_capture(inference_stream.cu_stream()) }
+                        unsafe { result::stream::end_capture(capture_stream.cu_stream()) }
                         && !captured_graph.is_null()
                     {
                         let _ = unsafe { result::graph::destroy(captured_graph) };
@@ -826,8 +829,8 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
                     });
                 }
                 let cuda_graph =
-                    CapturedCudaGraph::finish_capture(inference_stream).to_dispatch_result()?;
-                cuda_graph.launch().to_dispatch_result()?;
+                    CapturedCudaGraph::finish_capture(&capture_stream).to_dispatch_result()?;
+                cuda_graph.launch(inference_stream).to_dispatch_result()?;
                 graph.cuda_graphs.insert(io_pointers, cuda_graph);
             }
         } else {

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -739,6 +739,35 @@ webnn_graph "sample_graph" v1 {
         assert_eq!(&vec![2.0f32, 3., 4., 5.], &download);
     }
 
+    #[cfg(feature = "trtx-runtime")]
+    #[test]
+    fn test_trtx_cuda_graph_replay() {
+        let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {
+            return;
+        };
+        if context.rustnn_backend() != Backend::Trtx {
+            return;
+        }
+
+        let desc = rw_tensor_desc([2, 2].to_vec());
+        let input_tensor = context.create_tensor(&desc).unwrap();
+        let output_tensor = context.create_tensor(&desc).unwrap();
+        let inputs = HashMap::from([("lhs", &input_tensor)]);
+        let outputs = HashMap::from([("sum", &output_tensor)]);
+
+        for upload in [vec![1.0f32, 2., 3., 4.], vec![5.0f32, 6., 7., 8.]] {
+            context.write_tensor(&input_tensor, &upload).unwrap();
+            context.dispatch(&mut graph, &inputs, &outputs).unwrap();
+
+            let mut download = vec![0.0f32; 4];
+            context.read_tensor(&output_tensor, &mut download).unwrap();
+            assert_eq!(
+                upload.iter().map(|value| value + 1.0).collect::<Vec<_>>(),
+                download
+            );
+        }
+    }
+
     #[test]
     fn test_dispatch_invalid_input_name_error_message() {
         let Some((mut context, mut graph)) = create_add_graph_context_and_graph() else {

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -755,7 +755,11 @@ webnn_graph "sample_graph" v1 {
         let inputs = HashMap::from([("lhs", &input_tensor)]);
         let outputs = HashMap::from([("sum", &output_tensor)]);
 
-        for upload in [vec![1.0f32, 2., 3., 4.], vec![5.0f32, 6., 7., 8.]] {
+        for upload in [
+            vec![1.0f32, 2., 3., 4.],
+            vec![5.0f32, 6., 7., 8.],
+            vec![9.0f32, 10., 11., 12.],
+        ] {
             context.write_tensor(&input_tensor, &upload).unwrap();
             context.dispatch(&mut graph, &inputs, &outputs).unwrap();
 

--- a/src/mlcontextoptions.rs
+++ b/src/mlcontextoptions.rs
@@ -87,6 +87,8 @@ pub struct RustNNOptions {
 pub struct TrtxOptions {
     /// Caches built engines from GraphInfos to skip compilation for already built engines
     pub engine_caching: bool,
+    /// Uses a global runtime cache to speed up engine loading
+    pub runtime_cache: bool,
     /// Create a MLContext that does not build TRT engines and only uses already pre-built
     /// AOT engines from cache or user provided. Useful for debugging cache or for AOT only
     /// workflows
@@ -100,6 +102,7 @@ impl Default for TrtxOptions {
     fn default() -> Self {
         Self {
             engine_caching: true,
+            runtime_cache: true,
             cuda_graphs: true,
             fail_on_cache_miss: false,
         }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Add global Trtx Runtime cache. #165 but rebased on #192. Running the test suite for trt goes down from 44s from ~250s with engine cache only and ~500s+ without any caching.

~Whole test suite requires `836K` of compressed runtime cache.~ EDIT: running the tests a few times accumulates to 29M compressed 

We use global cache instead of per-engine cache like TRT RTX execution provider does to experiment with things done differently.

Global cache can potentially share cache results between different models, but has disadvantage that it can potentially grow to big without a chance to trim it back. A per-graph cache, would have everything necessary for one graph to reload it again quickly. But all graphs would start with a cold cache after AOT build.

There are some random serialization failures for the cache (don't know yet why this happens). When this happens the JIT cache will not be stored to disk. It will recover automatically the next time the cache is loaded from disk.

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

