### PR TITLE
fest(coreml): Wrap CoreML shim

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,24 @@ fn build_coreml_protos() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
+fn build_coreml_shim() {
+    // On macOS with the CoreML runtime, compile the Objective-C++ exception
+    // firewall (see src/executors/coreml_shim.mm). It catches Objective-C and
+    // C++ exceptions raised by CoreML before they can unwind across the
+    // `extern "C"` objc_msgSend boundary and abort the process.
+
+    let shim = "src/executors/coreml_shim.mm";
+    println!("cargo:rerun-if-changed={shim}");
+    cc::Build::new()
+        .file(shim)
+        .flag("-fobjc-arc")
+        .compile("rustnn_coreml_shim");
+    // The shim's `@catch (...)` pulls in the C++ runtime (__cxa_begin_catch,
+    // std::terminate); Rust links with -nodefaultlibs, so request libc++.
+    println!("cargo:rustc-link-lib=dylib=c++");
+}
+
 fn create_source_hash(source_files: &[&str]) {
     let mut hasher = SeaHasher::new();
     let mut buffer = Vec::new();
@@ -103,28 +121,12 @@ fn create_source_hash(source_files: &[&str]) {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Only compile CoreML protos - ONNX protos come from webnn-onnx-utils
     build_coreml_protos()?;
+    #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]
+    build_coreml_shim();
 
     // Build TFLite flatbuffer schema - Only required for the litert-runtime.
     #[cfg(feature = "litert-runtime")]
     build_tflite_schema();
-
-    // On macOS with the CoreML runtime, compile the Objective-C++ exception
-    // firewall (see src/executors/coreml_shim.mm). It catches Objective-C and
-    // C++ exceptions raised by CoreML before they can unwind across the
-    // `extern "C"` objc_msgSend boundary and abort the process.
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    let coreml_enabled = std::env::var("CARGO_FEATURE_COREML_RUNTIME").is_ok();
-    if target_os == "macos" && coreml_enabled {
-        let shim = "src/executors/coreml_shim.mm";
-        println!("cargo:rerun-if-changed={shim}");
-        cc::Build::new()
-            .file(shim)
-            .flag("-fobjc-arc")
-            .compile("rustnn_coreml_shim");
-        // The shim's `@catch (...)` pulls in the C++ runtime (__cxa_begin_catch,
-        // std::terminate); Rust links with -nodefaultlibs, so request libc++.
-        println!("cargo:rustc-link-lib=dylib=c++");
-    }
 
     println!("cargo:rerun-if-changed=protos");
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.
- Wrap CoreML shim
 
## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

