### PR TITLE
fix: use tempfile+atomic rename instead of locking for file writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-cli
 [features]
 default = []
 dynamic-inputs = []
-coreml-runtime = ["objc", "block", "dep:tempfile"]
-onnx-runtime = ["ort", "ndarray", "dep:tempfile"]
+coreml-runtime = ["objc", "block"]
+onnx-runtime = ["ort", "ndarray"]
 trtx-runtime = ["trtx", "cudarc", "zstd-cache-compression"]
 trtx-runtime-mock = ["trtx/mock", "cudarc"]
 litert-runtime = ["litert", "litert-sys", "dep:flatbuffers"]
@@ -48,7 +48,7 @@ prost-types = "0.12"
 bytes = "1.6"
 bytemuck = { version = "1.15", features = ["extern_crate_std"] }
 ndarray = { version = "0.17", optional = true }
-tempfile = { version = "3.8", optional = true }
+tempfile = "3.27"
 ort = { version = "=2.0.0-rc.12", optional = true, features = [
     "ndarray",
     "half",
@@ -86,7 +86,6 @@ seahash = "4.1.0"
 
 [dev-dependencies]
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
-tempfile = "3.8"
 half = "2.4"
 insta = { version = "1.47.2", features = ["yaml"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }

--- a/src/backends/caching.rs
+++ b/src/backends/caching.rs
@@ -144,10 +144,28 @@ pub(crate) fn write_cache_file(cache_path: &Path, content: &[u8]) -> std::io::Re
         "Trying to write {} bytes to cache file {cache_path:?}",
         content.len()
     );
-    let mut file = File::create(cache_path)?;
-    file.lock()?;
-    file.write_all(content)?;
-    Ok(())
+    write_cache_file_atomically(cache_path, |file| file.write_all(content))
+}
+
+fn write_cache_file_atomically(
+    cache_path: &Path,
+    write: impl FnOnce(&mut File) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let parent = cache_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("cache path has no parent: {cache_path:?}"),
+        )
+    })?;
+    let mut temporary_file = tempfile::Builder::new()
+        .prefix(".rustnn-cache-")
+        .tempfile_in(parent)?;
+    write(temporary_file.as_file_mut())?;
+    temporary_file.as_file_mut().sync_all()?;
+    temporary_file
+        .persist(cache_path)
+        .map(|_| ())
+        .map_err(|error| error.error)
 }
 
 #[cfg(feature = "zstd-cache-compression")]
@@ -166,12 +184,12 @@ pub(crate) fn write_zstd_cache_file(cache_path: &Path, content: &[u8]) -> std::i
         "Trying to write {} bytes to compressed cache file {cache_path:?}",
         content.len()
     );
-    let file = File::create(cache_path)?;
-    file.lock()?;
-    let mut encoder = zstd::stream::write::Encoder::new(file, 0)?;
-    encoder.write_all(content)?;
-    encoder.finish()?;
-    Ok(())
+    write_cache_file_atomically(cache_path, |file| {
+        let mut encoder = zstd::stream::write::Encoder::new(file, 0)?;
+        encoder.write_all(content)?;
+        encoder.finish()?;
+        Ok(())
+    })
 }
 
 #[cfg(all(test, feature = "zstd-cache-compression"))]


### PR DESCRIPTION

## Summary

- [x] Describe the user-visible and code-level changes.

Otherwise, two writes for identical cache entries could race on the File::create call. The tempfile+rename workflow also ensures that if writing the file after creation fails the original file is still preserved.

~Potentially addresses #191~

## Validation

- [x] `make test`
- [x] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

