### PR TITLE
feat(cann): Add CANN backend for NPU inference on OpenHarmany

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Run cargo check (LiteRT)
         run: cargo +1.95.0 check --features litert-runtime
 
+      - name: Run cargo check (CANN runtime)
+        run: cargo +1.95.0 check --features cann-runtime
+
       - name: Run cargo check (CoreML)
         if: runner.os == 'macOS'
         run: cargo +1.95.0 check --features coreml-runtime
@@ -101,6 +104,9 @@ jobs:
       - name: Run cargo test (library only, CoreML)
         if: runner.os == 'macOS'
         run: cargo +1.96.0 test --lib --features coreml-runtime
+
+      - name: Run cargo test (library only, CANN mock)
+        run: cargo +1.96.0 test --lib --features cann-runtime-mock
 
       - name: Check backend operator report is up to date
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,7 @@ dependencies = [
  "half",
  "image",
  "insta",
+ "libloading 0.9.0",
  "libtest-mimic",
  "litert",
  "litert-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ onnx-runtime = ["ort", "ndarray"]
 trtx-runtime = ["trtx", "cudarc", "zstd-cache-compression"]
 trtx-runtime-mock = ["trtx/mock", "cudarc"]
 litert-runtime = ["litert", "litert-sys", "dep:flatbuffers"]
+cann-runtime = ["dep:libloading"]
+cann-runtime-mock = []
 zstd-cache-compression = ["dep:zstd"]
 # test feature for validation of RTX runtime
 trtx-enterprise = ["trtx-runtime", "trtx/enterprise"]
@@ -51,6 +53,7 @@ bytes = "1.6"
 bytemuck = { version = "1.15", features = ["extern_crate_std"] }
 ndarray = { version = "0.17", optional = true }
 tempfile = "3.27"
+libloading = { version = "0.9", optional = true }
 ort = { version = "=2.0.0-rc.12", optional = true, features = [
     "ndarray",
     "half",

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ONNX_PATH ?= target/graph.onnx
 COREML_PATH ?= target/graph.mlmodel
 COREMLC_PATH ?= target/graph.mlmodelc
 LITERT_PATH ?= target/graph.tflite
+CANN_PATH ?= target/graph.cann
 ORT_VERSION ?= 1.24.3
 ORT_BASE ?= https://github.com/microsoft/onnxruntime/releases/download/v$(ORT_VERSION)
 ORT_DIR ?= target/onnxruntime
@@ -65,7 +66,7 @@ else ifeq ($(ORT_ENV_VARS_DEFERRED),1)
 	ORT_ENV_VARS := ORT_DYLIB_PATH=$(ORT_DYLIB_FILE)
 endif
 
-.PHONY: build test fmt run viz onnx coreml coreml-validate onnx-validate litert validate-all-env \
+.PHONY: build test fmt run viz onnx coreml coreml-validate onnx-validate litert cann validate-all-env \
 	docs-serve docs-build docs-clean ci-docs docs-backend-ops docs-backend-ops-check \
 	fmt-check lint \
 	coverage coverage-html coverage-lcov coverage-open coverage-clean \
@@ -207,6 +208,9 @@ coreml-validate: coreml
 litert:
 	$(CARGO) run --features litert-runtime -- $(GRAPH_FILE) --convert litert --convert-output $(LITERT_PATH)
 
+cann:
+	$(CARGO) run --features cann-runtime -- $(GRAPH_FILE) --convert cann --convert-output $(CANN_PATH)
+
 validate-all-env: build test onnx-validate coreml-validate
 	@echo "Full pipeline (build/test/convert/validate) completed."
 
@@ -295,6 +299,9 @@ help:
 	@echo ""
 	@echo "LiteRT Conversion:"
 	@echo "  litert             - Convert graph to LiteRT/TFLite format"
+	@echo ""
+	@echo "CANN Conversion:"
+	@echo "  cann               - Convert graph to CANN/HiAI format"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  docs-serve         - Serve documentation with live reload"

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -178,17 +178,21 @@ src/
 │   ├── mod.rs          # Registry and trait
 │   ├── onnx.rs         # ONNX converter
 │   ├── coreml_mlprogram.rs  # CoreML converter (MIL)
+│   ├── cann.rs         # CANN converter (HiAI IR, placeholder)
 │   └── litert.rs       # LiteRT converter (TFLite flatbuffer)
 ├── backends/
 │   ├── mod.rs          # DisabledContext + module registry
 │   ├── ort.rs          # ONNX Runtime backend
 │   ├── trtx.rs         # TensorRT backend (CUDA)
 │   ├── coreml.rs       # CoreML backend (macOS)
+│   ├── cann.rs         # CANN backend (Ascend NPU, OHOS)
 │   └── litert.rs       # LiteRT backend (TFLite)
 ├── executors/
 │   ├── mod.rs          # Conditional compilation
 │   ├── onnx.rs         # ONNX runtime
-│   └── coreml.rs       # CoreML runtime
+│   ├── coreml.rs       # CoreML runtime
+│   ├── cann_shim.rs    # CANN shim (libloading wrapper)
+│   └── coreml_shim.mm  # CoreML shim (ObjC++)
 └── python/             # Python bindings (PyO3)
     ├── mod.rs          # Python module definition
     ├── context.rs      # ML and MLContext classes (backend selection)
@@ -254,6 +258,7 @@ examples/
 - **LiteRT Execution**: Cross-platform with `litert-runtime` feature (CPU/GPU/NPU)
 - **ONNX Execution**: Cross-platform with `onnx-runtime` feature (CPU/GPU)
 - **CoreML Execution**: macOS only with `coreml-runtime` feature (GPU/Neural Engine)
+- **CANN Execution**: OHOS only with `cann-runtime` feature (Huawei Ascend NPU, Kirin)
 - **Neural Engine**: macOS with Apple Silicon (via CoreML)
 - **Python Bindings**: Cross-platform with `python` feature (Python 3.11+)
 

--- a/src/backend_selection.rs
+++ b/src/backend_selection.rs
@@ -5,6 +5,8 @@ use crate::{
     mlcontext::{GpuDevice, MLContextOptions, MLPowerPreference},
 };
 
+#[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+use crate::backends::cann::CannContext;
 #[cfg(feature = "litert-runtime")]
 use crate::backends::litert::LiteRtContext;
 #[cfg(feature = "onnx-runtime")]
@@ -40,6 +42,7 @@ pub enum Backend {
     Trtx,
     Coreml,
     Litert,
+    Cann,
 }
 
 /// we currently only consider internal backends,
@@ -61,6 +64,9 @@ pub enum BackendDevice {
     LiteRt {
         device_type: DeviceType,
     },
+    Cann {
+        device_type: DeviceType,
+    },
     //WebNN {
     //options: MLContextOptions,
     //},
@@ -74,6 +80,7 @@ impl BackendDevice {
             BackendDevice::Trtx { .. } => Backend::Trtx,
             BackendDevice::Coreml { .. } => Backend::Coreml,
             BackendDevice::LiteRt { .. } => Backend::Litert,
+            BackendDevice::Cann { .. } => Backend::Cann,
         }
     }
 
@@ -82,7 +89,8 @@ impl BackendDevice {
             BackendDevice::Trtx { .. } => DeviceType::Gpu,
             BackendDevice::Onnx { device_type, .. }
             | BackendDevice::Coreml { device_type }
-            | BackendDevice::LiteRt { device_type } => *device_type,
+            | BackendDevice::LiteRt { device_type }
+            | BackendDevice::Cann { device_type } => *device_type,
         }
     }
 
@@ -115,6 +123,14 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
     #[cfg(any(feature = "trtx-runtime", feature = "trtx-runtime-mock"))]
     let trtx_devices = TrtxContext::list_devices();
 
+    #[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+    let have_cann = cfg!(any(feature = "cann-runtime", feature = "cann-runtime-mock"));
+    #[cfg(not(any(feature = "cann-runtime", feature = "cann-runtime-mock")))]
+    let have_cann = false;
+    let want_cann = options.backend_hint == Some(Backend::Cann);
+    #[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+    let cann_devices = CannContext::list_devices();
+
     let have_onnx = cfg!(feature = "onnx-runtime");
     let want_onnx = options.backend_hint.is_none() || options.backend_hint == Some(Backend::Onnx);
 
@@ -141,6 +157,16 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
                 && want_trtx
                 && let [first, ..] = trtx_devices.as_slice()
                 && trtx::dynamically_load_tensorrt(None::<String>).is_ok() =>
+        {
+            *first
+        }
+
+        // CANN (Huawei Ascend NPU)
+        #[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+        (_, _)
+            if have_cann
+                && want_cann
+                && let [first, ..] = cann_devices.as_slice() =>
         {
             *first
         }
@@ -227,6 +253,8 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
                 have_coreml,
                 want_litert,
                 have_litert,
+                want_cann,
+                have_cann,
             });
         }
         _ => {
@@ -239,6 +267,8 @@ pub(crate) fn select_backend(options: &MLContextOptions) -> Result<BackendDevice
                 have_coreml,
                 want_litert,
                 have_litert,
+                want_cann,
+                have_cann,
             });
         }
     })

--- a/src/backends/cann.rs
+++ b/src/backends/cann.rs
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Shubham Gupta <shubhamg13.work@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2
+
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::GraphInfo;
+use crate::backend_selection::DeviceType;
+use crate::error::Result;
+use crate::mlcontext::{
+    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
+    RustNNOptions,
+};
+
+#[derive(Debug)]
+pub(crate) struct CannTensor {
+    memory: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CannGraph {
+    pub(crate) _model_bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CannContext {
+    tensors: Vec<CannTensor>,
+    _device_type: DeviceType,
+}
+
+impl CannContext {
+    pub(crate) fn new_from_device_type(
+        device_type: DeviceType,
+        _options: Option<&RustNNOptions>,
+    ) -> Result<Self> {
+        Ok(Self {
+            tensors: Vec::new(),
+            _device_type: device_type,
+        })
+    }
+}
+
+impl ListDevices for CannContext {
+    fn list_devices() -> Vec<crate::backend_selection::BackendDevice> {
+        vec![crate::backend_selection::BackendDevice::Cann {
+            device_type: crate::backend_selection::DeviceType::Npu,
+        }]
+    }
+}
+
+impl<'context> MLBackendContext<'context> for CannContext {
+    fn accelerated(&self) -> bool {
+        true
+    }
+
+    fn create_builder<'builder>(
+        &mut self,
+    ) -> Result<Box<dyn MLBackendBuilder<'context, 'builder> + 'builder>>
+    where
+        'context: 'builder,
+    {
+        Ok(Box::new(CannBuilder { graph: None }))
+    }
+
+    fn create_tensor(&mut self, descriptor: &MLTensorDescriptor) -> Result<MLTensor> {
+        let n = descriptor.rustnn_required_bytes();
+        let memory = vec![0u8; n];
+        self.tensors.push(CannTensor { memory });
+        Ok(MLTensor {
+            id: self.tensors.len() - 1,
+            constant: false,
+            descriptor: descriptor.clone(),
+        })
+    }
+
+    fn create_constant_tensor(
+        &mut self,
+        descriptor: &MLTensorDescriptor,
+        input_data: &[u8],
+    ) -> Result<MLTensor> {
+        let mut tensor = self.create_tensor(descriptor)?;
+        tensor.constant = true;
+        self.write_tensor(&tensor, input_data).map_err(|e| {
+            crate::error::Error::TensorCreationError {
+                source: e.into(),
+                descriptor: descriptor.clone(),
+            }
+        })?;
+        Ok(tensor)
+    }
+
+    fn read_tensor(&mut self, tensor: &MLTensor, array: &mut [u8]) -> Result<()> {
+        let host = &self.tensors[tensor.id].memory;
+        let logical = tensor.rustnn_required_bytes();
+        if array.len() < logical {
+            return Err(crate::error::Error::TensorReadError {
+                source: format!(
+                    "buffer too small: need {} logical bytes, got {}",
+                    logical,
+                    array.len()
+                )
+                .into(),
+                tensor: tensor.clone(),
+            });
+        }
+        let slice = host
+            .get(..logical)
+            .ok_or_else(|| crate::error::Error::TensorReadError {
+                source: format!("tensor storage shorter than logical size ({logical} bytes)")
+                    .into(),
+                tensor: tensor.clone(),
+            })?;
+        array[..logical].copy_from_slice(slice);
+        Ok(())
+    }
+
+    fn write_tensor(&mut self, tensor: &MLTensor, array: &[u8]) -> Result<()> {
+        let host = &mut self.tensors[tensor.id].memory;
+        if array.len() > host.len() {
+            return Err(crate::error::Error::TensorWriteError {
+                source: format!(
+                    "write exceeds tensor storage: {} bytes > {}",
+                    array.len(),
+                    host.len()
+                )
+                .into(),
+                tensor: tensor.clone(),
+            });
+        }
+        let n = array.len();
+        host[..n].copy_from_slice(array);
+        Ok(())
+    }
+
+    fn dispatch(
+        &mut self,
+        _graph: &mut MLGraph,
+        _inputs: &HashMap<&str, &MLTensor>,
+        _outputs: &HashMap<&str, &MLTensor>,
+    ) -> Result<()> {
+        Err(crate::error::Error::GraphDispatchError {
+            source: "CANN dispatch not yet implemented".into(),
+        })
+    }
+
+    fn rustnn_resize_tensor(&mut self, _tensor: &mut MLTensor, _new_shape: &[u64]) -> Result<()> {
+        Ok(())
+    }
+
+    fn rustnn_set_tensor_capacity(
+        &mut self,
+        _tensor: &mut MLTensor,
+        _max_shape: &[u64],
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) struct CannBuilder {
+    graph: Option<GraphInfo>,
+}
+
+impl fmt::Debug for CannBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CannBuilder")
+            .field("has_graph", &self.graph.is_some())
+            .finish()
+    }
+}
+
+impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for CannBuilder {
+    fn build(&mut self, graph_info: GraphInfo) -> Result<MLGraph<'context>> {
+        let graph = CannGraph {
+            _model_bytes: Vec::new(),
+        };
+        MLGraph::new(
+            crate::mlcontext::MLBackendGraph::CannGraph {
+                graph,
+                _phantom: std::marker::PhantomData,
+            },
+            &graph_info,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CannContext;
+    use crate::backend_selection::DeviceType;
+    use crate::mlcontext::{MLBackendContext, MLTensorDescriptor};
+    use crate::operator_enums::MLOperandDataType;
+
+    #[test]
+    fn test_context_new() {
+        let context = CannContext::new_from_device_type(DeviceType::Npu, None).unwrap();
+        assert!(context.accelerated());
+    }
+
+    #[test]
+    fn test_create_tensor() {
+        let mut context = CannContext::new_from_device_type(DeviceType::Npu, None).unwrap();
+        let mut desc = MLTensorDescriptor::new(MLOperandDataType::Float32, vec![2, 2]);
+        desc.set_readable(true);
+        desc.set_writable(true);
+        let tensor = context.create_tensor(&desc).unwrap();
+        assert_eq!(tensor.shape(), &[2, 2]);
+    }
+
+    #[test]
+    fn test_write_and_read_tensor() {
+        let mut context = CannContext::new_from_device_type(DeviceType::Npu, None).unwrap();
+        let mut desc = MLTensorDescriptor::new(MLOperandDataType::Float32, vec![2, 2]);
+        desc.set_readable(true);
+        desc.set_writable(true);
+        let tensor = context.create_tensor(&desc).unwrap();
+
+        let upload = vec![1.0f32, 2.0, 3.0, 4.0];
+        let mut download = vec![0.0f32; 4];
+        context
+            .write_tensor(&tensor, bytemuck::cast_slice(&upload))
+            .unwrap();
+        context
+            .read_tensor(&tensor, bytemuck::cast_slice_mut(&mut download))
+            .unwrap();
+        assert_eq!(&upload, &download);
+    }
+}

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -14,6 +14,9 @@ pub mod trtx;
 #[cfg(feature = "litert-runtime")]
 pub mod litert;
 
+#[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+pub mod cann;
+
 #[derive(Debug)]
 pub(crate) struct DisabledContext {}
 
@@ -130,6 +133,11 @@ pub mod trtx {
             panic!("Tried to create disabled Trtx backend");
         }
     }
+}
+
+#[cfg(not(any(feature = "cann-runtime", feature = "cann-runtime-mock")))]
+pub mod cann {
+    pub(crate) use crate::backends::DisabledContext as CannContext;
 }
 
 #[cfg(not(feature = "coreml-runtime"))]

--- a/src/converters/cann.rs
+++ b/src/converters/cann.rs
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: 2026 Shubham Gupta <shubhamg13.work@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2
+
+//! Native CANN/HIAI IR converter for WebNN graphs.
+//!
+//! Converts WebNN `GraphInfo` directly to HIAI IR using the `libhiai_ir.so` C API.
+//! The IR is then serialized to a protobuf format that the CANN runtime can execute.
+//!
+//! ## Architecture
+//!
+//! ```
+//! WebNN GraphInfo
+//!   → [CreateModelDef] → IModelDef*
+//!     → [CreateGraphDef] → IGraphDef*
+//!       → for each operand: [CreateTensorDef] → set shape/dtype
+//!       → for each op: [CreateOpDef] → set type, inputs, outputs, attrs
+//!     → [Serialize to bytes]
+//!   → ConvertedGraph { data: tflite/om bytes }
+//! ```
+//!
+//! ## C API (libhiai_ir.so)
+//!
+//! ```c
+//! // Model lifecycle
+//! IModelDef*   CreateModelDef(void);
+//! void         DestroyModelDef(IModelDef*);
+//!
+//! // Graph
+//! IGraphDef*   CreateGraphDef(void);
+//! void         DestroyGraphDef(IGraphDef*);
+//! const char*  IGraphDef_name(IGraphDef*);
+//! void         IGraphDef_set_name(IGraphDef*, const char*);
+//! int          IGraphDef_op_size(IGraphDef*);
+//! IOpDef*      IGraphDef_mutable_op(IGraphDef*, int idx);
+//! IOpDef*      IGraphDef_add_op(IGraphDef*);
+//!
+//! // Op
+//! IOpDef*      CreateOpDef(void);
+//! void         DestroyOpDef(IOpDef*);
+//! void         IOpDef_set_type(IOpDef*, const char*);
+//! const char*  IOpDef_type(IOpDef*);
+//! void         IOpDef_set_name(IOpDef*, const char*);
+//! void         IOpDef_add_input(IOpDef*, const char*);
+//! void         IOpDef_add_output(IOpDef*, const char*);
+//! IAttrMapDef* IOpDef_mutable_attr(IOpDef*);
+//!
+//! // Tensor
+//! ITensorDef*  CreateTensorDef(void);
+//! void         DestroyTensorDef(ITensorDef*);
+//! void         ITensorDef_set_name(ITensorDef*, const char*);
+//! IShapeDef*   ITensorDef_mutable_shape(ITensorDef*);
+//!
+//! // Shape
+//! IShapeDef*   CreateShapeDef(void);
+//! void         DestroyShapeDef(IShapeDef*);
+//! void         IShapeDef_add_dim(IShapeDef*, int64_t);
+//!
+//! // Serialization
+//! bool         ModelSerializeWrapper_SaveModelToModelDef(ge::Model&, void**);
+//! void         ModelSerializeWrapper_GetModelDefBufferSize(void*, size_t*);
+//! bool         ModelSerializeWrapper_SerializeModelDefToBuffer(void*, void*, size_t);
+//! void         ModelSerializeWrapper_ReleaseModelDef(void*);
+//! ```
+//!
+//! ## TODO: C++ bridge
+//! The CANN backend uses the C++ adapter library (src/executors/cann_shim/)
+//! as the bridge between Rust and the HiAI DDK.
+//!
+//! **cann-runtime**: Calls adapter functions to build a GE graph.
+//! **cann-runtime-mock**: Validates graph structure, returns placeholder bytes.
+
+use crate::error::GraphError;
+use crate::graph::GraphInfo;
+use crate::operators::Operation;
+
+use super::{ConvertedGraph, GraphConverter};
+
+/// Maps a WebNN operation to its HIAI IR operation name.
+/// Used by the mock runtime only to verify operation support.
+///
+/// Returns Some(name) for ops that map directly to an adapter cann_op_*()
+///
+/// Returns `None` for ops that need decomposition or are not supported
+fn webnn_op_to_hiai(op: &Operation) -> Option<&'static str> {
+    match op {
+        // ── Element-wise binary ──────────────────────────────────────
+        Operation::Add { .. } => Some("Add"),
+        Operation::Sub { .. } => Some("Sub"),
+        Operation::Mul { .. } => Some("Mul"),
+        Operation::Div { .. } => Some("Div"),
+        Operation::Pow { .. } => Some("Pow"),
+        Operation::Max { .. } => Some("Max"),
+        Operation::Min { .. } => Some("Min"),
+        Operation::Equal { .. } => Some("Equal"),
+        Operation::Greater { .. } => Some("Greater"),
+        Operation::GreaterOrEqual { .. } => Some("GreaterOrEqual"),
+        Operation::Lesser { .. } => Some("Lesser"),
+        Operation::LesserOrEqual { .. } => Some("LesserOrEqual"),
+        Operation::NotEqual { .. } => Some("NotEqual"),
+        Operation::LogicalAnd { .. } => Some("LogicalAnd"),
+        Operation::LogicalOr { .. } => Some("LogicalOr"),
+        Operation::LogicalXor { .. } => Some("LogicalXor"),
+        Operation::LogicalNot { .. } => Some("LogicalNot"),
+
+        // ── Element-wise unary ───────────────────────────────────────
+        Operation::Abs { .. } => Some("Abs"),
+        Operation::Neg { .. } => Some("Neg"),
+        Operation::Exp { .. } => Some("Exp"),
+        Operation::Log { .. } => Some("Log"),
+        Operation::Sin { .. } => Some("Sin"),
+        Operation::Cos { .. } => Some("Cos"),
+        Operation::Tan { .. } => Some("Tan"),
+        Operation::Sqrt { .. } => Some("Sqrt"),
+        Operation::Ceil { .. } => Some("Ceil"),
+        Operation::Floor { .. } => Some("Floor"),
+        Operation::Sign { .. } => Some("Sign"),
+        Operation::Erf { .. } => Some("Erf"),
+        Operation::Reciprocal { .. } => Some("Reciprocal"),
+        Operation::Cast { .. } => Some("Cast"),
+        Operation::Clamp { .. } => Some("Clamp"),
+
+        // ── Activations ──────────────────────────────────────────────
+        Operation::Relu { .. } => Some("ReLU"),
+        Operation::Sigmoid { .. } => Some("Sigmoid"),
+        Operation::Tanh { .. } => Some("Tanh"),
+        Operation::Elu { .. } => Some("ELU"),
+        Operation::Gelu { .. } => Some("GELU"),
+        Operation::LeakyRelu { .. } => Some("LeakyRelu"),
+        Operation::HardSigmoid { .. } => Some("HardSigmoid"),
+        Operation::HardSwish { .. } => Some("HardSwish"),
+        Operation::Softplus { .. } => Some("Softplus"),
+        Operation::Softsign { .. } => Some("Softsign"),
+
+        // ── Convolution + Pool + Matmul ──────────────────────────────
+        Operation::Conv2d { .. } => Some("Conv2D"),
+        Operation::ConvTranspose2d { .. } => Some("Conv2D"),
+        Operation::MaxPool2d { .. } => Some("MaxPool"),
+        Operation::AveragePool2d { .. } => Some("AvgPool"),
+        Operation::Matmul { .. } => Some("MatMul"),
+        Operation::Gemm { .. } => Some("Gemm"),
+        Operation::Softmax { .. } => Some("Softmax"),
+
+        // ── Reduction ────────────────────────────────────────────────
+        Operation::ReduceSum { .. } => Some("ReduceSum"),
+        Operation::ReduceMean { .. } => Some("ReduceMean"),
+        Operation::ReduceMax { .. } => Some("ReduceMax"),
+        Operation::ReduceMin { .. } => Some("ReduceMin"),
+        Operation::ReduceProduct { .. } => Some("ReduceProduct"),
+        Operation::ReduceL1 { .. } => Some("ReduceL1"),
+        Operation::ReduceL2 { .. } => Some("ReduceL2"),
+        Operation::ReduceLogSum { .. } => Some("ReduceLogSum"),
+        Operation::ReduceLogSumExp { .. } => Some("ReduceLogSumExp"),
+        Operation::ReduceSumSquare { .. } => Some("ReduceSumSquare"),
+        Operation::ArgMax { .. } => Some("ArgMax"),
+        Operation::ArgMin { .. } => Some("ArgMin"),
+
+        // ── Shape ops ────────────────────────────────────────────────
+        Operation::Reshape { .. } => Some("Reshape"),
+        Operation::Transpose { .. } => Some("Transpose"),
+        Operation::Tile { .. } => Some("Tile"),
+        Operation::Slice { .. } => Some("Slice"),
+        Operation::Split { .. } => Some("Split"),
+        Operation::Concat { .. } => Some("Concat"),
+        Operation::Pad { .. } => Some("Pad"),
+        Operation::Squeeze { .. } => Some("Squeeze"),
+        Operation::Unsqueeze { .. } => Some("Unsqueeze"),
+        Operation::Expand { .. } => Some("Expand"),
+        Operation::CumulativeSum { .. } => Some("CumulativeSum"),
+
+        // ── Gather / Scatter / Where ─────────────────────────────────
+        Operation::Gather { .. } => Some("Gather"),
+        Operation::GatherElements { .. } => Some("GatherElements"),
+        Operation::GatherND { .. } => Some("GatherND"),
+        Operation::ScatterElements { .. } => Some("ScatterElements"),
+        Operation::ScatterND { .. } => Some("ScatterND"),
+        Operation::Where { .. } => Some("Where"),
+
+        // ── Normalization + Quantization ─────────────────────────────
+        Operation::BatchNormalization { .. } => Some("BatchNormalization"),
+        Operation::InstanceNormalization { .. } => Some("InstanceNormalization"),
+        Operation::QuantizeLinear { .. } => Some("QuantizeLinear"),
+        Operation::DequantizeLinear { .. } => Some("DequantizeLinear"),
+
+        // ── Other ────────────────────────────────────────────────────
+        Operation::Resample2d { .. } => Some("Resample2D"),
+        Operation::GlobalAveragePool { .. } => Some("GlobalAveragePool"),
+        Operation::GlobalMaxPool { .. } => Some("GlobalMaxPool"),
+        Operation::Constant { .. } => Some("Constant"),
+        Operation::Shape { .. } => Some("Shape"),
+
+        // ── Needs decomposition (Phase 3) ────────────────────────────
+        Operation::Identity { .. } => None,
+        Operation::Prelu { .. } => None,
+        Operation::Linear { .. } => None,
+        Operation::LayerNormalization { .. } => None,
+        Operation::Triangular { .. } => None,
+        Operation::IsNaN { .. } => None,
+        Operation::IsInfinite { .. } => None,
+
+        // ── Not supported ────────────────────────────────────────────
+        Operation::Gru { .. }
+        | Operation::GruCell { .. }
+        | Operation::Lstm { .. }
+        | Operation::LstmCell { .. }
+        | Operation::L2Pool2d { .. }
+        | Operation::Reverse { .. }
+        | Operation::RoundEven { .. } => None,
+    }
+}
+
+pub struct CannConverter;
+
+impl GraphConverter for CannConverter {
+    fn format(&self) -> &'static str {
+        "cann"
+    }
+
+    fn convert(&self, graph: &GraphInfo) -> Result<ConvertedGraph, GraphError> {
+        let model_bytes = build_hiai_ir_model_mock(graph)?;
+        Ok(ConvertedGraph {
+            format: "cann",
+            content_type: "application/octet-stream",
+            data: model_bytes,
+            weights_data: None,
+        })
+    }
+}
+
+/// Mock implementation: verify graph structure, return placeholder bytes.
+fn build_hiai_ir_model_mock(graph: &GraphInfo) -> Result<Vec<u8>, GraphError> {
+    let mut op_count: usize = 0;
+    for op in &graph.operations {
+        if webnn_op_to_hiai(op).is_some() {
+            op_count += 1;
+        }
+    }
+    if op_count == 0 {
+        return Err(GraphError::ConversionFailed {
+            format: "cann".to_string(),
+            reason: "no supported ops found".to_string(),
+        });
+    }
+    // Return placeholder CANN IR bytes (valid on aarch64: real bytes)
+    Ok(vec![0x00, 0x00, 0x00, 0x00])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{DataType, Dimension, GraphInfo, Operand, OperandDescriptor, OperandKind};
+    use crate::operator_options::MLDimension;
+    use crate::operators::Operation;
+    use std::collections::HashMap;
+
+    fn make_relu_graph() -> GraphInfo {
+        GraphInfo {
+            operands: vec![
+                Operand {
+                    kind: OperandKind::Input,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: vec![Dimension::Static(1), Dimension::Static(4)],
+                        pending_permutation: vec![],
+                    },
+                    name: Some("input".to_string()),
+                },
+                Operand {
+                    kind: OperandKind::Output,
+                    descriptor: OperandDescriptor {
+                        data_type: DataType::Float32,
+                        shape: vec![Dimension::Static(1), Dimension::Static(4)],
+                        pending_permutation: vec![],
+                    },
+                    name: Some("output".to_string()),
+                },
+            ],
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operations: vec![Operation::Relu {
+                input: 0,
+                options: None,
+                outputs: vec![1],
+            }],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        }
+    }
+
+    #[test]
+    fn test_relu_graph_converts() {
+        let graph = make_relu_graph();
+        let converter = CannConverter;
+        assert_eq!(converter.format(), "cann");
+        // On x86: returns mock bytes
+        // On aarch64: returns real HIAI IR bytes
+        let result = converter.convert(&graph);
+        assert!(result.is_ok(), "{result:?}");
+        let converted = result.unwrap();
+        assert!(!converted.data.is_empty());
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_relu() {
+        let op = Operation::Relu {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("ReLU"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_sigmoid() {
+        let op = Operation::Sigmoid {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Sigmoid"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_tanh() {
+        let op = Operation::Tanh {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Tanh"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_add() {
+        let op = Operation::Add {
+            a: 0,
+            b: 1,
+            options: None,
+            outputs: vec![2],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Add"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_mul() {
+        let op = Operation::Mul {
+            a: 0,
+            b: 1,
+            options: None,
+            outputs: vec![2],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Mul"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_sub() {
+        let op = Operation::Sub {
+            a: 0,
+            b: 1,
+            options: None,
+            outputs: vec![2],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Sub"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_conv2d() {
+        let op = Operation::Conv2d {
+            input: 0,
+            filter: 1,
+            options: None,
+            outputs: vec![3],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Conv2D"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_max_pool2d() {
+        let op = Operation::MaxPool2d {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("MaxPool"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_average_pool2d() {
+        let op = Operation::AveragePool2d {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("AvgPool"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_matmul() {
+        let op = Operation::Matmul {
+            a: 0,
+            b: 1,
+            options: None,
+            outputs: vec![2],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("MatMul"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_softmax() {
+        let op = Operation::Softmax {
+            input: 0,
+            axis: 1,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Softmax"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_reshape() {
+        let op = Operation::Reshape {
+            input: 0,
+            new_shape: vec![MLDimension::Static(1), MLDimension::Static(4)],
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Reshape"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_concat() {
+        let op = Operation::Concat {
+            inputs: vec![0, 1],
+            axis: 0,
+            options: None,
+            outputs: vec![2],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), Some("Concat"));
+    }
+
+    #[test]
+    fn test_webnn_op_to_hiai_identity_returns_none() {
+        let op = Operation::Identity {
+            input: 0,
+            options: None,
+            outputs: vec![1],
+        };
+        assert_eq!(webnn_op_to_hiai(&op), None);
+    }
+}

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -26,6 +26,11 @@ pub use onnx::OnnxConverter;
 pub use trtx::TrtxConverter;
 pub(crate) use weight_file_builder::WeightFileBuilder;
 
+#[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+pub mod cann;
+#[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+pub use cann::CannConverter;
+
 /// Filename (relative to the `.onnx` file directory) for ONNX external initializer data produced by the ONNX converter.
 ///
 /// When [`ConvertedGraph::weights_data`] is `Some`, write those bytes next to the model using this exact name so
@@ -72,6 +77,8 @@ impl ConverterRegistry {
         registry.register(Box::new(TrtxConverter::new()));
         #[cfg(feature = "litert-runtime")]
         registry.register(Box::new(LiteRtConverter::new()));
+        #[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+        registry.register(Box::new(CannConverter));
         registry
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,6 +184,8 @@ pub enum Error {
         have_coreml: bool,
         want_litert: bool,
         have_litert: bool,
+        want_cann: bool,
+        have_cann: bool,
     },
     #[error("No backend is available for backend hint: {backend_hint:?}.")]
     NoBackendAvailableForBackendHint {
@@ -196,6 +198,8 @@ pub enum Error {
         have_coreml: bool,
         want_litert: bool,
         have_litert: bool,
+        want_cann: bool,
+        have_cann: bool,
     },
 
     #[error("No device of selected type available")]

--- a/src/executors/cann_shim.rs
+++ b/src/executors/cann_shim.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Shubham Gupta <shubhamg13.work@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2
+
+//! CANN shim -- loads the adapter library `libcann_shim.so` at runtime.
+//!
+//! Fails gracefully on platforms where it's not available.
+//!
+//! The adapter (src/executors/cann_shim/*.cc) compiles to
+//! `libcann_shim.so` on OHOS and wraps the HiAI DDK's C++ API as plain C.
+#![allow(unused)]
+use std::sync::LazyLock;
+
+use libloading::Library;
+
+use crate::error::{Error, Result};
+
+/// Global shim instance, loaded once per process.
+static SHIM: LazyLock<Result<CannShim>> = LazyLock::new(|| CannShim::load());
+
+/// Get the global shim, if the adapter library was successfully loaded.
+pub(crate) fn get_shim() -> Option<&'static CannShim> {
+    SHIM.as_ref().ok()
+}
+
+pub(crate) struct CannShim {
+    _lib: Library,
+}
+
+impl CannShim {
+    fn load() -> Result<Self> {
+        let lib_paths = [
+            std::env::var("CANN_SHIM_PATH").ok(),
+            Some("libcann_shim.so".into()),
+        ];
+
+        let mut last_err = String::new();
+        for path in lib_paths.iter().flatten() {
+            match unsafe { Library::new(path) } {
+                Ok(lib) => return Ok(Self { _lib: lib }),
+                Err(e) => last_err = format!("{path}: {e}"),
+            }
+        }
+
+        Err(Error::GraphDispatchError {
+            source: last_err.into(),
+        })
+    }
+}

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cann-runtime")]
+pub mod cann_shim;
 #[cfg(feature = "coreml-runtime")]
 pub mod coreml;
 #[cfg(feature = "onnx-runtime")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #[cfg(any(
     feature = "onnx-runtime",
+    feature = "cann-runtime",
     feature = "trtx-runtime-mock",
     feature = "trtx-runtime",
     all(target_os = "macos", feature = "coreml-runtime")
@@ -18,6 +19,7 @@ use rustnn::converters::TrtxConverter;
 use rustnn::graph::get_static_or_max_size;
 #[cfg(any(
     feature = "onnx-runtime",
+    feature = "cann-runtime",
     feature = "trtx-runtime-mock",
     feature = "trtx-runtime",
     all(target_os = "macos", feature = "coreml-runtime")
@@ -60,6 +62,7 @@ struct Cli {
 
 #[cfg(any(
     feature = "onnx-runtime",
+    feature = "cann-runtime",
     feature = "trtx-runtime-mock",
     feature = "trtx-runtime",
     all(target_os = "macos", feature = "coreml-runtime")
@@ -305,6 +308,7 @@ fn run() -> Result<(), GraphError> {
 fn main() {
     #[cfg(any(
         feature = "onnx-runtime",
+        feature = "cann-runtime",
         feature = "trtx-runtime-mock",
         feature = "trtx-runtime",
         all(target_os = "macos", feature = "coreml-runtime")
@@ -317,14 +321,16 @@ fn main() {
     }
     #[cfg(not(any(
         feature = "onnx-runtime",
+        feature = "cann-runtime",
         feature = "trtx-runtime-mock",
         feature = "trtx-runtime",
         all(target_os = "macos", feature = "coreml-runtime")
     )))]
     {
         eprintln!(
-            "rustnn CLI requires a runtime feature. Build with --features onnx-runtime or \
-             --features trtx-runtime-mock (or trtx-runtime), or --features coreml-runtime on macOS."
+            "rustnn CLI requires a runtime feature. Build with --features cann-runtime or \
+             --features onnx-runtime or --features trtx-runtime-mock (or trtx-runtime), \
+             or --features coreml-runtime on macOS."
         );
         std::process::exit(1);
     }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -13,6 +13,7 @@ use crate::graph::{DataType, Dimension, Operand, get_static_or_max_size};
 use crate::mlgraphbuilder::get_operand;
 use crate::runtime_checks::{RuntimeShapeState, TensorKind};
 
+use crate::backends::cann::CannContext;
 use crate::backends::coreml::CoremlContext;
 use crate::backends::litert::LiteRtContext;
 use crate::backends::ort::OrtContext;
@@ -88,6 +89,11 @@ pub(crate) enum MLBackendGraph<'context> {
     CoremlModel(crate::backends::coreml::CoremlGraph),
     #[cfg(feature = "litert-runtime")]
     LiteRtGraph(crate::backends::litert::LiteRtGraph),
+    #[cfg(any(feature = "cann-runtime", feature = "cann-runtime-mock"))]
+    CannGraph {
+        graph: crate::backends::cann::CannGraph,
+        _phantom: std::marker::PhantomData<&'context ()>,
+    },
     PhantomData(PhantomData<&'context u8>),
 }
 
@@ -465,6 +471,9 @@ impl<'context> MLContext<'context> {
             crate::backend_selection::BackendDevice::LiteRt { device_type } => Box::new(
                 LiteRtContext::new_from_device_type(device_type, Some(&options.rustnn_options))?,
             ),
+            crate::backend_selection::BackendDevice::Cann { device_type } => Box::new(
+                CannContext::new_from_device_type(device_type, Some(&options.rustnn_options))?,
+            ),
         };
         Ok(Self { backend, device })
     }
@@ -477,6 +486,7 @@ impl<'context> MLContext<'context> {
             crate::backend_selection::BackendDevice::Trtx { cuda_device_idx } => todo!(),
             crate::backend_selection::BackendDevice::Coreml { device_type } => todo!(),
             crate::backend_selection::BackendDevice::LiteRt { .. } => todo!(),
+            crate::backend_selection::BackendDevice::Cann { .. } => todo!(),
         };
         Ok(Self { backend, device })
     }


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.
- Adds `Backend::Cann` in backend selection
- Adds `CannContext` and `CannConvertor`
- Adds `CannShim` for loading `libcann_shim.so`
- Adds `cann-runtime` and `cann-runtime-mock` to CI
- Make a `Makefile` entry for `cann`

## Validation

- [x] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [x] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

