### PR TITLE
refactor!: HashMap -> MLNamedTensors, MLNamedOperands

### DIFF
--- a/examples/fast_style_transfer_builder_api.rs
+++ b/examples/fast_style_transfer_builder_api.rs
@@ -1,7 +1,6 @@
 // Port of https://d3i5xkfad89fac.cloudfront.net/test-data/models/fast_style_transfer_nchw/weights
 // (Apache 2.0)
 use std::{
-    collections::HashMap,
     fmt,
     path::{Path, PathBuf},
     time::Instant,
@@ -11,8 +10,8 @@ use anyhow::{Context, Result, bail, ensure};
 use clap::{Parser, ValueEnum};
 use futures_util::future::join_all;
 use rustnn::mlcontext::{
-    MLContext, MLContextOptions, MLGraphBuilder, MLOperand, MLOperandDescriptor, MLPowerPreference,
-    MLTensorDescriptor,
+    MLContext, MLContextOptions, MLGraphBuilder, MLNamedOperands, MLNamedTensors, MLOperand,
+    MLOperandDescriptor, MLPowerPreference, MLTensorDescriptor,
 };
 use rustnn::operator_enums::MLOperandDataType;
 use rustnn::operator_options::{
@@ -850,8 +849,8 @@ fn run_inferences(
             .write_tensor(&input_tensors[slot], input_data)
             .context("write input tensor")?;
         starts[slot] = Some(Instant::now());
-        let inputs = HashMap::from([("input", &input_tensors[slot])]);
-        let outputs = HashMap::from([("output", &output_tensors[slot])]);
+        let inputs = MLNamedTensors::from([("input", &input_tensors[slot])]);
+        let outputs = MLNamedTensors::from([("output", &output_tensors[slot])]);
         context
             .dispatch(graph, &inputs, &outputs)
             .context("dispatch graph")?;
@@ -1010,7 +1009,7 @@ async fn main() -> Result<()> {
             inferred_output_shape,
             OUTPUT_SHAPE
         );
-        let outputs = HashMap::from([("output", output_operand)]);
+        let outputs = MLNamedOperands::from([("output", output_operand)]);
         builder.build(&outputs).context("build MLGraph")?
     };
 

--- a/examples/resnet50_webnn_rust.rs
+++ b/examples/resnet50_webnn_rust.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
 use rustnn::mlcontext::{
-    MLContext, MLContextOptions, MLGraphBuilder, MLPowerPreference, MLTensorDescriptor,
+    MLContext, MLContextOptions, MLGraphBuilder, MLNamedTensors, MLPowerPreference,
+    MLTensorDescriptor,
 };
 use rustnn::operator_enums::MLOperandDataType;
 use rustnn::{ContextProperties, GraphValidator, load_graph_from_path};
@@ -292,8 +292,8 @@ fn run() -> Result<(), String> {
         context
             .write_tensor(&input_tensor, input_data)
             .map_err(|e| format!("write_tensor: {e}"))?;
-        let inputs = HashMap::from([(input_name.as_str(), &input_tensor)]);
-        let outputs = HashMap::from([(output_name.as_str(), &output_tensor)]);
+        let inputs = MLNamedTensors::from([(input_name.as_str(), &input_tensor)]);
+        let outputs = MLNamedTensors::from([(output_name.as_str(), &output_tensor)]);
         context
             .dispatch(ml_graph, &inputs, &outputs)
             .map_err(|e| format!("dispatch: {e:?}"))?;
@@ -316,8 +316,8 @@ fn run() -> Result<(), String> {
             context
                 .write_tensor(&input_tensor, &input_data)
                 .map_err(|e| format!("write_tensor: {e}"))?;
-            let inputs = HashMap::from([(input_name.as_str(), &input_tensor)]);
-            let outputs = HashMap::from([(output_name.as_str(), &output_tensor)]);
+            let inputs = MLNamedTensors::from([(input_name.as_str(), &input_tensor)]);
+            let outputs = MLNamedTensors::from([(output_name.as_str(), &output_tensor)]);
             let start = Instant::now();
             context
                 .dispatch(&mut ml_graph, &inputs, &outputs)

--- a/examples/smollm_mlcontext.rs
+++ b/examples/smollm_mlcontext.rs
@@ -6,8 +6,8 @@ use log::{debug, info};
 use rustnn::{
     ContextProperties, GraphValidator, ValidationArtifacts, load_graph_from_path,
     mlcontext::{
-        MLContext, MLContextOptions, MLGraph, MLGraphBuilder, MLPowerPreference, MLTensor,
-        MLTensorDescriptor,
+        MLContext, MLContextOptions, MLGraph, MLGraphBuilder, MLNamedTensors, MLPowerPreference,
+        MLTensor, MLTensorDescriptor,
     },
     operator_enums::MLOperandDataType,
 };
@@ -375,7 +375,7 @@ fn run_step<'context>(
         }
     }
 
-    // Name strings must outlive the HashMap borrows below.
+    // Name strings must outlive the named tensor map borrows below.
     let past_k_names: Vec<String> = (0..layout.num_layers)
         .map(|l| format!("past_key_values_{l}_key"))
         .collect();
@@ -389,7 +389,7 @@ fn run_step<'context>(
         .map(|l| format!("present_{l}_value"))
         .collect();
 
-    let mut inputs: HashMap<&str, &MLTensor> = HashMap::new();
+    let mut inputs = MLNamedTensors::new();
     inputs.insert("input_ids", &tensors.input_ids);
     inputs.insert("position_ids", &tensors.position_ids);
     inputs.insert("attention_mask", &tensors.attention_mask);
@@ -398,7 +398,7 @@ fn run_step<'context>(
         inputs.insert(&past_v_names[i], &tensors.past_v[i]);
     }
 
-    let mut outputs: HashMap<&str, &MLTensor> = HashMap::new();
+    let mut outputs = MLNamedTensors::new();
     outputs.insert(&layout.logits_name, logits_tensor);
     for i in 0..layout.num_layers {
         outputs.insert(&pres_k_names[i], &tensors.present_k[i]);

--- a/src/backends/cann.rs
+++ b/src/backends/cann.rs
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2
 
-use std::collections::HashMap;
 use std::fmt;
 
 use crate::GraphInfo;
 use crate::backend_selection::DeviceType;
 use crate::error::Result;
+use crate::mlcontext::MLNamedTensors;
 use crate::mlcontext::{
     ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
     RustNNOptions,
@@ -136,8 +136,8 @@ impl<'context> MLBackendContext<'context> for CannContext {
     fn dispatch(
         &mut self,
         _graph: &mut MLGraph,
-        _inputs: &HashMap<&str, &MLTensor>,
-        _outputs: &HashMap<&str, &MLTensor>,
+        _inputs: &MLNamedTensors,
+        _outputs: &MLNamedTensors,
     ) -> Result<()> {
         Err(crate::error::Error::GraphDispatchError {
             source: "CANN dispatch not yet implemented".into(),

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -22,7 +22,8 @@ use crate::executors::coreml::{
 use crate::graph::DataType;
 use crate::mlcontext::RustNNOptions;
 use crate::mlcontext::{
-    MLBackendBuilder, MLBackendContext, MLBackendGraph, MLGraph, MLTensor, MLTensorDescriptor,
+    MLBackendBuilder, MLBackendContext, MLBackendGraph, MLGraph, MLNamedTensors, MLTensor,
+    MLTensorDescriptor,
 };
 use crate::operators::Operation;
 
@@ -205,8 +206,8 @@ impl<'context> MLBackendContext<'context> for CoremlContext {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> crate::error::Result<()> {
         // Gather raw-byte inputs keyed by feature name, then run; the borrow of
         // `self.tensors` is released before we write outputs back.
@@ -364,11 +365,9 @@ impl<'context> MLBackendContext<'context> for CoremlContext {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use crate::mlcontext::{
-        Backend, MLContext, MLContextOptions, MLOperandDescriptor, MLPowerPreference,
-        MLTensorDescriptor,
+        Backend, MLContext, MLContextOptions, MLNamedOperands, MLNamedTensors, MLOperandDescriptor,
+        MLPowerPreference, MLTensorDescriptor,
     };
     use crate::mlgraphbuilder::MLGraphBuilder;
     use crate::operator_enums::MLOperandDataType;
@@ -401,7 +400,7 @@ mod test {
         let b = builder.input("b", &desc).unwrap();
         let a = builder.relu(a).unwrap();
         let output = builder.add(a, b).unwrap();
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", output);
         let mut graph = builder.build(&outputs).unwrap();
 
@@ -417,10 +416,10 @@ mod test {
         context.write_tensor(&a, &[-1.0f32, 2., -3., 4.]).unwrap();
         context.write_tensor(&b, &[1.0f32, 1., 1., 1.]).unwrap();
 
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("a", &a);
         inputs.insert("b", &b);
-        let mut out_bindings = HashMap::new();
+        let mut out_bindings = MLNamedTensors::new();
         out_bindings.insert("out", &out);
 
         context
@@ -445,7 +444,7 @@ mod test {
         let a = builder.input("a", &desc).unwrap();
         let b = builder.input("b", &desc).unwrap();
         let output = builder.add(a, b).unwrap();
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", output);
 
         // CoreML's MLMultiArray has no native int32 add on every compute unit; if the
@@ -469,10 +468,10 @@ mod test {
         context.write_tensor(&a, &[1i32, 2, 3, 4]).unwrap();
         context.write_tensor(&b, &[10i32, 20, 30, 40]).unwrap();
 
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("a", &a);
         inputs.insert("b", &b);
-        let mut out_bindings = HashMap::new();
+        let mut out_bindings = MLNamedTensors::new();
         out_bindings.insert("out", &out);
 
         if let Err(e) = context.dispatch(&mut graph, &inputs, &out_bindings) {

--- a/src/backends/litert.rs
+++ b/src/backends/litert.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2
 
-use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fmt;
 use std::ptr::NonNull;
@@ -14,8 +13,8 @@ use crate::backend_selection::DeviceType;
 use crate::converters::{GraphConverter, LiteRtConverter};
 use crate::error::{Error, Result};
 use crate::mlcontext::{
-    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
-    RustNNOptions,
+    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLNamedTensors, MLTensor,
+    MLTensorDescriptor, RustNNOptions,
 };
 
 use crate::operator_enums::MLOperandDataType;
@@ -971,8 +970,8 @@ impl<'context> MLBackendContext<'context> for LiteRtContext {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> Result<()> {
         let lite_graph = match &graph.backend {
             crate::mlcontext::MLBackendGraph::LiteRtGraph(graph) => graph,

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -81,8 +81,8 @@ impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
     fn dispatch(
         &mut self,
         _graph: &mut mlcontext::MLGraph,
-        _inputs: &std::collections::HashMap<&str, &mlcontext::MLTensor>,
-        _outputs: &std::collections::HashMap<&str, &mlcontext::MLTensor>,
+        _inputs: &mlcontext::MLNamedTensors,
+        _outputs: &mlcontext::MLNamedTensors,
     ) -> crate::error::Result<()> {
         panic!("RustNN is expected to never use a disabled backend")
     }

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
@@ -18,8 +17,8 @@ use crate::error::Error;
 use crate::executors::onnx::ensure_ort_initialized;
 use crate::graph::{pack_int4, pack_uint4_from_i32, unpack_int4, unpack_uint4};
 use crate::mlcontext::{
-    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLTensor, MLTensorDescriptor,
-    RustNNOptions,
+    ListDevices, MLBackendBuilder, MLBackendContext, MLGraph, MLNamedTensors, MLTensor,
+    MLTensorDescriptor, RustNNOptions,
 };
 use crate::{GraphError, GraphInfo, ONNX_EXTERNAL_WEIGHTS_FILENAME};
 
@@ -551,7 +550,7 @@ fn copy_dyn_value_to_buffer(
 
 fn write_outputs_from_session<'s>(
     session_outputs: &SessionOutputs<'s>,
-    outputs: &HashMap<&str, &MLTensor>,
+    outputs: &MLNamedTensors,
     tensors: &mut [OrtTensor],
 ) -> crate::error::Result<()> {
     for (&name, ml_tensor) in outputs.iter() {
@@ -765,8 +764,8 @@ impl<'context> MLBackendContext<'context> for OrtContext {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> crate::error::Result<()> {
         let ort_graph =
             graph

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -35,7 +35,7 @@ use crate::graph::WeightsToHash;
 use crate::mlcontext::MLTensor;
 use crate::mlcontext::RustNNOptions;
 use crate::mlcontext::{ListDevices, MLOperand};
-use crate::mlcontext::{MLBackendBuilder, MLGraph};
+use crate::mlcontext::{MLBackendBuilder, MLGraph, MLNamedTensors};
 use crate::mlcontext::{MLBackendContext, MLBackendGraph};
 use crate::mlcontextoptions::TrtxOptions;
 
@@ -746,8 +746,8 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
     fn dispatch(
         &mut self,
         graph: &mut crate::mlcontext::MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> crate::error::Result<()> {
         self.cuda_ctx.bind_to_thread()?;
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -18,12 +18,16 @@ use crate::backends::coreml::CoremlContext;
 use crate::backends::litert::LiteRtContext;
 use crate::backends::ort::OrtContext;
 use crate::backends::trtx::TrtxContext;
+use std::collections::BTreeMap;
 use std::{collections::HashMap, fmt::Display, marker::PhantomData};
 
 pub use crate::mlcontextoptions::{
     CoremlOptions, LiteRtOptions, MLContextOptions, MLPowerPreference, OrtOptions, RustNNOptions,
     TrtxOptions,
 };
+pub type MLNamedTensors<'names> = BTreeMap<&'names str, &'names MLTensor>;
+pub type MLNamedOperands<'names> = BTreeMap<&'names str, MLOperand>;
+
 pub use crate::mlgraphbuilder::MLGraphBuilder;
 use crate::{
     backend_selection::{select_backend, select_backend_by_gpu},
@@ -64,8 +68,8 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
     fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> Result<()>;
 }
 
@@ -224,8 +228,8 @@ impl<'context> MLGraph<'context> {
 
     fn verify_dispatch_bindings(
         &mut self,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> Result<()> {
         let input_shapes: HashMap<String, Vec<usize>> = inputs
             .iter()
@@ -531,8 +535,8 @@ impl<'context> MLContext<'context> {
     pub fn dispatch(
         &mut self,
         graph: &mut MLGraph,
-        inputs: &HashMap<&str, &MLTensor>,
-        outputs: &HashMap<&str, &MLTensor>,
+        inputs: &MLNamedTensors,
+        outputs: &MLNamedTensors,
     ) -> crate::error::Result<()> {
         debug!("Dispatch {graph:?}, inputs={inputs:?}, outputs={outputs:?}");
         //https://www.w3.org/TR/webnn/#dom-mlcontext-dispatch
@@ -734,9 +738,9 @@ webnn_graph "sample_graph" v1 {
         let desc = rw_tensor_desc([2, 2].to_vec());
 
         let tensor = context.create_tensor(&desc).unwrap();
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("lhs", &tensor);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("sum", &tensor);
 
         let upload = vec![1.0f32, 2., 3., 4.];
@@ -762,8 +766,8 @@ webnn_graph "sample_graph" v1 {
         let desc = rw_tensor_desc([2, 2].to_vec());
         let input_tensor = context.create_tensor(&desc).unwrap();
         let output_tensor = context.create_tensor(&desc).unwrap();
-        let inputs = HashMap::from([("lhs", &input_tensor)]);
-        let outputs = HashMap::from([("sum", &output_tensor)]);
+        let inputs = MLNamedTensors::from([("lhs", &input_tensor)]);
+        let outputs = MLNamedTensors::from([("sum", &output_tensor)]);
 
         for upload in [
             vec![1.0f32, 2., 3., 4.],
@@ -790,9 +794,9 @@ webnn_graph "sample_graph" v1 {
 
         let desc = rw_tensor_desc([2, 2].to_vec());
         let tensor = context.create_tensor(&desc).unwrap();
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("invalid_input", &tensor);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("sum", &tensor);
 
         let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
@@ -811,9 +815,9 @@ webnn_graph "sample_graph" v1 {
 
         let desc = rw_tensor_desc([2, 3].to_vec());
         let tensor = context.create_tensor(&desc).unwrap();
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("lhs", &tensor);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("sum", &tensor);
 
         let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
@@ -835,9 +839,9 @@ webnn_graph "sample_graph" v1 {
         let out_desc = rw_tensor_desc([2, 3].to_vec());
         let input_tensor = context.create_tensor(&in_desc).unwrap();
         let output_tensor = context.create_tensor(&out_desc).unwrap();
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("lhs", &input_tensor);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("sum", &output_tensor);
 
         let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -25,7 +25,10 @@ pub use crate::mlcontextoptions::{
     CoremlOptions, LiteRtOptions, MLContextOptions, MLPowerPreference, OrtOptions, RustNNOptions,
     TrtxOptions,
 };
+
+/// <https://www.w3.org/TR/webnn/#typedefdef-mlnamedtensors>
 pub type MLNamedTensors<'names> = BTreeMap<&'names str, &'names MLTensor>;
+/// <https://www.w3.org/TR/webnn/#typedefdef-mlnamedoperands>
 pub type MLNamedOperands<'names> = BTreeMap<&'names str, MLOperand>;
 
 pub use crate::mlgraphbuilder::MLGraphBuilder;
@@ -152,12 +155,12 @@ impl Display for MLContextLostInfo {
     }
 }
 
-/// https://www.w3.org/TR/webnn/#api-mltensor
+/// <https://www.w3.org/TR/webnn/#api-mltensor>
 #[derive(Debug, Clone)]
 pub struct MLTensor {
     pub(crate) id: usize,
     pub(crate) constant: bool,
-    /// internal slots as per https://www.w3.org/TR/webnn/#api-mltensor
+    /// internal slots as per <https://www.w3.org/TR/webnn/#api-mltensor>
     pub(crate) descriptor: MLTensorDescriptor,
     //context: &'context MLContext, // todo, omit context?
     //// pending promises, need to be canceled when tensor is destroyed

--- a/src/mlcontextoptions.rs
+++ b/src/mlcontextoptions.rs
@@ -12,8 +12,8 @@ pub enum MLPowerPreference {
     LowPower,
 }
 
-/// https://www.w3.org/TR/webnn/#dictdef-mlcontextoptions
-/// https://www.w3.org/TR/webnn/#api-ml
+/// <https://www.w3.org/TR/webnn/#dictdef-mlcontextoptions>
+/// <https://www.w3.org/TR/webnn/#api-ml>
 ///
 /// From specs: Note: MLContextOptions is under active development, and the design is expected to change,
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -6,7 +6,7 @@ use webnn_graph::serialize::SerializeOptions;
 
 use crate::error::{GraphBuilderError, GraphError, ShapeInferenceError};
 use crate::graph::{Dimension, get_static_or_max_size, to_dimension_vector};
-use crate::mlcontext::{MLGraph, MLOperand, MLOperandDescriptor, MLTensor};
+use crate::mlcontext::{MLGraph, MLNamedOperands, MLOperand, MLOperandDescriptor, MLTensor};
 use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{
     MLArgMinMaxOptions, MLBatchNormalizationOptions, MLClampOptions, MLConstantOptions,
@@ -2009,10 +2009,7 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
     }
 
     /// Serialize the in-progress graph (with outputs marked) as `.webnn` text for debugging.
-    pub fn rustnn_webnn_text_for_outputs(
-        &self,
-        outputs: &HashMap<&str, MLOperand>,
-    ) -> Option<String> {
+    pub fn rustnn_webnn_text_for_outputs(&self, outputs: &MLNamedOperands) -> Option<String> {
         let graph = self.graph.as_ref()?;
         if outputs.is_empty() {
             return None;
@@ -2052,7 +2049,7 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
     /// the builder can still be built afterwards.
     pub fn rustnn_save_webnn(
         &self,
-        outputs: &HashMap<&str, MLOperand>,
+        outputs: &MLNamedOperands,
         path: impl AsRef<std::path::Path>,
     ) -> crate::error::Result<()> {
         if outputs.is_empty() {
@@ -2104,7 +2101,7 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
     /*async*/
     pub fn build(
         &mut self,
-        outputs: &'_ HashMap<&str, MLOperand>,
+        outputs: &'_ MLNamedOperands,
     ) -> crate::error::Result<MLGraph<'context>> {
         trace!("Trying to build graph for outputs {outputs:?}");
         // spec: If outputs is empty, then return a new promise in realm rejected with a TypeError.
@@ -3060,14 +3057,12 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use log::warn;
 
     use crate::{
         mlcontext::{
-            Backend, MLContext, MLContextOptions, MLOperandDescriptor, MLPowerPreference,
-            MLTensorDescriptor,
+            Backend, MLContext, MLContextOptions, MLNamedOperands, MLNamedTensors,
+            MLOperandDescriptor, MLPowerPreference, MLTensorDescriptor,
         },
         mlgraphbuilder::MLGraphBuilder,
     };
@@ -3093,7 +3088,7 @@ mod test {
         let b = builder.input("b", &desc).unwrap();
         assert_eq!(builder.graph.as_ref().unwrap().operands.len(), 2);
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out1", a);
         outputs.insert("out2", b);
         let error = builder.build(&outputs).unwrap_err();
@@ -3111,7 +3106,7 @@ mod test {
         assert_eq!(builder.graph.as_ref().unwrap().operands.len(), 2);
         let out1 = builder.identity(a).unwrap();
         let out2 = builder.add(a, b).unwrap();
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out1", out1);
         outputs.insert("out2", out2);
         builder.build(&outputs).unwrap();
@@ -3153,7 +3148,7 @@ mod test {
         let a = builder.identity(a).unwrap();
         let output = builder.identity(a).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", output);
 
         // This graph deliberately stresses the graph-builder's binding/validation logic
@@ -3188,11 +3183,11 @@ mod test {
         let output = context.create_tensor(&a_desc).unwrap();
 
         // All declared graph inputs must be provided at dispatch (including unused ones).
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("a", &a);
         inputs.insert("unused", &unused);
         inputs.insert("incompatible", &incompatible);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("out", &output);
         context.write_tensor(&a, &[3.0f32, 4., 5., 6.]).unwrap();
         // CoreML rejects binding the declared-but-unused `incompatible` input at dispatch
@@ -3237,7 +3232,7 @@ mod test {
         let a = builder.identity(a).unwrap();
         let output = builder.add(a, b).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", output);
         let mut graph = builder.build(&outputs).unwrap();
 
@@ -3258,7 +3253,7 @@ mod test {
         assert_eq!(builder.rustnn_operand_shape(a).unwrap(), mat_desc.shape());
         let a = builder.identity(a).unwrap();
         let output = builder.add(a, b).unwrap();
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", output);
         let mut graph2 = builder.build(&outputs).unwrap();
 
@@ -3275,10 +3270,10 @@ mod test {
         context.write_tensor(&a, &[1.0f32, 2., 3., 4.]).unwrap();
         context.write_tensor(&b, &[2.0f32]).unwrap();
 
-        let mut inputs = HashMap::new();
+        let mut inputs = MLNamedTensors::new();
         inputs.insert("a", &a);
         inputs.insert("b", &b);
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedTensors::new();
         outputs.insert("out", &output);
         context.dispatch(&mut graph, &inputs, &outputs).unwrap();
         let mut output_cpu = vec![0.0f32; 4];
@@ -3343,7 +3338,7 @@ mod test {
         );
         assert_eq!(builder.rustnn_operand_shape(dq).unwrap(), int_desc.shape());
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", dq);
         builder.build(&outputs).unwrap();
     }
@@ -3369,7 +3364,7 @@ mod test {
             .unwrap();
         let sum = builder.add(a, b).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("sum", sum);
 
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -3428,7 +3423,7 @@ mod test {
             .unwrap();
         let out = builder.mul(a, scale).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out", out);
 
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -3461,7 +3456,7 @@ mod test {
             .unwrap();
         let sum = builder.add(a, b).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("a", sum);
 
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -3469,7 +3464,7 @@ mod test {
         let err = builder
             .rustnn_save_webnn(&outputs, &webnn_path)
             .unwrap_err();
-        assert!(matches!(
+        std::assert_matches!(
             err,
             crate::error::Error::GraphBuilderError {
                 source: crate::error::GraphBuilderError::OutputNameConflictsWithOperand {
@@ -3477,7 +3472,7 @@ mod test {
                     operand_kind: "input",
                 }
             } if name == "a"
-        ));
+        );
         assert!(!webnn_path.exists());
     }
 
@@ -3502,7 +3497,7 @@ mod test {
             .unwrap();
         let sum = builder.add(a, b).unwrap();
 
-        let mut outputs = HashMap::new();
+        let mut outputs = MLNamedOperands::new();
         outputs.insert("out1", sum);
         outputs.insert("out2", sum);
 
@@ -3511,12 +3506,12 @@ mod test {
         let err = builder
             .rustnn_save_webnn(&outputs, &webnn_path)
             .unwrap_err();
-        assert!(matches!(
+        std::assert_matches!(
             err,
             crate::error::Error::GraphBuilderError {
                 source: crate::error::GraphBuilderError::DuplicateOutput { .. }
             }
-        ));
+        );
         assert!(!webnn_path.exists());
     }
 }

--- a/src/shape_inference.rs
+++ b/src/shape_inference.rs
@@ -303,7 +303,7 @@ fn conv_transpose_filter_dims_from_layout(
 /// Infer output shape for 2D convolution
 ///
 /// Following the W3C WebNN specification for conv2d:
-/// https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d
+/// <https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d>
 ///
 /// Uses [`MLConv2dOptions`]. `padding` is WebNN order:
 /// `[beginning_height, ending_height, beginning_width, ending_width]`.
@@ -487,7 +487,7 @@ pub fn infer_conv2d_shape(
 /// Infer output shape for 2D transposed convolution (deconvolution)
 ///
 /// Following the W3C WebNN specification for convTranspose2d:
-/// https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d
+/// <https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d>
 ///
 /// Uses [`MLConvTranspose2dOptions`]. `padding` is WebNN order:
 /// `[beginning_height, ending_height, beginning_width, ending_width]`.
@@ -685,7 +685,7 @@ fn pool2d_ceil_output_spatial(output_shape_rounding: &str) -> bool {
 /// Infer output shape for 2D pooling operations (average, max)
 ///
 /// Following the W3C WebNN specification for pool2d:
-/// https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d
+/// <https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d>
 ///
 /// Uses [`MLPool2dOptions`]: `padding` is WebNN order
 /// `[beginning_height, ending_height, beginning_width, ending_width]`.
@@ -1004,7 +1004,7 @@ pub struct ReduceOptions {
 /// across specified axes.
 ///
 /// Following the W3C WebNN specification for reduction operations:
-/// https://www.w3.org/TR/webnn/#api-mlgraphbuilder-reduce
+/// <https://www.w3.org/TR/webnn/#api-mlgraphbuilder-reduce>
 pub fn infer_reduce_shape(
     input_shape: &[u32],
     options: &ReduceOptions,

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -100,7 +100,7 @@ pub trait DeviceTensorBackend: Send + Sync + std::fmt::Debug {
     /// Read tensor data from device to host
     ///
     /// This performs a device-to-host memory transfer.
-    /// Returns data as Vec<f32> (will expand to support other types later).
+    /// Returns data as `Vec<f32>` (will expand to support other types later).
     fn read_to_host(&self) -> Result<Vec<f32>, GraphError>;
 
     /// Write tensor data from host to device

--- a/tests/wpt_conformance/wpt_execute_graph.rs
+++ b/tests/wpt_conformance/wpt_execute_graph.rs
@@ -22,7 +22,10 @@
 use half::f16;
 use rustnn::error::GraphBuilderError;
 use rustnn::graph::{unpack_int4, unpack_uint4};
-use rustnn::mlcontext::{MLContext, MLOperand, MLOperandDescriptor, MLTensor, MLTensorDescriptor};
+use rustnn::mlcontext::{
+    MLContext, MLNamedOperands, MLNamedTensors, MLOperand, MLOperandDescriptor, MLTensor,
+    MLTensorDescriptor,
+};
 use rustnn::mlgraphbuilder::MLGraphBuilder;
 use rustnn::operator_enums::MLOperandDataType;
 use rustnn::operator_options::{
@@ -1684,7 +1687,7 @@ pub fn execute_wpt_graph(
         }
     }
 
-    let mut build_outputs: HashMap<&str, MLOperand> = HashMap::new();
+    let mut build_outputs = MLNamedOperands::new();
     for name in graph.expected_outputs.keys() {
         let operand = operand_map
             .get(name)
@@ -1698,7 +1701,7 @@ pub fn execute_wpt_graph(
         .build(&build_outputs)
         .map_err(|e| append_webnn_graph_text(e.to_string(), webnn_text.as_deref()))?;
 
-    let mut input_tensors: HashMap<&str, &MLTensor> = HashMap::new();
+    let mut input_tensors = MLNamedTensors::new();
     let mut output_tensors_owned: HashMap<String, MLTensor> = HashMap::new();
     let mut input_owned: HashMap<String, MLTensor> = HashMap::new();
 
@@ -1724,7 +1727,7 @@ pub fn execute_wpt_graph(
     for (name, tensor) in &input_owned {
         input_tensors.insert(name.as_str(), tensor);
     }
-    let output_bindings: HashMap<&str, &MLTensor> = output_tensors_owned
+    let output_bindings: MLNamedTensors = output_tensors_owned
         .iter()
         .map(|(k, v)| (k.as_str(), v))
         .collect();


### PR DESCRIPTION


## Summary

- [x] Describe the user-visible and code-level changes.

The WebNN spec defines the parameters to MLContext::dispatch, MLGraphBuilder::{build,rustnn_save_webnn} as MLNamedTensors, MLNamedOperands as typedef to typed dictionary.

Let's also use MLNamedTensors, MLNamedOperands and switch BTreeMap which return the entries sorted and not random like HashMap.

Breaking change!

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

