### PR TITLE
Fix warning in trtx test and `cargo check` trtx with `--all-targets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: cargo +1.95.0 check --no-default-features --features onnx-runtime
 
       - name: Run cargo check (TensorRT)
-        run: cargo +1.95.0 check -F trtx-runtime
+        run: cargo +1.96.0 check -F trtx-runtime --all-targets
 
       - name: Run cargo check (LiteRT)
         run: cargo +1.95.0 check --features litert-runtime

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -976,10 +976,7 @@ impl ListDevices for TrtxContext<'_> {
 #[cfg(feature = "trtx-runtime")]
 mod tests {
     use crate::mlcontext::{MLBackendContext, MLTensorDescriptor};
-    use crate::{
-        backends::trtx::{TrtxContext, format_cuda_device_cache_id},
-        mlcontext::ListDevices,
-    };
+    use crate::{backends::trtx::TrtxContext, mlcontext::ListDevices};
 
     #[test]
     fn test_context_creation() {


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Fix warning in trtx test ~and deny warnings in CI to catch future warnings ending up in main.~

EDIT: warnings in CI are already denied. The trtx test configuration is just not built in CI

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

