### PR TITLE
Dynamic shape trtx new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,8 +3430,6 @@ dependencies = [
 [[package]]
 name = "trtx"
 version = "0.8.0+rtx1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d971bf89aaa85fc86760596874ca15e91afe9249cc4de844d188919d658423"
 dependencies = [
  "autocxx",
  "cudarc 0.11.9",
@@ -3446,8 +3444,6 @@ dependencies = [
 [[package]]
 name = "trtx-sys"
 version = "0.8.0+rtx1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf440fdb1b8bd4d3afd4046957ef7a00733904b0ce75d9157999cec6faa697c"
 dependencies = [
  "autocxx",
  "autocxx-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,7 @@ dependencies = [
 [[package]]
 name = "trtx"
 version = "0.8.0+rtx1.5"
+source = "git+https://github.com/rustnn/trtx-rs#eaab89a99ec0bbd9ac84e6c99a8daeb82880f3b5"
 dependencies = [
  "autocxx",
  "cudarc 0.11.9",
@@ -3444,6 +3445,7 @@ dependencies = [
 [[package]]
 name = "trtx-sys"
 version = "0.8.0+rtx1.5"
+source = "git+https://github.com/rustnn/trtx-rs#eaab89a99ec0bbd9ac84e6c99a8daeb82880f3b5"
 dependencies = [
  "autocxx",
  "autocxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ort = { version = "=2.0.0-rc.12", optional = true, features = [
 ] }
 half = "2.4"
 safetensors = "0.7"
-trtx = { version = "0.8.0", path = "../trtx-rs/trtx", optional = true }
+trtx = { version = "0.8.0", git = "https://github.com/rustnn/trtx-rs", optional = true }
 litert = { version = "0.2.1", optional = true }
 litert-sys = { version = "0.2.1", optional = true }
 flatbuffers = { version = "25.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ort = { version = "=2.0.0-rc.12", optional = true, features = [
 ] }
 half = "2.4"
 safetensors = "0.7"
-trtx = { version = "0.8.0", optional = true }
+trtx = { version = "0.8.0", path = "../trtx-rs/trtx", optional = true }
 litert = { version = "0.2.1", optional = true }
 litert-sys = { version = "0.2.1", optional = true }
 flatbuffers = { version = "25.12", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ else ifeq ($(ORT_ENV_VARS_DEFERRED),1)
 	ORT_ENV_VARS := ORT_DYLIB_PATH=$(ORT_DYLIB_FILE)
 endif
 
-.PHONY: build test fmt run viz onnx coreml coreml-validate onnx-validate litert cann validate-all-env \
+.PHONY: build test fmt run viz onnx coreml coreml-validate onnx-validate litert cann validate-all-env smollm-trtx \
 	docs-serve docs-build docs-clean ci-docs docs-backend-ops docs-backend-ops-check \
 	fmt-check lint \
 	coverage coverage-html coverage-lcov coverage-open coverage-clean \
@@ -100,6 +100,10 @@ test-wpt: onnxruntime-download
 
 test-wpt-trtx:
 	$(CARGO) test --test run_wpt_conformance --features "onnx-runtime,trtx-runtime" -- trtx --test-threads 1
+
+# Run the MLContext SmolLM example using TensorRT. Set SMOLLM_ARGS to forward example arguments.
+smollm-trtx:
+	$(CARGO) run --features "trtx-runtime,dynamic-inputs" --example smollm_mlcontext -- $(SMOLLM_ARGS)
 
 test-wpt-litert:
 	@HOST_TRIPLE=$$(rustc -vV 2>/dev/null | grep host: | cut -d' ' -f2); \

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -944,16 +944,42 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             Vec::new()
         };
         for (input, tensor) in inputs.iter() {
-            let shape: Vec<i64> = tensor
+            let logical_shape: Vec<i64> = tensor
                 .shape()
                 .iter()
                 .map(|&dimension| dimension as i64)
                 .collect();
+            // TensorRT optimization profiles do not permit a zero-sized dynamic dimension.
+            // Bind a zero-filled placeholder instead. This is required for the initial empty KV
+            // cache passed to cached transformer graphs.
+            let shape: Vec<i64> = logical_shape
+                .iter()
+                .map(|&dimension| dimension.max(1))
+                .collect();
+            if shape != logical_shape {
+                warn!(
+                    "TensorRT does not support zero-sized input dimensions; binding {input} as {:?} instead of {:?}",
+                    shape, logical_shape
+                );
+            }
             graph
                 .exec
                 .set_input_shape(input, &Dims64::from_slice(&shape))
                 .to_dispatch_result()?;
             let cuda_tensor = &mut self.tensors[tensor.id];
+            if shape != logical_shape {
+                let placeholder_elements = shape.iter().product::<i64>() as usize;
+                let placeholder_bytes = tensor
+                    .data_type()
+                    .rustnn_storage_byte_length(placeholder_elements);
+                if cuda_tensor.memory.num_bytes() < placeholder_bytes {
+                    debug!(
+                        "Growing TensorRT zero-dimension placeholder for {input} from {} to {placeholder_bytes} bytes",
+                        cuda_tensor.memory.num_bytes(),
+                    );
+                    cuda_tensor.memory = cuda_tensor.stream.alloc_zeros(placeholder_bytes)?;
+                }
+            }
 
             let (ptr, _) = cuda_tensor.memory.device_ptr_mut(&cuda_tensor.stream);
             if cuda_graphs_enabled {

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -889,8 +889,13 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             array.len(),
         );
         stream.context().bind_to_thread()?;
+        // Empty logical cache outputs use a one-element physical TensorRT
+        // placeholder. Read only the logical result length, rather than asking
+        // cudarc to copy the full placeholder into the caller's zero-byte
+        // destination.
+        let memory = cuda_tensor.memory.slice(..array.len());
         stream
-            .memcpy_dtoh(&cuda_tensor.memory, array)
+            .memcpy_dtoh(&memory, array)
             .to_read_tensor_result(|| tensor.clone())?;
         stream
             .synchronize()
@@ -906,6 +911,23 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
         let cuda_tensor = &mut self.tensors[tensor.id];
         let stream = &cuda_tensor.stream;
         stream.context().bind_to_thread()?;
+        // `write_tensor` precedes `dispatch`, where TensorRT receives its input
+        // shapes. Allocate the physical one-element placeholder here as well so
+        // uploading an empty KV cache never copies into the logical zero-byte
+        // allocation.
+        let logical_shape = tensor.shape();
+        if logical_shape.contains(&0) {
+            let placeholder_elements = logical_shape
+                .iter()
+                .map(|&dimension| dimension.max(1) as usize)
+                .product::<usize>();
+            let placeholder_bytes = tensor
+                .data_type()
+                .rustnn_storage_byte_length(placeholder_elements);
+            if cuda_tensor.memory.num_bytes() < placeholder_bytes {
+                cuda_tensor.memory = cuda_tensor.stream.alloc_zeros(placeholder_bytes)?;
+            }
+        }
         debug!(
             "Uploading tensor {cuda_tensor:?} to array (ptr={:?}, size={:?})",
             array.as_ptr(),

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -17,8 +17,10 @@ use log::warn;
 use std::sync::{Arc, Mutex};
 use trtx::CudaEngine;
 use trtx::ExecutionContext;
+use trtx::OptProfileSelector;
 use trtx::Refitter;
 use trtx::host_memory::HostMemory;
+use trtx::trtx_sys::Dims64;
 
 use crate::GraphInfo;
 use crate::backends::caching::CacheResult;
@@ -453,6 +455,54 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                 .take()
                 .expect("Frontend API should prevent TrtxBuilder::build to be called twice");
             crate::converters::TrtxConverter::build_network(&graph, &mut network)?;
+            if graph.has_dynamic_dimensions() {
+                let mut profile = self
+                    .builder
+                    .lock()
+                    .unwrap()
+                    .creata_optimization_profile()
+                    .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                for (operand_id, operand) in graph.operands.iter().enumerate() {
+                    if operand.kind != crate::graph::OperandKind::Input {
+                        continue;
+                    }
+                    let name = TrtxConverter::engine_io_tensor_name(&graph, operand_id as u32);
+                    let min: Vec<i64> = operand
+                        .descriptor
+                        .shape
+                        .iter()
+                        .map(|dimension| match dimension {
+                            crate::graph::Dimension::Static(size) => i64::from(*size),
+                            crate::graph::Dimension::Dynamic(_) => 1,
+                        })
+                        .collect();
+                    let max: Vec<i64> = operand
+                        .descriptor
+                        .shape
+                        .iter()
+                        .map(|dimension| i64::from(crate::graph::get_static_or_max_size(dimension)))
+                        .collect();
+                    let opt: Vec<i64> = min
+                        .iter()
+                        .zip(&max)
+                        .map(|(&min, &max)| min.max(max.min(16)))
+                        .collect();
+                    profile
+                        .set_dimensions(&name, OptProfileSelector::kMIN, &Dims64::from_slice(&min))
+                        .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                    profile
+                        .set_dimensions(&name, OptProfileSelector::kOPT, &Dims64::from_slice(&opt))
+                        .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                    profile
+                        .set_dimensions(&name, OptProfileSelector::kMAX, &Dims64::from_slice(&max))
+                        .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+                }
+                self.config
+                    .lock()
+                    .unwrap()
+                    .add_optimization_profile(&mut profile)
+                    .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;
+            }
             let non_refittable_constants =
                 crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
             for constant_id in graph.constant_operand_ids_to_handles.keys() {
@@ -767,6 +817,15 @@ impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
             Vec::new()
         };
         for (input, tensor) in inputs.iter() {
+            let shape: Vec<i64> = tensor
+                .shape()
+                .iter()
+                .map(|&dimension| dimension as i64)
+                .collect();
+            graph
+                .exec
+                .set_input_shape(input, &Dims64::from_slice(&shape))
+                .to_dispatch_result()?;
             let cuda_tensor = &mut self.tensors[tensor.id];
 
             let (ptr, _) = cuda_tensor.memory.device_ptr_mut(&cuda_tensor.stream);

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -42,6 +42,7 @@ use crate::mlcontext::{MLBackendContext, MLBackendGraph};
 use crate::mlcontextoptions::TrtxOptions;
 
 const TRTX_JSON_DUMP_PATH_ENV_VAR: &str = "TRTX_JSON_DUMP_PATH";
+const TRTX_MANAGED_MEMORY_ENV_VAR: &str = "RUSTNN_TRTX_MANAGED_MEMORY";
 
 // TODO: also used in trtexec-rs. Should be part of trtx API?
 enum HostMemoryOrVec<'memory> {
@@ -244,6 +245,124 @@ impl TrtxTensor {
     }
 }
 
+/// TensorRT allocator backed by CUDA unified memory for diagnosing device-memory pressure.
+///
+/// CUDA may migrate these pages to host memory when device memory is exhausted. This is a
+/// correctness-oriented escape hatch, not a performance mode.
+#[derive(Default)]
+struct ManagedGpuAllocator {
+    allocations: Mutex<HashMap<usize, usize>>,
+}
+
+impl ManagedGpuAllocator {
+    unsafe fn allocate(&self, size: u64) -> *mut c_void {
+        let Ok(size) = usize::try_from(size) else {
+            return std::ptr::null_mut();
+        };
+        let size = size.max(1);
+        let pointer = match unsafe {
+            result::malloc_managed(size, sys::CUmemAttach_flags::CU_MEM_ATTACH_GLOBAL)
+        } {
+            Ok(pointer) => pointer,
+            Err(error) => {
+                warn!("cudaMallocManaged({size} bytes) for TensorRT failed: {error}");
+                return std::ptr::null_mut();
+            }
+        };
+        let pointer = pointer as usize;
+        self.allocations.lock().unwrap().insert(pointer, size);
+        pointer as *mut c_void
+    }
+
+    unsafe fn free(&self, pointer: *mut c_void) -> bool {
+        if pointer.is_null() {
+            return true;
+        }
+        let pointer = pointer as usize;
+        let Some(_) = self.allocations.lock().unwrap().remove(&pointer) else {
+            warn!("TensorRT attempted to free an untracked managed allocation {pointer:#x}");
+            return false;
+        };
+        match unsafe { result::free_sync(pointer as sys::CUdeviceptr) } {
+            Ok(()) => true,
+            Err(error) => {
+                warn!("cudaFree for TensorRT managed allocation {pointer:#x} failed: {error}");
+                false
+            }
+        }
+    }
+}
+
+impl trtx::interfaces::AllocateGpu for ManagedGpuAllocator {
+    unsafe fn allocate_async(
+        &self,
+        size: u64,
+        _alignment: u64,
+        _flags: u32,
+        _cuda_stream: *mut c_void,
+    ) -> *mut c_void {
+        unsafe { self.allocate(size) }
+    }
+
+    unsafe fn reallocate(
+        &self,
+        memory: *mut c_void,
+        _alignment: u64,
+        new_size: u64,
+    ) -> *mut c_void {
+        let old_size = self
+            .allocations
+            .lock()
+            .unwrap()
+            .get(&(memory as usize))
+            .copied()
+            .unwrap_or(0);
+        let replacement = unsafe { self.allocate(new_size) };
+        if replacement.is_null() {
+            return replacement;
+        }
+        if !memory.is_null() && old_size > 0 {
+            let copy_size = old_size.min(new_size as usize);
+            if let Err(error) = unsafe {
+                result::memcpy_dtod_sync(
+                    replacement as sys::CUdeviceptr,
+                    memory as sys::CUdeviceptr,
+                    copy_size,
+                )
+            } {
+                warn!("TensorRT managed allocation reallocation copy failed: {error}");
+                unsafe { self.free(replacement) };
+                return std::ptr::null_mut();
+            }
+            unsafe { self.free(memory) };
+        }
+        replacement
+    }
+
+    unsafe fn deallocate_async(&self, memory: *mut c_void, _cuda_stream: *mut c_void) -> bool {
+        unsafe { self.free(memory) }
+    }
+}
+
+impl Drop for ManagedGpuAllocator {
+    fn drop(&mut self) {
+        for pointer in self
+            .allocations
+            .get_mut()
+            .unwrap()
+            .drain()
+            .map(|(pointer, _)| pointer)
+        {
+            // SAFETY: pointers in the tracking map were allocated by `malloc_managed`.
+            if let Err(error) = unsafe { result::free_sync(pointer as sys::CUdeviceptr) } {
+                warn!(
+                    "cudaFree for leaked TensorRT managed allocation {pointer:#x} failed: {error}"
+                );
+            }
+        }
+    }
+}
+
 pub(crate) struct TrtxContext<'context> {
     cuda_ctx: Arc<CudaContext>,
     device_cache_id: String,
@@ -285,7 +404,16 @@ impl<'context> TrtxContext<'context> {
             config.set_profiling_verbosity(trtx::ProfilingVerbosity::kDETAILED);
         }
         let config = Arc::new(config.into());
-        let runtime = Arc::new(trtx::Runtime::new(&LOGGER)?.into());
+        let mut runtime = trtx::Runtime::new(&LOGGER)?;
+        if std::env::var_os(TRTX_MANAGED_MEMORY_ENV_VAR).is_some() {
+            info!(
+                "Using cudaMallocManaged for TensorRT runtime allocations because {TRTX_MANAGED_MEMORY_ENV_VAR} is set"
+            );
+            runtime.set_gpu_allocator(trtx::interfaces::GpuAllocator::new(Box::new(
+                ManagedGpuAllocator::default(),
+            ))?);
+        }
+        let runtime = Arc::new(runtime.into());
         debug!("Created new TrtxContext");
         Ok(Self {
             cuda_ctx,
@@ -482,11 +610,10 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                         .iter()
                         .map(|dimension| i64::from(crate::graph::get_static_or_max_size(dimension)))
                         .collect();
-                    let opt: Vec<i64> = min
-                        .iter()
-                        .zip(&max)
-                        .map(|(&min, &max)| min.max(max.min(16)))
-                        .collect();
+                    // The graph materializes a causal-mask branch at its declared maximum
+                    // sequence length (4096). Its static and dynamic inputs therefore need
+                    // the same profile point; an arbitrary opt=16 is not valid here.
+                    let opt = max.clone();
                     profile
                         .set_dimensions(&name, OptProfileSelector::kMIN, &Dims64::from_slice(&min))
                         .map_err(|e| crate::error::Error::GraphBuildError { source: e.into() })?;

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -4761,6 +4761,7 @@ impl super::GraphConverter for CoremlMlProgramConverter {
     }
 
     fn convert(&self, graph_info: &GraphInfo) -> Result<super::ConvertedGraph, GraphError> {
+        graph_info.ensure_known_shapes(self.format())?;
         if !crate::graph::dynamic_inputs_enabled() && graph_info.has_dynamic_dimensions() {
             return Err(GraphError::DynamicInputsFeatureDisabled);
         }
@@ -5001,7 +5002,11 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                         .map(|&v| GraphDimension::Static(v))
                         .collect()
                 } else {
-                    operand.descriptor.shape.clone()
+                    operand
+                        .descriptor
+                        .known_shape()
+                        .unwrap_or_default()
+                        .to_vec()
                 };
 
                 // Compute the final dtype (and convert bytes if needed).
@@ -5030,7 +5035,7 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 let mut modified_operand = operand.clone();
                 modified_operand.descriptor = OperandDescriptor {
                     data_type: final_dtype,
-                    shape: final_shape,
+                    shape: crate::graph::TensorShape::Known(final_shape),
                     pending_permutation: Vec::new(),
                 };
                 let const_op = Self::create_const_operation(
@@ -8039,7 +8044,7 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                             } else {
                                 let orig_var_shape = graph_info
                                     .operand(variance_id_v)
-                                    .map(|o| o.descriptor.shape.clone())
+                                    .and_then(|o| o.descriptor.known_shape().map(ToOwned::to_owned))
                                     .unwrap_or_default();
                                 (mean_name, var_name, orig_var_shape)
                             };
@@ -9065,13 +9070,13 @@ mod tests {
     use prost::Message;
     use std::collections::HashMap;
 
-    fn s(shape: &[u32]) -> Vec<crate::graph::Dimension> {
-        crate::graph::to_dimension_vector(shape)
+    fn s(shape: &[u32]) -> crate::graph::TensorShape {
+        crate::graph::TensorShape::Known(crate::graph::to_dimension_vector(shape))
     }
 
     /// Helper to create a simple graph with a Float16 constant
     fn create_graph_with_float16_constant(
-        shape: Vec<crate::graph::Dimension>,
+        shape: crate::graph::TensorShape,
         data: Vec<u8>,
     ) -> GraphInfo {
         let mut graph = GraphInfo {
@@ -9704,13 +9709,13 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: crate::graph::TensorShape::Known(vec![
                             crate::graph::Dimension::Dynamic(crate::graph::DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             crate::graph::Dimension::Static(4),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                 },
@@ -9719,13 +9724,13 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: crate::graph::TensorShape::Known(vec![
                             crate::graph::Dimension::Dynamic(crate::graph::DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             crate::graph::Dimension::Static(4),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                 },
@@ -9884,10 +9889,10 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: crate::graph::TensorShape::Known(vec![
                             crate::graph::Dimension::Static(2),
                             crate::graph::Dimension::Static(3),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                 },
@@ -9896,10 +9901,10 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: crate::graph::TensorShape::Known(vec![
                             crate::graph::Dimension::Static(2),
                             crate::graph::Dimension::Static(3),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                 },

--- a/src/converters/litert.rs
+++ b/src/converters/litert.rs
@@ -38,6 +38,7 @@ impl GraphConverter for LiteRtConverter {
     }
 
     fn convert(&self, graph: &GraphInfo) -> Result<ConvertedGraph, GraphError> {
+        graph.ensure_known_shapes(self.format())?;
         let bytes = build_native(graph)?;
         Ok(ConvertedGraph {
             format: "litert",
@@ -4726,8 +4727,8 @@ mod tests {
     use crate::operators::Operation;
     use std::collections::HashMap;
 
-    fn s(shape: &[u32]) -> Vec<crate::graph::Dimension> {
-        to_dimension_vector(shape)
+    fn s(shape: &[u32]) -> crate::graph::TensorShape {
+        crate::graph::TensorShape::Known(to_dimension_vector(shape))
     }
 
     fn op(op_type: &str, inputs: &[u32], outputs: &[u32]) -> Operation {

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -110,8 +110,8 @@ mod tests {
     use crate::error::GraphError;
     use crate::graph::{DataType, GraphInfo, Operand, OperandDescriptor, OperandKind};
 
-    fn s(shape: &[u32]) -> Vec<crate::graph::Dimension> {
-        crate::graph::to_dimension_vector(shape)
+    fn s(shape: &[u32]) -> crate::graph::TensorShape {
+        crate::graph::TensorShape::Known(crate::graph::to_dimension_vector(shape))
     }
 
     struct DummyConverter;

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -20,7 +20,8 @@ use crate::converters::{ConvertedGraph, ONNX_EXTERNAL_WEIGHTS_FILENAME, operand_
 use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{
-    DataType, Dimension, GraphInfo, OperandKind, get_static_or_max_size, unpack_int4, unpack_uint4,
+    DataType, Dimension, GraphInfo, OperandKind, TensorShape, get_static_or_max_size, unpack_int4,
+    unpack_uint4,
 };
 use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{MLDimension, MLPool2dOptions, mldimensions_static_or_max};
@@ -484,8 +485,10 @@ impl OnnxConverter {
                     );
                     normalized_input_shape = vec![1, channels];
                     if normalized_descriptor_shape.len() == 1 {
-                        normalized_descriptor_shape =
-                            vec![Dimension::Static(1), normalized_descriptor_shape[0].clone()];
+                        normalized_descriptor_shape = TensorShape::Known(vec![
+                            Dimension::Static(1),
+                            normalized_descriptor_shape[0].clone(),
+                        ]);
                     }
                     node_output_name = format!("{}_bn_output", op_name);
                     reshape_back_shape = Some(vec![channels as i64]);
@@ -2265,6 +2268,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
     }
 
     fn convert(&self, graph: &GraphInfo) -> Result<ConvertedGraph, GraphError> {
+        graph.ensure_known_shapes(self.format())?;
         if !crate::graph::dynamic_inputs_enabled() && graph.has_dynamic_dimensions() {
             return Err(GraphError::DynamicInputsFeatureDisabled);
         }
@@ -10339,8 +10343,8 @@ mod tests {
     use crate::protos::onnx::tensor_proto::DataType as ProtoDataType;
     use std::collections::HashMap;
 
-    fn s(shape: &[u32]) -> Vec<Dimension> {
-        crate::graph::to_dimension_vector(shape)
+    fn s(shape: &[u32]) -> TensorShape {
+        TensorShape::Known(crate::graph::to_dimension_vector(shape))
     }
 
     #[test]
@@ -10872,13 +10876,13 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: TensorShape::Known(vec![
                             Dimension::Dynamic(DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             Dimension::Static(4),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                     name: Some("input".to_string()),
@@ -10887,13 +10891,13 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: TensorShape::Known(vec![
                             Dimension::Dynamic(DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             Dimension::Static(4),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                     name: Some("output".to_string()),
@@ -11085,7 +11089,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(3), Dimension::Static(2)],
+                    shape: TensorShape::Known(vec![Dimension::Static(3), Dimension::Static(2)]),
                     pending_permutation: vec![],
                 },
                 name: Some("x".to_string()),
@@ -11094,7 +11098,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(12), Dimension::Static(2)],
+                    shape: TensorShape::Known(vec![Dimension::Static(12), Dimension::Static(2)]),
                     pending_permutation: vec![],
                 },
                 name: Some("w".to_string()),
@@ -11103,7 +11107,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(12), Dimension::Static(4)],
+                    shape: TensorShape::Known(vec![Dimension::Static(12), Dimension::Static(4)]),
                     pending_permutation: vec![],
                 },
                 name: Some("r".to_string()),
@@ -11112,7 +11116,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(3), Dimension::Static(4)],
+                    shape: TensorShape::Known(vec![Dimension::Static(3), Dimension::Static(4)]),
                     pending_permutation: vec![],
                 },
                 name: Some("h".to_string()),
@@ -11121,7 +11125,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(12)],
+                    shape: TensorShape::Known(vec![Dimension::Static(12)]),
                     pending_permutation: vec![],
                 },
                 name: Some("b".to_string()),
@@ -11130,7 +11134,7 @@ mod tests {
                 kind: OperandKind::Input,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(12)],
+                    shape: TensorShape::Known(vec![Dimension::Static(12)]),
                     pending_permutation: vec![],
                 },
                 name: Some("rb".to_string()),
@@ -11139,7 +11143,7 @@ mod tests {
                 kind: OperandKind::Output,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Static(3), Dimension::Static(4)],
+                    shape: TensorShape::Known(vec![Dimension::Static(3), Dimension::Static(4)]),
                     pending_permutation: vec![],
                 },
                 name: Some("y".to_string()),

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -31,7 +31,8 @@ use super::{
 use crate::error::GraphError;
 use crate::executors::trtx::create_trtx_logger;
 use crate::graph::{
-    DataType, GraphInfo, Operand, OperandKind, get_static_or_max_size, unpack_int4, unpack_uint4,
+    DataType, Dimension, GraphInfo, Operand, OperandKind, get_static_or_max_size, unpack_int4,
+    unpack_uint4,
 };
 use crate::operator_options::{MLDimension, MLPool2dOptions};
 use crate::operators::Operation;
@@ -800,7 +801,10 @@ impl TrtxConverter {
                     .descriptor
                     .shape
                     .iter()
-                    .map(|d| get_static_or_max_size(d) as i64)
+                    .map(|d| match d {
+                        Dimension::Static(size) => i64::from(*size),
+                        Dimension::Dynamic(_) => -1,
+                    })
                     .collect();
                 let trt_io_name = io_binding_names
                     .get(&(operand_id as u32))

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1206,7 +1206,7 @@ impl TrtxConverter {
             "reduceSumSquare" => Self::add_reduce_sum_square_op(network, tensor_map, operation)?,
 
             // Shape manipulation operations
-            "slice" => Self::add_slice_op(network, tensor_map, operation)?,
+            "slice" => Self::add_slice_op(graph, network, tensor_map, operation)?,
             "split" => Self::add_split_op(network, tensor_map, operation)?,
             "squeeze" => Self::add_squeeze_op(network, tensor_map, operation)?,
             "unsqueeze" => Self::add_unsqueeze_op(network, tensor_map, operation)?,
@@ -1346,6 +1346,89 @@ impl TrtxConverter {
             .collect()
     }
 
+    /// Prefix singleton dimensions using a runtime shape tensor, preserving all dynamic extents.
+    fn rank_pad_dynamic_tensor<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        rank: usize,
+        target_rank: usize,
+        op_name: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        if rank == target_rank {
+            return network
+                .add_identity(tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                });
+        }
+        let prefix_len = target_rank - rank;
+        let shape = network
+            .add_shape(tensor)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast Shape: {e}"),
+            })?
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast Shape output: {e}"),
+            })?;
+        let mut one_bytes = Vec::with_capacity(prefix_len * std::mem::size_of::<i64>());
+        for _ in 0..prefix_len {
+            one_bytes.extend_from_slice(&1_i64.to_le_bytes());
+        }
+        let ones = network
+            .add_small_constant_copied(&[prefix_len as i64], &one_bytes, TrtDataType::kINT64, None)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast prefix ones: {e}"),
+            })?
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast prefix ones output: {e}"),
+            })?;
+        let mut concat = network.add_concatenation(&[&ones, &shape]).map_err(|e| {
+            GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast shape concat: {e}"),
+            }
+        })?;
+        concat.set_axis(network, 0);
+        let target_shape =
+            concat
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast shape concat output: {e}"),
+                })?;
+        let mut shuffle =
+            network
+                .add_shuffle(tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast rank padding shuffle: {e}"),
+                })?;
+        shuffle
+            .set_input(network, 1, &target_shape)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast rank padding shape: {e}"),
+            })?;
+        shuffle
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_name}: dynamic broadcast rank padding output: {e}"),
+            })
+    }
+
     /// Helper to ensure two tensors have compatible shapes for elementwise operations.
     /// Expands both tensors to the NumPy broadcast union shape (rank pad + resize).
     fn ensure_broadcast_compatible<'a>(
@@ -1365,34 +1448,21 @@ impl TrtxConverter {
             .operand(id1)
             .map(|o| o.descriptor.static_or_max_shape())
             .unwrap_or_default();
-        let dims0 = Self::trtx_dims_or_fallback(&*network, tensor0, &fb0, op_name)?;
-        let dims1 = Self::trtx_dims_or_fallback(&*network, tensor1, &fb1, op_name)?;
+        let dims0 = tensor0
+            .dimensions(&*network)
+            .unwrap_or_else(|_| fb0.iter().copied().map(i64::from).collect());
+        let dims1 = tensor1
+            .dimensions(&*network)
+            .unwrap_or_else(|_| fb1.iter().copied().map(i64::from).collect());
         // TensorRT elementwise layers broadcast dynamic dimensions natively.  Static broadcast
         // inference below cannot represent `-1`; when ranks already agree, preserve the dynamic
         // tensors unchanged and let TensorRT resolve the shape at execution time.
         if dims0.contains(&-1) || dims1.contains(&-1) {
-            let output0 = network
-                .add_identity(tensor0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
-                })?
-                .output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
-                })?;
-            let output1 = network
-                .add_identity(tensor1)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
-                })?
-                .output(&*network, 0)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
-                })?;
+            let target_rank = dims0.len().max(dims1.len());
+            let output0 =
+                Self::rank_pad_dynamic_tensor(network, tensor0, dims0.len(), target_rank, op_name)?;
+            let output1 =
+                Self::rank_pad_dynamic_tensor(network, tensor1, dims1.len(), target_rank, op_name)?;
             return Ok((output0, output1));
         }
         Self::ensure_broadcast_compatible_dims(network, tensor0, &dims0, tensor1, &dims1, op_name)
@@ -7622,7 +7692,70 @@ impl TrtxConverter {
     // ============================================================================
 
     /// Add slice operation
+    fn dynamic_dimension_size_tensor<'a>(
+        graph: &'a GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &HashMap<u32, trtx::Tensor<'a>>,
+        name: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        for (operand_id, operand) in graph.operands.iter().enumerate() {
+            if operand.kind != OperandKind::Input {
+                continue;
+            }
+            for (axis, dimension) in operand.descriptor.shape.iter().enumerate() {
+                let Dimension::Dynamic(dynamic) = dimension else {
+                    continue;
+                };
+                if dynamic.name != name {
+                    continue;
+                }
+                let source = tensor_map.get(&(operand_id as u32)).ok_or_else(|| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Slice dynamic dimension {name:?}: input operand {operand_id} tensor is missing"
+                        ),
+                    }
+                })?;
+                let shape = network
+                    .add_shape(source)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice dynamic dimension {name:?}: Shape layer: {e}"),
+                    })?
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice dynamic dimension {name:?}: Shape output: {e}"),
+                    })?;
+                return network
+                    .add_slice(&shape, &[axis as i64], &[1], &[1])
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Slice dynamic dimension {name:?}: shape-vector slice: {e}"
+                        ),
+                    })?
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!(
+                            "Slice dynamic dimension {name:?}: shape-vector slice output: {e}"
+                        ),
+                    });
+            }
+        }
+        Err(GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!(
+                "Slice dynamic dimension {name:?} does not correspond to any graph input dimension"
+            ),
+        })
+    }
+
+    /// Add slice operation.
     fn add_slice_op<'a>(
+        graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -7706,12 +7839,70 @@ impl TrtxConverter {
         let trt_sizes_i64: Vec<i64> = trt_sizes.iter().map(|&x| x as i64).collect();
         let strides_i64: Vec<i64> = strides.iter().map(|&x| x as i64).collect();
 
-        let layer = network
+        let mut layer = network
             .add_slice(input, &starts_i64, &trt_sizes_i64, &strides_i64)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add slice layer: {}", e),
             })?;
+
+        if sizes_ml
+            .iter()
+            .any(|dimension| matches!(dimension, MLDimension::Dynamic(_)))
+        {
+            let mut size_pieces = Vec::with_capacity(sizes_ml.len());
+            for dimension in sizes_ml {
+                let piece = match dimension {
+                    MLDimension::Static(size) => network
+                        .add_small_constant_copied(
+                            &[1],
+                            &i64::from(*size).to_le_bytes(),
+                            TrtDataType::kINT64,
+                            None,
+                        )
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Slice static size constant: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Slice static size constant output: {e}"),
+                        })?,
+                    MLDimension::Dynamic(dynamic) => Self::dynamic_dimension_size_tensor(
+                        graph,
+                        network,
+                        tensor_map,
+                        &dynamic.name,
+                    )?,
+                };
+                size_pieces.push(piece);
+            }
+            let size_refs: Vec<&trtx::Tensor<'a>> = size_pieces.iter().collect();
+            let size_tensor = if size_refs.len() == 1 {
+                size_pieces.pop().unwrap()
+            } else {
+                let mut concat = network.add_concatenation(&size_refs).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice dynamic size concat: {e}"),
+                    }
+                })?;
+                concat.set_axis(network, 0);
+                concat
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Slice dynamic size concat output: {e}"),
+                    })?
+            };
+            layer.set_input(network, 2, &size_tensor).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Slice dynamic size input: {e}"),
+                }
+            })?;
+        }
 
         let output = layer
             .output(&*network, 0)
@@ -8046,7 +8237,7 @@ impl TrtxConverter {
     /// Add expand operation (broadcast to new shape)
     /// Implemented as input * ones(new_shape) so elementwise broadcast produces the expanded tensor.
     fn add_expand_op<'a>(
-        graph: &GraphInfo,
+        graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -8058,11 +8249,8 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        let new_shape: Vec<i32> = match operation {
-            Operation::Expand { new_shape, .. } => new_shape
-                .iter()
-                .map(|d| MLDimension::static_or_max(d) as i32)
-                .collect(),
+        let new_shape_ml = match operation {
+            Operation::Expand { new_shape, .. } => new_shape,
             _ => {
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
@@ -8070,6 +8258,10 @@ impl TrtxConverter {
                 });
             }
         };
+        let new_shape: Vec<i32> = new_shape_ml
+            .iter()
+            .map(|d| MLDimension::static_or_max(d) as i32)
+            .collect();
 
         let new_shape_i64: Vec<i64> = new_shape.iter().map(|&d| d as i64).collect();
         let target_rank = new_shape_i64.len();
@@ -8079,7 +8271,21 @@ impl TrtxConverter {
             .operand(in_id)
             .map(|o| o.descriptor.static_or_max_shape())
             .unwrap_or_default();
-        let in_dims = Self::trtx_dims_or_fallback(&*network, input, &fb_in, "expand")?;
+        // Preserve TensorRT's `-1` runtime dimensions for shape manipulation. Replacing them
+        // with WebNN maxima here would turn a dynamic rank-alignment shuffle into e.g.
+        // `[1, 4096]` and make the input effectively static.
+        let in_dims = match input.dimensions(&*network) {
+            Ok(dims) if !dims.is_empty() || fb_in.is_empty() => dims,
+            Ok(_) if !fb_in.is_empty() => fb_in.iter().copied().map(i64::from).collect(),
+            Ok(_) => Vec::new(),
+            Err(_) if !fb_in.is_empty() => fb_in.iter().copied().map(i64::from).collect(),
+            Err(error) => {
+                return Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("expand: input dimensions: {error}"),
+                });
+            }
+        };
         if in_dims.len() > target_rank {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -8135,7 +8341,7 @@ impl TrtxConverter {
         let mut stride: Vec<i64> = Vec::with_capacity(target_rank);
         for (i, &t) in new_shape_i64.iter().enumerate() {
             let d = aligned_dims.get(i).copied().unwrap_or(1);
-            if d == t {
+            if d < 0 || d == t {
                 stride.push(1);
             } else if d == 1 {
                 stride.push(0);
@@ -8160,12 +8366,70 @@ impl TrtxConverter {
         }
         let start: Vec<i64> = vec![0i64; target_rank];
 
-        let output = network
+        let mut slice = network
             .add_slice(&aligned_input, &start, &new_shape_i64, &stride)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("expand slice broadcast: {e}"),
-            })?
+            })?;
+        if new_shape_ml
+            .iter()
+            .any(|dimension| matches!(dimension, MLDimension::Dynamic(_)))
+        {
+            let mut size_pieces = Vec::with_capacity(new_shape_ml.len());
+            for dimension in new_shape_ml {
+                let piece = match dimension {
+                    MLDimension::Static(size) => network
+                        .add_small_constant_copied(
+                            &[1],
+                            &i64::from(*size).to_le_bytes(),
+                            TrtDataType::kINT64,
+                            None,
+                        )
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Expand static target-size constant: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Expand static target-size constant output: {e}"),
+                        })?,
+                    MLDimension::Dynamic(dynamic) => Self::dynamic_dimension_size_tensor(
+                        graph,
+                        network,
+                        tensor_map,
+                        &dynamic.name,
+                    )?,
+                };
+                size_pieces.push(piece);
+            }
+            let size_refs: Vec<&trtx::Tensor<'a>> = size_pieces.iter().collect();
+            let size_tensor = if size_refs.len() == 1 {
+                size_pieces.pop().unwrap()
+            } else {
+                let mut concat = network.add_concatenation(&size_refs).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Expand dynamic target-size concat: {e}"),
+                    }
+                })?;
+                concat.set_axis(network, 0);
+                concat
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Expand dynamic target-size concat output: {e}"),
+                    })?
+            };
+            slice.set_input(network, 2, &size_tensor).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Expand dynamic target-size input: {e}"),
+                }
+            })?;
+        }
+        let output = slice
             .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -14179,7 +14443,7 @@ impl TrtxConverter {
 
     /// Add reshape operation using shuffle layer
     fn add_reshape_op<'a>(
-        _graph: &GraphInfo,
+        graph: &'a GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -14221,6 +14485,64 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to set reshape dimensions: {}", e),
             })?;
+
+        if new_shape
+            .iter()
+            .any(|dimension| matches!(dimension, MLDimension::Dynamic(_)))
+        {
+            let mut shape_pieces = Vec::with_capacity(new_shape.len());
+            for dimension in new_shape {
+                let piece = match dimension {
+                    MLDimension::Static(size) => network
+                        .add_small_constant_copied(
+                            &[1],
+                            &i64::from(*size).to_le_bytes(),
+                            TrtDataType::kINT64,
+                            None,
+                        )
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Reshape static dimension constant: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Reshape static dimension constant output: {e}"),
+                        })?,
+                    MLDimension::Dynamic(dynamic) => Self::dynamic_dimension_size_tensor(
+                        graph,
+                        network,
+                        tensor_map,
+                        &dynamic.name,
+                    )?,
+                };
+                shape_pieces.push(piece);
+            }
+            let shape_refs: Vec<&trtx::Tensor<'a>> = shape_pieces.iter().collect();
+            let shape_tensor = if shape_refs.len() == 1 {
+                shape_pieces.pop().unwrap()
+            } else {
+                let mut concat = network.add_concatenation(&shape_refs).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Reshape dynamic dimension concat: {e}"),
+                    }
+                })?;
+                concat.set_axis(network, 0);
+                concat
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Reshape dynamic dimension concat output: {e}"),
+                    })?
+            };
+            layer.set_input(network, 1, &shape_tensor).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Reshape dynamic dimension input: {e}"),
+                }
+            })?;
+        }
 
         // Extract output tensor from layer
         let output = layer

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1373,6 +1373,34 @@ impl TrtxConverter {
             .unwrap_or_default();
         let dims0 = Self::trtx_dims_or_fallback(&*network, tensor0, &fb0, op_name)?;
         let dims1 = Self::trtx_dims_or_fallback(&*network, tensor1, &fb1, op_name)?;
+        // TensorRT elementwise layers broadcast dynamic dimensions natively.  Static broadcast
+        // inference below cannot represent `-1`; when ranks already agree, preserve the dynamic
+        // tensors unchanged and let TensorRT resolve the shape at execution time.
+        if dims0.len() == dims1.len() && (dims0.contains(&-1) || dims1.contains(&-1)) {
+            let output0 = network
+                .add_identity(tensor0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            let output1 = network
+                .add_identity(tensor1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            return Ok((output0, output1));
+        }
         Self::ensure_broadcast_compatible_dims(network, tensor0, &dims0, tensor1, &dims1, op_name)
     }
 
@@ -7768,38 +7796,125 @@ impl TrtxConverter {
                 reason: format!("Unsqueeze: invalid axes {axes:?} for output rank {output_rank}"),
             });
         }
-        let mut output_dims = Vec::with_capacity(output_rank);
-        let mut input_axis = 0;
-        for output_axis in 0..output_rank {
-            if axes.binary_search(&(output_axis as u32)).is_ok() {
-                output_dims.push(1);
-            } else {
-                output_dims.push(input_dims[input_axis]);
-                input_axis += 1;
-            }
-        }
-
-        // Use IShuffleLayer to add dimensions
-        let mut layer = network
-            .add_shuffle(input)
+        let mut output = network
+            .add_identity(input)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to add shuffle layer for unsqueeze: {}", e),
-            })?;
-
-        layer
-            .set_reshape_dimensions(network, &output_dims)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Unsqueeze: failed to set reshape dimensions {output_dims:?}: {e}"),
-            })?;
-
-        let output = layer
+                reason: format!("Unsqueeze input identity: {e}"),
+            })?
             .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
+                reason: format!("Unsqueeze input identity output: {e}"),
             })?;
+
+        // A static reshape may contain only one `-1`. Build the target shape at runtime instead,
+        // preserving every dynamic input dimension and inserting a literal one at each axis.
+        for axis in axes {
+            let rank = output
+                .dimensions(&*network)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: input dimensions: {e}"),
+                })?
+                .len();
+            let shape = network
+                .add_shape(&output)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: Shape layer: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: Shape output: {e}"),
+                })?;
+            let one = network
+                .add_small_constant_copied(&[1], &1_i64.to_le_bytes(), TrtDataType::kINT64, None)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: one constant: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: one constant output: {e}"),
+                })?;
+            let mut pieces = Vec::new();
+            if axis > 0 {
+                pieces.push(
+                    network
+                        .add_slice(&shape, &[0], &[axis as i64], &[1])
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Unsqueeze: prefix shape slice: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Unsqueeze: prefix shape output: {e}"),
+                        })?,
+                );
+            }
+            pieces.push(one);
+            if (axis as usize) < rank {
+                pieces.push(
+                    network
+                        .add_slice(
+                            &shape,
+                            &[axis as i64],
+                            &[(rank - axis as usize) as i64],
+                            &[1],
+                        )
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Unsqueeze: suffix shape slice: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("Unsqueeze: suffix shape output: {e}"),
+                        })?,
+                );
+            }
+            let piece_refs: Vec<&trtx::Tensor<'a>> = pieces.iter().collect();
+            let target_shape = if piece_refs.len() == 1 {
+                pieces.pop().unwrap()
+            } else {
+                let mut concat = network.add_concatenation(&piece_refs).map_err(|e| {
+                    GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Unsqueeze: shape concat: {e}"),
+                    }
+                })?;
+                concat.set_axis(network, 0);
+                concat
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Unsqueeze: shape concat output: {e}"),
+                    })?
+            };
+            let mut shuffle =
+                network
+                    .add_shuffle(&output)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("Unsqueeze: shuffle: {e}"),
+                    })?;
+            shuffle.set_input(network, 1, &target_shape).map_err(|e| {
+                GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: set dynamic reshape shape: {e}"),
+                }
+            })?;
+            output = shuffle
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("Unsqueeze: shuffle output: {e}"),
+                })?;
+        }
 
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -7842,6 +7842,22 @@ impl TrtxConverter {
         }
         let starts: Vec<i32> = starts_u32.iter().map(|&u| u as i32).collect();
         let sizes: Vec<i32> = sizes_ml.iter().map(|d| d.static_or_max() as i32).collect();
+        let source_shape = graph
+            .operand(operation.input_operands()[0])
+            .and_then(|operand| operand.descriptor.shape.known());
+        // The WebNN JSON representation records the profile maximum for some
+        // slices (notably attention's sequence axis) as a static extent.  The
+        // source descriptor still marks that axis dynamic, so make the TensorRT
+        // size input follow the actual runtime source shape instead of trying to
+        // read, for example, positions 0..4095 from a one-token prefill.
+        let needs_runtime_sizes = sizes_ml.iter().enumerate().any(|(axis, dimension)| {
+            matches!(dimension, MLDimension::Dynamic(_))
+                || (matches!(dimension, MLDimension::Static(size) if *size > 1)
+                    && matches!(
+                        source_shape.and_then(|shape| shape.get(axis)),
+                        Some(Dimension::Dynamic(_))
+                    ))
+        });
         let strides: Vec<i32> = if opts.strides.is_empty() {
             vec![1; starts.len()]
         } else {
@@ -7876,22 +7892,27 @@ impl TrtxConverter {
                 reason: format!("Failed to add slice layer: {}", e),
             })?;
 
-        if sizes_ml
-            .iter()
-            .any(|dimension| matches!(dimension, MLDimension::Dynamic(_)))
-        {
+        if needs_runtime_sizes {
             let mut size_pieces = Vec::with_capacity(sizes_ml.len());
             for (axis, dimension) in sizes_ml.iter().enumerate() {
                 let piece = match dimension {
                     // In mixed static/dynamic slices, exporter-provided non-singleton static
                     // extents are profile maxima (e.g. 4096), not the current runtime extent.
                     // Bind them to the source shape to avoid slicing past a short sequence.
-                    MLDimension::Static(size) if *size > 1 => Self::tensor_dimension_size_tensor(
-                        network,
-                        input,
-                        axis,
-                        "Slice static maximum extent",
-                    )?,
+                    MLDimension::Static(size)
+                        if *size > 1
+                            && matches!(
+                                source_shape.and_then(|shape| shape.get(axis)),
+                                Some(Dimension::Dynamic(_))
+                            ) =>
+                    {
+                        Self::tensor_dimension_size_tensor(
+                            network,
+                            input,
+                            axis,
+                            "Slice dynamic source extent",
+                        )?
+                    }
                     MLDimension::Static(size) => network
                         .add_small_constant_copied(
                             &[1],

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1775,12 +1775,23 @@ impl TrtxConverter {
 
         Self::widen_matching_integer_inputs(network, &mut bc_input0, &mut bc_input1)?;
 
-        let layer = network
+        let mut layer = network
             .add_elementwise(&bc_input0, &bc_input1, op_code)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add elementwise operation: {}", e),
             })?;
+
+        let _ = layer.set_name(
+            network,
+            &format!(
+                "webnn_{}_{}_{}_to_{}",
+                operation.op_type(),
+                id0,
+                id1,
+                operation.output_operands_slice()[0]
+            ),
+        );
 
         // Extract output tensor from layer
         let output = layer

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -528,17 +528,11 @@ impl TrtxConverter {
                     return Ok(None);
                 }
                 if tensor.get_type(&*network) == TrtDataType::kINT8 {
-                    let webnn_ty = graph
-                        .operand(operand_id)
-                        .map(|o| o.descriptor.data_type)
-                        .unwrap_or(DataType::Int8);
-                    Ok(Some(Self::trtx_int8_uint8_identity_dequantize(
-                        network,
-                        tensor,
-                        TrtDataType::kFLOAT,
-                        "mask broadcast promote",
-                        webnn_ty,
-                    )?))
+                    // Dynamic attention masks have an unknown TensorRT rank while the network
+                    // is assembled. TensorRT RTX 1.6 rejects Dequantize for that case because
+                    // block quantization requires a rank-matched scale. Cast has no such
+                    // rank-dependent scale contract and is sufficient before float broadcast.
+                    Ok(Some(Self::cast_to_float32(network, tensor)?))
                 } else {
                     Ok(Some(Self::cast_to_float32(network, tensor)?))
                 }
@@ -3370,7 +3364,21 @@ impl TrtxConverter {
         label: &str,
     ) -> Result<Vec<i64>, GraphError> {
         match tensor.dimensions(network) {
-            Ok(dims) if !dims.is_empty() || fallback_shape.is_empty() => Ok(dims),
+            Ok(dims) if !dims.is_empty() || fallback_shape.is_empty() => Ok(dims
+                .into_iter()
+                .enumerate()
+                .map(|(axis, dim)| {
+                    if dim < 0 {
+                        fallback_shape
+                            .get(axis)
+                            .copied()
+                            .map(i64::from)
+                            .unwrap_or(dim)
+                    } else {
+                        dim
+                    }
+                })
+                .collect()),
             Ok(_) => Ok(fallback_shape.iter().map(|&d| d as i64).collect()),
             Err(_) if !fallback_shape.is_empty() => {
                 Ok(fallback_shape.iter().map(|&d| d as i64).collect())
@@ -3775,9 +3783,19 @@ impl TrtxConverter {
         webnn_integer_dtype: DataType,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         let input_ty = tensor.get_type(&*network);
-        // Always use a **scalar** (0D) scale for identity DQ. Matching zp rank (e.g. `[1,1]`) hits
-        // TensorRT `ScaleMode is illegal`; per-tensor scale broadcasts. Myelin: data rank >= scale rank.
-        let scale_shape: Vec<i64> = vec![];
+        // TensorRT RTX 1.6 requires the Dequantize scale to have the same rank as the
+        // dynamically-broadcast attention mask. Keep the normal per-tensor scalar scale for
+        // all other paths, whose QDQ lowering relies on scalar ScaleMode.
+        let scale_shape: Vec<i64> = if label == "mask broadcast promote" {
+            tensor
+                .dimensions(&*network)
+                .ok()
+                .filter(|dims| !dims.is_empty())
+                .map(|dims| vec![1; dims.len()])
+                .unwrap_or_else(|| vec![1; 4])
+        } else {
+            vec![]
+        };
         let scale_bytes: Vec<u8> = match dq_out_ty {
             TrtDataType::kFLOAT => 1.0f32.to_le_bytes().to_vec(),
             TrtDataType::kHALF => f16::from_f32(1.0f32).to_le_bytes().to_vec(),
@@ -8121,6 +8139,12 @@ impl TrtxConverter {
                 stride.push(1);
             } else if d == 1 {
                 stride.push(0);
+            } else if d > t {
+                // Dynamic-shape inference may conservatively add maxima through a concat
+                // (e.g. 4096 + 4096) even when a later graph constraint limits the runtime
+                // extent to `t`. ISlice can retain the valid prefix without treating this as
+                // an illegal broadcast.
+                stride.push(1);
             } else {
                 let input_name = graph
                     .operand(in_id)
@@ -15297,6 +15321,7 @@ impl GraphConverter for TrtxConverter {
     }
 
     fn convert(&self, graph_info: &GraphInfo) -> Result<ConvertedGraph, GraphError> {
+        graph_info.ensure_known_shapes(self.format())?;
         trtx::dynamically_load_tensorrt(None::<&str>).map_err(|e| {
             GraphError::ConversionFailed {
                 format: "trtx".to_string(),
@@ -15343,7 +15368,7 @@ impl GraphConverter for TrtxConverter {
             })?;
 
         // Set workspace size (1 GB)
-        config.set_memory_pool_limit(trtx::builder::MemoryPoolType::kWORKSPACE, 1 << 30);
+        config.set_memory_pool_limit(trtx::builder::MemoryPoolType::kWORKSPACE, 1 << 32);
 
         // WPT conformance often compares TRT to strict IEEE fp32 (ulpTol=0). TF32 matmul/conv rounds to
         // 10-bit mantissa on supported GPUs and can differ by many ULP from CPU reference.
@@ -15415,7 +15440,7 @@ mod tests {
         use crate::graph::{Operand, OperandDescriptor, OperandKind};
         let desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: to_dimension_vector(&[1, 1]),
+            shape: crate::graph::TensorShape::Known(to_dimension_vector(&[1, 1])),
             pending_permutation: vec![],
         };
         let graph = GraphInfo {
@@ -15454,7 +15479,7 @@ mod tests {
         use crate::graph::{Operand, OperandDescriptor, OperandKind};
         let desc = OperandDescriptor {
             data_type: DataType::Float32,
-            shape: to_dimension_vector(&[1]),
+            shape: crate::graph::TensorShape::Known(to_dimension_vector(&[1])),
             pending_permutation: vec![],
         };
         let graph = GraphInfo {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -9662,28 +9662,33 @@ impl TrtxConverter {
                         format: "trtx".to_string(),
                         reason: format!("scatterND index zero output: {e}"),
                     })?;
-                let maxed = network
+                let mut maxed_layer = network
                     .add_elementwise(indices, &zero_t, ElementWiseOperation::kMAX)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("scatterND index max(0): {e}"),
-                    })?
-                    .output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("scatterND index max output: {e}"),
                     })?;
-                let clamped = network
+                let _ = maxed_layer.set_name(network, "scatter_nd_index_max");
+                let maxed =
+                    maxed_layer
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("scatterND index max output: {e}"),
+                        })?;
+                let mut clamped_layer = network
                     .add_elementwise(&maxed, &bound_t, ElementWiseOperation::kMIN)
                     .map_err(|e| GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("scatterND index min(bound): {e}"),
-                    })?
-                    .output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
+                    })?;
+                let _ = clamped_layer.set_name(network, "scatter_nd_index_min");
+                let clamped = clamped_layer.output(&*network, 0).map_err(|e| {
+                    GraphError::ConversionFailed {
                         format: "trtx".to_string(),
                         reason: format!("scatterND index min output: {e}"),
-                    })?;
+                    }
+                })?;
                 Some(clamped)
             }
             _ => None,
@@ -15593,6 +15598,35 @@ impl TrtxConverter {
         // Get input shape from graph
         let input_operand = &graph.operands[operation.input_operands()[0] as usize];
         let shape = &input_operand.descriptor.shape;
+
+        // SmolLM builds its causal-mask base with ConstantOfShape(0) and then applies
+        // triangular(k=1).  The existing lowering materializes a fixed profile-maximum
+        // `[4096, 4096]` mask, which cannot multiply the runtime `[sequence, past]`
+        // zero tensor once decoding reaches length 2.  Triangular preserves an all-zero
+        // input exactly, so retain that runtime-shaped tensor instead.
+        if shape
+            .iter()
+            .any(|dimension| matches!(dimension, Dimension::Dynamic(_)))
+            && input_operand
+                .name
+                .as_deref()
+                .is_some_and(|name| name.contains("ConstantOfShape"))
+        {
+            return network
+                .add_identity(input_tensor)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dynamic zero triangular identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map(|output| {
+                    tensor_map.insert(operation.output_operands_slice()[0], output);
+                })
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("dynamic zero triangular identity output: {e}"),
+                });
+        }
 
         // Triangular only makes sense for 2D matrices (or higher-D tensors treated as batches of 2D)
         if shape.len() < 2 {

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1309,6 +1309,7 @@ impl TrtxConverter {
             "transpose" => Self::add_transpose_op(graph, network, tensor_map, operation)?,
             "reshape" => Self::add_reshape_op(graph, network, tensor_map, operation)?,
             "resample2d" => Self::add_resample2d_op(graph, network, tensor_map, operation)?,
+            "shape" => Self::add_shape_op(network, tensor_map, operation)?,
 
             "gru" => {
                 crate::converters::trtx_gru::add_gru_op(graph, network, tensor_map, operation)?
@@ -1524,20 +1525,25 @@ impl TrtxConverter {
                 });
         }
 
-        let mut resize_layer =
-            network
-                .add_resize(cur)
+        // TensorRT elementwise layers perform NumPy broadcasting natively.  Do not materialize
+        // it with IResizeLayer: IResizeLayer rejects the INT64 shape tensors used by dynamic
+        // graphs. The leading-dimension shuffle above is enough to align ranks.
+        if let Some(tensor) = staged {
+            Ok(tensor)
+        } else {
+            let layer = network
+                .add_identity(cur)
                 .map_err(|e| GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("{op_label} broadcast resize: {e}"),
+                    reason: format!("{op_label} broadcast identity: {e}"),
                 })?;
-        resize_layer.set_output_dimensions(network, target_dims);
-        resize_layer
-            .output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast resize output: {e}"),
-            })
+            layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_label} broadcast identity output: {e}"),
+                })
+        }
     }
 
     /// Add elementwise operation
@@ -1565,7 +1571,7 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility (this may reshape tensors if needed)
-        let (bc_input0, bc_input1) = Self::ensure_broadcast_compatible(
+        let (mut bc_input0, mut bc_input1) = Self::ensure_broadcast_compatible(
             network,
             graph,
             id0,
@@ -1574,6 +1580,8 @@ impl TrtxConverter {
             input1,
             operation.op_type(),
         )?;
+
+        Self::widen_matching_integer_inputs(network, &mut bc_input0, &mut bc_input1)?;
 
         let layer = network
             .add_elementwise(&bc_input0, &bc_input1, op_code)
@@ -1593,6 +1601,58 @@ impl TrtxConverter {
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
         tensor_map.insert(output_id, output);
+        Ok(())
+    }
+
+    /// TensorRT elementwise layers require matching input data types.  Dynamic-shape graphs often
+    /// combine an INT64 shape tensor with an INT32 scalar, so promote compatible integer pairs.
+    fn widen_matching_integer_inputs<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        input0: &mut trtx::Tensor<'a>,
+        input1: &mut trtx::Tensor<'a>,
+    ) -> Result<(), GraphError> {
+        let dtype0 = input0.data_type(&*network);
+        let dtype1 = input1.data_type(&*network);
+        let target = match (dtype0, dtype1) {
+            (left, right) if left == right => return Ok(()),
+            (TrtDataType::kINT64, _) | (_, TrtDataType::kINT64) => TrtDataType::kINT64,
+            (TrtDataType::kINT32, TrtDataType::kINT8)
+            | (TrtDataType::kINT8, TrtDataType::kINT32)
+            | (TrtDataType::kINT32, TrtDataType::kUINT8)
+            | (TrtDataType::kUINT8, TrtDataType::kINT32) => TrtDataType::kINT32,
+            _ => return Ok(()),
+        };
+
+        if dtype0 != target {
+            let layer =
+                network
+                    .add_cast(input0, target)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("integer input cast: {e}"),
+                    })?;
+            *input0 = layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("integer input cast output: {e}"),
+                })?;
+        }
+        if dtype1 != target {
+            let layer =
+                network
+                    .add_cast(input1, target)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("integer input cast: {e}"),
+                    })?;
+            *input1 = layer
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("integer input cast output: {e}"),
+                })?;
+        }
         Ok(())
     }
 
@@ -1631,7 +1691,7 @@ impl TrtxConverter {
 
         let i32_0 = Self::cast_uint8_to_int32(network, input0)?;
         let i32_1 = Self::cast_uint8_to_int32(network, input1)?;
-        let (bc_input0, bc_input1) = Self::ensure_broadcast_compatible(
+        let (mut bc_input0, mut bc_input1) = Self::ensure_broadcast_compatible(
             network,
             graph,
             id0,
@@ -1640,6 +1700,8 @@ impl TrtxConverter {
             &i32_1,
             operation.op_type(),
         )?;
+
+        Self::widen_matching_integer_inputs(network, &mut bc_input0, &mut bc_input1)?;
 
         let layer = network
             .add_elementwise(&bc_input0, &bc_input1, op_code)
@@ -1685,7 +1747,7 @@ impl TrtxConverter {
             })?;
 
         // Ensure broadcast compatibility
-        let (bc_input0, bc_input1) = Self::ensure_broadcast_compatible(
+        let (mut bc_input0, mut bc_input1) = Self::ensure_broadcast_compatible(
             network,
             graph,
             id0,
@@ -1694,6 +1756,8 @@ impl TrtxConverter {
             input1,
             operation.op_type(),
         )?;
+
+        Self::widen_matching_integer_inputs(network, &mut bc_input0, &mut bc_input1)?;
 
         // Comparison operation returns BOOL
         let layer = network
@@ -7674,38 +7738,57 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        // Get axes from attributes
-        let axes_value =
-            operation
-                .attributes()
-                .get("axes")
-                .ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: "Unsqueeze operation missing 'axes' attribute".to_string(),
-                })?;
-
-        let _axes: Vec<u32> = if let Some(arr) = axes_value.as_array() {
-            arr.iter()
-                .filter_map(|v| v.as_u64().map(|u| u as u32))
-                .collect()
-        } else {
+        let axes = match operation {
+            Operation::Unsqueeze { options, .. } => options
+                .as_ref()
+                .map(|options| options.axes.clone())
+                .unwrap_or_default(),
+            _ => unreachable!("add_unsqueeze_op is only called for unsqueeze operations"),
+        };
+        let input_dims = input
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Unsqueeze: failed to get input dimensions: {e}"),
+            })?;
+        let output_rank = input_dims.len() + axes.len();
+        let mut axes = axes;
+        axes.sort_unstable();
+        if axes
+            .iter()
+            .enumerate()
+            .any(|(i, &axis)| axis as usize >= output_rank || (i > 0 && axes[i - 1] == axis))
+        {
             return Err(GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: "Invalid 'axes' attribute format".to_string(),
+                reason: format!("Unsqueeze: invalid axes {axes:?} for output rank {output_rank}"),
             });
-        };
+        }
+        let mut output_dims = Vec::with_capacity(output_rank);
+        let mut input_axis = 0;
+        for output_axis in 0..output_rank {
+            if axes.binary_search(&(output_axis as u32)).is_ok() {
+                output_dims.push(1);
+            } else {
+                output_dims.push(input_dims[input_axis]);
+                input_axis += 1;
+            }
+        }
 
         // Use IShuffleLayer to add dimensions
-        let layer = network
+        let mut layer = network
             .add_shuffle(input)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("Failed to add shuffle layer for unsqueeze: {}", e),
             })?;
 
-        // Note: Setting reshape dimensions requires accessing layer methods
-        // Full implementation requires calling layer.set_reshape_dimensions()
-        // with the expanded shape (inserting 1s at specified axes)
+        layer
+            .set_reshape_dimensions(network, &output_dims)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Unsqueeze: failed to set reshape dimensions {output_dims:?}: {e}"),
+            })?;
 
         let output = layer
             .output(&*network, 0)
@@ -7817,9 +7900,15 @@ impl TrtxConverter {
             } else if d == 1 {
                 stride.push(0);
             } else {
+                let input_name = graph
+                    .operand(in_id)
+                    .and_then(|operand| operand.name.as_deref())
+                    .unwrap_or("<unnamed>");
                 return Err(GraphError::ConversionFailed {
                     format: "trtx".to_string(),
-                    reason: format!("expand: cannot broadcast dim {d} to {t}"),
+                    reason: format!(
+                        "expand input {in_id} ({input_name}): cannot broadcast dim {d} to {t}"
+                    ),
                 });
             }
         }
@@ -8379,12 +8468,30 @@ impl TrtxConverter {
         } else {
             indices_shape_i64.iter().map(|&d| d as usize).product()
         };
-        let min_data: Vec<u8> = (0..num_elements)
-            .flat_map(|_| clamp_min_val.to_le_bytes())
-            .collect();
-        let max_data: Vec<u8> = (0..num_elements)
-            .flat_map(|_| clamp_max_val.to_le_bytes())
-            .collect();
+        let indices_dtype = indices.data_type(&*network);
+        let (min_data, max_data, constant_dtype) = if indices_dtype == TrtDataType::kINT64 {
+            let min = clamp_min_val as i64;
+            let max = clamp_max_val as i64;
+            (
+                (0..num_elements)
+                    .flat_map(|_| min.to_le_bytes())
+                    .collect::<Vec<_>>(),
+                (0..num_elements)
+                    .flat_map(|_| max.to_le_bytes())
+                    .collect::<Vec<_>>(),
+                TrtDataType::kINT64,
+            )
+        } else {
+            (
+                (0..num_elements)
+                    .flat_map(|_| clamp_min_val.to_le_bytes())
+                    .collect::<Vec<_>>(),
+                (0..num_elements)
+                    .flat_map(|_| clamp_max_val.to_le_bytes())
+                    .collect::<Vec<_>>(),
+                TrtDataType::kINT32,
+            )
+        };
         let trt_dims: Vec<i64> = if indices_shape_i64.is_empty() {
             vec![1]
         } else {
@@ -8392,13 +8499,13 @@ impl TrtxConverter {
         };
 
         let min_const = network
-            .add_small_constant_copied(&trt_dims, &min_data, trtx::DataType::kINT32, None)
+            .add_small_constant_copied(&trt_dims, &min_data, constant_dtype, None)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label}: clamp min constant: {e}"),
             })?;
         let max_const = network
-            .add_small_constant_copied(&trt_dims, &max_data, trtx::DataType::kINT32, None)
+            .add_small_constant_copied(&trt_dims, &max_data, constant_dtype, None)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
                 reason: format!("{label}: clamp max constant: {e}"),
@@ -13880,6 +13987,36 @@ impl TrtxConverter {
         let output_ids = operation.output_operands_slice();
         let output_id = output_ids[0];
         tensor_map.insert(output_id, output);
+        Ok(())
+    }
+
+    /// Add an internal Shape operation. TensorRT produces an INT64 shape tensor whose values are
+    /// resolved from the runtime input dimensions.
+    fn add_shape_op<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
+        operation: &Operation,
+    ) -> Result<(), GraphError> {
+        let input_id = operation.input_operands()[0];
+        let input = tensor_map
+            .get(&input_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Shape input operand {input_id} not found"),
+            })?;
+        let layer = network
+            .add_shape(input)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("add Shape layer: {e}"),
+            })?;
+        let output = layer
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Shape layer output: {e}"),
+            })?;
+        tensor_map.insert(operation.output_operands_slice()[0], output);
         Ok(())
     }
 

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -7753,6 +7753,36 @@ impl TrtxConverter {
         })
     }
 
+    fn tensor_dimension_size_tensor<'a>(
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor: &trtx::Tensor<'a>,
+        axis: usize,
+        label: &str,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let shape = network
+            .add_shape(tensor)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: Shape layer: {e}"),
+            })?
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: Shape output: {e}"),
+            })?;
+        network
+            .add_slice(&shape, &[axis as i64], &[1], &[1])
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: shape-vector slice: {e}"),
+            })?
+            .output(&*network, 0)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: shape-vector slice output: {e}"),
+            })
+    }
+
     /// Add slice operation.
     fn add_slice_op<'a>(
         graph: &'a GraphInfo,
@@ -7851,8 +7881,17 @@ impl TrtxConverter {
             .any(|dimension| matches!(dimension, MLDimension::Dynamic(_)))
         {
             let mut size_pieces = Vec::with_capacity(sizes_ml.len());
-            for dimension in sizes_ml {
+            for (axis, dimension) in sizes_ml.iter().enumerate() {
                 let piece = match dimension {
+                    // In mixed static/dynamic slices, exporter-provided non-singleton static
+                    // extents are profile maxima (e.g. 4096), not the current runtime extent.
+                    // Bind them to the source shape to avoid slicing past a short sequence.
+                    MLDimension::Static(size) if *size > 1 => Self::tensor_dimension_size_tensor(
+                        network,
+                        input,
+                        axis,
+                        "Slice static maximum extent",
+                    )?,
                     MLDimension::Static(size) => network
                         .add_small_constant_copied(
                             &[1],
@@ -8973,11 +9012,16 @@ impl TrtxConverter {
         clamp_max_val: i32,
         label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
-        let num_elements: usize = if indices_shape_i64.is_empty() {
-            1
-        } else {
-            indices_shape_i64.iter().map(|&d| d as usize).product()
-        };
+        let indices_rank = indices
+            .dimensions(&*network)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{label}: indices dimensions: {e}"),
+            })?
+            .len();
+        // Use singleton constants for clamping. Constants at the WebNN maximum index shape
+        // force TensorRT to broadcast dynamic indices to that maximum and make Gather static.
+        let num_elements = 1;
         let indices_dtype = indices.data_type(&*network);
         let (min_data, max_data, constant_dtype) = if indices_dtype == TrtDataType::kINT64 {
             let min = clamp_min_val as i64;
@@ -9005,7 +9049,7 @@ impl TrtxConverter {
         let trt_dims: Vec<i64> = if indices_shape_i64.is_empty() {
             vec![1]
         } else {
-            indices_shape_i64.to_vec()
+            vec![1; indices_rank]
         };
 
         let min_const = network

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1413,6 +1413,77 @@ impl TrtxConverter {
         dims1: &[i64],
         op_name: &str,
     ) -> Result<(trtx::Tensor<'a>, trtx::Tensor<'a>), GraphError> {
+        // TensorRT requires matching ranks even when one input is a scalar. A scalar can always
+        // be rank-padded with static singleton dimensions; unlike a general dynamic reshape this
+        // needs no wildcard dimensions or shape tensor.
+        if dims0.is_empty() && !dims1.is_empty() {
+            let mut shuffle =
+                network
+                    .add_shuffle(tensor0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_name}: scalar rank padding shuffle: {e}"),
+                    })?;
+            shuffle
+                .set_reshape_dimensions(network, &vec![1; dims1.len()])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: scalar rank padding reshape: {e}"),
+                })?;
+            let padded =
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_name}: scalar rank padding output: {e}"),
+                    })?;
+            let other = network
+                .add_identity(tensor1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            return Ok((padded, other));
+        }
+        if dims1.is_empty() && !dims0.is_empty() {
+            let mut shuffle =
+                network
+                    .add_shuffle(tensor1)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_name}: scalar rank padding shuffle: {e}"),
+                    })?;
+            shuffle
+                .set_reshape_dimensions(network, &vec![1; dims0.len()])
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: scalar rank padding reshape: {e}"),
+                })?;
+            let padded =
+                shuffle
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("{op_name}: scalar rank padding output: {e}"),
+                    })?;
+            let other = network
+                .add_identity(tensor0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            return Ok((other, padded));
+        }
         if dims0.contains(&-1) || dims1.contains(&-1) {
             let output0 = network
                 .add_identity(tensor0)
@@ -3499,7 +3570,14 @@ impl TrtxConverter {
                 reason: format!("{label} uint8 storage fix dimensions: {e}"),
             })?;
         let bshape: Vec<i64> = if dims.is_empty() {
-            vec![]
+            // TensorRT may not expose a DQ output's dynamic rank during construction. The mask
+            // promotion path feeds rank-4 attention masks, so keep its correction constants
+            // rank-aligned rather than emitting illegal scalar elementwise inputs.
+            if label == "mask broadcast promote" {
+                vec![1; 4]
+            } else {
+                vec![]
+            }
         } else {
             vec![1_i64; dims.len()]
         };

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -1376,7 +1376,7 @@ impl TrtxConverter {
         // TensorRT elementwise layers broadcast dynamic dimensions natively.  Static broadcast
         // inference below cannot represent `-1`; when ranks already agree, preserve the dynamic
         // tensors unchanged and let TensorRT resolve the shape at execution time.
-        if dims0.len() == dims1.len() && (dims0.contains(&-1) || dims1.contains(&-1)) {
+        if dims0.contains(&-1) || dims1.contains(&-1) {
             let output0 = network
                 .add_identity(tensor0)
                 .map_err(|e| GraphError::ConversionFailed {
@@ -1413,6 +1413,31 @@ impl TrtxConverter {
         dims1: &[i64],
         op_name: &str,
     ) -> Result<(trtx::Tensor<'a>, trtx::Tensor<'a>), GraphError> {
+        if dims0.contains(&-1) || dims1.contains(&-1) {
+            let output0 = network
+                .add_identity(tensor0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            let output1 = network
+                .add_identity(tensor1)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity: {e}"),
+                })?
+                .output(&*network, 0)
+                .map_err(|e| GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!("{op_name}: dynamic broadcast identity output: {e}"),
+                })?;
+            return Ok((output0, output1));
+        }
         let shape0 = Self::trtx_dims_to_u32(dims0, op_name)?;
         let shape1 = Self::trtx_dims_to_u32(dims1, op_name)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -355,6 +355,8 @@ pub enum GraphError {
     TooManyOperands { count: usize },
     #[error("operand {operand} has a shape that overflows element count")]
     OperandElementCountOverflow { operand: u32 },
+    #[error("cannot lower operand {operand}: its shape is unknown for {format}")]
+    UnknownOperandShape { operand: u32, format: String },
     #[error("operand {operand} exceeds tensor byte limit ({byte_length} > {limit})")]
     TensorLimit {
         operand: u32,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -198,25 +198,134 @@ pub fn pack_uint4_from_i32(values: &[i32]) -> Vec<u8> {
     )
 }
 
+/// Whether a tensor's rank and dimensions are known in the graph IR.
+///
+/// `Known(Vec::new())` is a rank-0 scalar. `Unknown` is reserved for intermediate
+/// operands whose shape has not yet been inferred.
+#[derive(Debug, Clone, Deserialize, Hash, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum TensorShape {
+    Known(Vec<Dimension>),
+    Unknown(()),
+}
+
+impl Serialize for TensorShape {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Known(shape) => shape.serialize(serializer),
+            Self::Unknown(_) => serializer.serialize_none(),
+        }
+    }
+}
+
+impl Default for TensorShape {
+    fn default() -> Self {
+        Self::Unknown(())
+    }
+}
+
+impl TensorShape {
+    pub fn known(&self) -> Option<&[Dimension]> {
+        match self {
+            Self::Unknown(_) => None,
+            Self::Known(shape) => Some(shape),
+        }
+    }
+
+    pub fn known_mut(&mut self) -> Option<&mut Vec<Dimension>> {
+        match self {
+            Self::Unknown(_) => None,
+            Self::Known(shape) => Some(shape),
+        }
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown(_))
+    }
+
+    pub fn rank(&self) -> Option<usize> {
+        self.known().map(|shape| shape.len())
+    }
+}
+
+// Transitional compatibility for existing shape-inference code. Read-side callers must migrate to
+// `known()` before relying on rank; mutation materializes a previously unknown shape as known.
+impl std::ops::Deref for TensorShape {
+    type Target = Vec<Dimension>;
+
+    fn deref(&self) -> &Self::Target {
+        static EMPTY: std::sync::LazyLock<Vec<Dimension>> = std::sync::LazyLock::new(Vec::new);
+        match self {
+            Self::Unknown(_) => &EMPTY,
+            Self::Known(shape) => shape,
+        }
+    }
+}
+
+impl std::ops::DerefMut for TensorShape {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        if matches!(self, Self::Unknown(_)) {
+            *self = Self::Known(Vec::new());
+        }
+        match self {
+            Self::Known(shape) => shape,
+            Self::Unknown(_) => unreachable!(),
+        }
+    }
+}
+
+impl From<Vec<Dimension>> for TensorShape {
+    fn from(shape: Vec<Dimension>) -> Self {
+        Self::Known(shape)
+    }
+}
+
+impl std::iter::FromIterator<Dimension> for TensorShape {
+    fn from_iter<T: IntoIterator<Item = Dimension>>(iter: T) -> Self {
+        Self::Known(iter.into_iter().collect())
+    }
+}
+
+impl<'a> IntoIterator for &'a TensorShape {
+    type Item = &'a Dimension;
+    type IntoIter = std::slice::Iter<'a, Dimension>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::ops::Deref::deref(self).iter()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]
 pub struct OperandDescriptor {
     pub data_type: DataType,
     #[serde(default)]
-    pub shape: Vec<Dimension>,
+    pub shape: TensorShape,
     #[serde(default)]
     pub pending_permutation: Vec<u32>,
 }
 
 impl OperandDescriptor {
+    pub fn known_shape(&self) -> Option<&[Dimension]> {
+        match &self.shape {
+            TensorShape::Unknown(_) => None,
+            TensorShape::Known(shape) => Some(shape),
+        }
+    }
+
     pub fn has_dynamic_dimensions(&self) -> bool {
-        self.shape
+        self.known_shape()
+            .unwrap_or_default()
             .iter()
             .any(|dim| matches!(dim, Dimension::Dynamic(_)))
     }
 
     pub fn static_shape(&self) -> Option<Vec<u32>> {
-        let mut shape = Vec::with_capacity(self.shape.len());
-        for dim in &self.shape {
+        let known = self.known_shape()?;
+        let mut shape = Vec::with_capacity(known.len());
+        for dim in known {
             match dim {
                 Dimension::Static(v) => shape.push(*v),
                 Dimension::Dynamic(_) => return None,
@@ -226,15 +335,20 @@ impl OperandDescriptor {
     }
 
     pub fn static_or_max_shape(&self) -> Vec<u32> {
-        self.shape.iter().map(get_static_or_max_size).collect()
+        self.known_shape()
+            .unwrap_or_default()
+            .iter()
+            .map(get_static_or_max_size)
+            .collect()
     }
 
     pub fn element_count(&self) -> Option<usize> {
-        if self.shape.is_empty() {
+        let shape = self.known_shape()?;
+        if shape.is_empty() {
             return Some(1);
         }
         let mut count = 1usize;
-        for dim in &self.shape {
+        for dim in shape {
             let size = get_static_or_max_size(dim) as usize;
             count = count.checked_mul(size)?;
         }
@@ -301,6 +415,18 @@ impl GraphInfo {
         self.operands
             .iter()
             .any(|operand| operand.descriptor.has_dynamic_dimensions())
+    }
+
+    pub fn ensure_known_shapes(&self, format: &str) -> Result<(), GraphError> {
+        for (operand, value) in self.operands.iter().enumerate() {
+            if value.descriptor.shape.is_unknown() {
+                return Err(GraphError::UnknownOperandShape {
+                    operand: operand as u32,
+                    format: format.to_string(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Ensures `input_operands` / `output_operands` match operands tagged as graph I/O.
@@ -439,6 +565,10 @@ impl GraphInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn to_dimension_vector(shape: &[u32]) -> TensorShape {
+        TensorShape::Known(super::to_dimension_vector(shape))
+    }
     use crate::error::GraphError;
 
     #[test]
@@ -762,5 +892,46 @@ mod tests {
             graph.validate_io_operand_lists(),
             Err(GraphError::InputIdListMismatch { .. })
         );
+    }
+
+    #[test]
+    fn tensor_shape_distinguishes_unknown_from_scalar() {
+        let unknown = TensorShape::Unknown(());
+        let scalar = TensorShape::Known(vec![]);
+
+        assert!(unknown.is_unknown());
+        assert_eq!(unknown.rank(), None);
+        assert!(!scalar.is_unknown());
+        assert_eq!(scalar.rank(), Some(0));
+        assert_eq!(
+            OperandDescriptor {
+                data_type: DataType::Float32,
+                shape: scalar,
+                pending_permutation: vec![],
+            }
+            .element_count(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn tensor_shape_serde_preserves_scalar_and_dynamic_dimension() {
+        let descriptor = OperandDescriptor {
+            data_type: DataType::Float32,
+            shape: TensorShape::Known(vec![Dimension::Dynamic(DynamicDimension {
+                name: "batch".to_string(),
+                max_size: 8,
+            })]),
+            pending_permutation: vec![],
+        };
+        let encoded = serde_json::to_value(&descriptor).unwrap();
+        assert_eq!(encoded["shape"][0]["name"], "batch");
+        let decoded: OperandDescriptor = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.shape, descriptor.shape);
+
+        let scalar: TensorShape = serde_json::from_str("[]").unwrap();
+        assert_eq!(scalar, TensorShape::Known(vec![]));
+        let unknown: TensorShape = serde_json::from_str("null").unwrap();
+        assert!(unknown.is_unknown());
     }
 }

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -101,7 +101,10 @@ fn escape_label(label: &str) -> String {
         .replace('\n', "\\n")
 }
 
-fn format_shape(shape: &[Dimension]) -> String {
+fn format_shape(shape: &crate::graph::TensorShape) -> String {
+    let Some(shape) = shape.known() else {
+        return "unknown".to_string();
+    };
     if shape.is_empty() {
         return "scalar".to_string();
     }
@@ -119,9 +122,14 @@ fn format_shape(shape: &[Dimension]) -> String {
 mod tests {
     use super::graph_to_dot;
     use crate::graph::{
-        DataType, GraphInfo, Operand, OperandDescriptor, OperandKind, to_dimension_vector,
+        DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
+        to_dimension_vector as dimensions,
     };
     use crate::operators::Operation;
+
+    fn to_dimension_vector(shape: &[u32]) -> crate::graph::TensorShape {
+        crate::graph::TensorShape::Known(dimensions(shape))
+    }
 
     #[test]
     fn exports_graphviz_with_operands_and_operations() {

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -5,7 +5,7 @@ use log::{debug, trace};
 use webnn_graph::serialize::SerializeOptions;
 
 use crate::error::{GraphBuilderError, GraphError, ShapeInferenceError};
-use crate::graph::{Dimension, get_static_or_max_size, to_dimension_vector};
+use crate::graph::{Dimension, TensorShape, get_static_or_max_size, to_dimension_vector};
 use crate::mlcontext::{MLGraph, MLOperand, MLOperandDescriptor, MLTensor};
 use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{
@@ -125,7 +125,7 @@ fn slice_shape(
 
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -144,7 +144,7 @@ fn concat_shape(
     } else {
         let input_shapes: Vec<Vec<Dimension>> = operands
             .iter()
-            .map(|op| op.descriptor.shape.clone())
+            .map(|op| op.descriptor.known_shape().unwrap_or_default().to_vec())
             .collect();
         infer_concat_shape_dimensions(&input_shapes, axis).map_err(|e| {
             Box::new(ShapeInferenceError::ConcatError {
@@ -160,7 +160,7 @@ fn concat_shape(
     };
     Ok(OperandDescriptor {
         data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -189,7 +189,7 @@ fn expand_shape(
 
     Ok(OperandDescriptor {
         data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -252,7 +252,7 @@ fn constant_shape(
     };
     Ok(OperandDescriptor {
         data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -273,7 +273,7 @@ fn matmul_shape(
     )?;
     Ok(OperandDescriptor {
         data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -309,7 +309,7 @@ fn gemm_shape(
     }
     Ok(OperandDescriptor {
         data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -331,7 +331,7 @@ fn transpose_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -357,7 +357,7 @@ fn gather_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -397,7 +397,7 @@ fn gather_nd_shape(
         )?;
         return Ok(OperandDescriptor {
             data_type: input_op.descriptor.data_type,
-            shape,
+            shape: TensorShape::Known(shape),
             pending_permutation: vec![],
         });
     }
@@ -420,7 +420,7 @@ fn gather_nd_shape(
         )?;
         return Ok(OperandDescriptor {
             data_type: input_op.descriptor.data_type,
-            shape,
+            shape: TensorShape::Known(shape),
             pending_permutation: vec![],
         });
     }
@@ -428,7 +428,7 @@ fn gather_nd_shape(
     shape.extend_from_slice(&input_op.descriptor.shape[k..]);
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -531,7 +531,7 @@ fn resample2d_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -556,7 +556,7 @@ fn argminmax_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: opts.output_data_type.into(),
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -585,7 +585,7 @@ fn reduce_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -600,7 +600,7 @@ fn reshape_shape(
     let shape: Vec<Dimension> = new_shape.iter().cloned().map(Into::into).collect();
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -627,7 +627,7 @@ fn conv2d_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -654,7 +654,7 @@ fn conv_transpose2d_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -684,7 +684,7 @@ fn pool2d_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -711,7 +711,7 @@ fn global_pool_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -734,7 +734,7 @@ fn pad_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -757,7 +757,7 @@ fn squeeze_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -777,7 +777,7 @@ fn unsqueeze_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -797,7 +797,7 @@ fn tile_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: operand.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -821,7 +821,7 @@ fn prelu_shape(
     )?;
     Ok(OperandDescriptor {
         data_type: input_op.descriptor.data_type,
-        shape,
+        shape: TensorShape::Known(shape),
         pending_permutation: vec![],
     })
 }
@@ -867,7 +867,7 @@ fn shape_op_shape(input: MLOperand, graph: &GraphInfo) -> Result<OperandDescript
     let rank = operand.descriptor.shape.len() as u32;
     Ok(OperandDescriptor {
         data_type: DataType::Int64,
-        shape: vec![Dimension::Static(rank)],
+        shape: TensorShape::Known(vec![Dimension::Static(rank)]),
         pending_permutation: vec![],
     })
 }
@@ -925,7 +925,7 @@ fn where_shape(
 
     Ok(OperandDescriptor {
         data_type: operands[1].descriptor.data_type,
-        shape: output_shape,
+        shape: TensorShape::Known(output_shape),
         pending_permutation: vec![],
     })
 }
@@ -941,21 +941,23 @@ fn same_shape(
 
     let mut output_descriptor = operands[0].descriptor.clone();
     for op in operands.iter().skip(1) {
-        output_descriptor.shape = crate::shape_inference::broadcast_shapes_dimensions(
-            &output_descriptor.shape,
-            &op.descriptor.shape,
-        )
-        .map_err(|e| {
-            Box::new(ShapeInferenceError::BroadcastError {
-                operation: operation.clone(),
-                inputs: inputs
-                    .iter()
-                    .copied()
-                    .zip(operands.iter().map(|&o| o.clone()))
-                    .collect(),
-                source: e,
-            })
-        })?;
+        output_descriptor.shape = TensorShape::Known(
+            crate::shape_inference::broadcast_shapes_dimensions(
+                &output_descriptor.shape,
+                &op.descriptor.shape,
+            )
+            .map_err(|e| {
+                Box::new(ShapeInferenceError::BroadcastError {
+                    operation: operation.clone(),
+                    inputs: inputs
+                        .iter()
+                        .copied()
+                        .zip(operands.iter().map(|&o| o.clone()))
+                        .collect(),
+                    source: e,
+                })
+            })?,
+        );
     }
 
     Ok(output_descriptor)
@@ -1280,13 +1282,13 @@ fn gru_output_shapes(
 
     let mut shapes = vec![OperandDescriptor {
         data_type: dtype,
-        shape: to_dimension_vector(&[num_dir, batch, h]),
+        shape: TensorShape::Known(to_dimension_vector(&[num_dir, batch, h])),
         pending_permutation: vec![],
     }];
     if opts.return_sequence {
         shapes.push(OperandDescriptor {
             data_type: dtype,
-            shape: to_dimension_vector(&[steps, num_dir, batch, h]),
+            shape: TensorShape::Known(to_dimension_vector(&[steps, num_dir, batch, h])),
             pending_permutation: vec![],
         });
     }
@@ -1310,18 +1312,18 @@ fn lstm_output_shapes(
     let mut shapes = Vec::new();
     shapes.push(OperandDescriptor {
         data_type: dtype,
-        shape: to_dimension_vector(&[num_dir, batch, h]),
+        shape: TensorShape::Known(to_dimension_vector(&[num_dir, batch, h])),
         pending_permutation: vec![],
     });
     shapes.push(OperandDescriptor {
         data_type: dtype,
-        shape: to_dimension_vector(&[num_dir, batch, h]),
+        shape: TensorShape::Known(to_dimension_vector(&[num_dir, batch, h])),
         pending_permutation: vec![],
     });
     if opts.return_sequence {
         shapes.push(OperandDescriptor {
             data_type: dtype,
-            shape: to_dimension_vector(&[steps, num_dir, batch, h]),
+            shape: TensorShape::Known(to_dimension_vector(&[steps, num_dir, batch, h])),
             pending_permutation: vec![],
         });
     }
@@ -1355,7 +1357,10 @@ fn gru_cell_shape(
     if input_shape.len() == 2 && hidden_size > 0 {
         return Ok(OperandDescriptor {
             data_type: graph.operands[input.id].descriptor.data_type,
-            shape: to_dimension_vector(&[get_static_or_max_size(&input_shape[0]), hidden_size]),
+            shape: TensorShape::Known(to_dimension_vector(&[
+                get_static_or_max_size(&input_shape[0]),
+                hidden_size,
+            ])),
             pending_permutation: vec![],
         });
     }
@@ -1911,7 +1916,7 @@ fn shape_inference_single_output(
             )?;
             Ok(OperandDescriptor {
                 data_type: operand.descriptor.data_type,
-                shape,
+                shape: TensorShape::Known(shape),
                 pending_permutation: vec![],
             })
         }

--- a/src/runtime_checks.rs
+++ b/src/runtime_checks.rs
@@ -72,20 +72,24 @@ impl RuntimeShapeState {
         descriptor: &OperandDescriptor,
         kind: TensorKind,
     ) -> Result<(), GraphError> {
-        if actual_shape.len() != descriptor.shape.len() {
+        let expected_shape =
+            descriptor
+                .known_shape()
+                .ok_or_else(|| GraphError::UnknownOperandShape {
+                    operand: 0,
+                    format: format!("runtime {} tensor `{}`", kind.as_str(), name),
+                })?;
+        if actual_shape.len() != expected_shape.len() {
             return Err(GraphError::RuntimeTensorRankMismatch {
                 kind: kind.as_str().to_string(),
                 name: name.to_string(),
-                expected_rank: descriptor.shape.len(),
+                expected_rank: expected_shape.len(),
                 actual_rank: actual_shape.len(),
             });
         }
 
-        for (axis, (actual, expected_dim)) in actual_shape
-            .iter()
-            .copied()
-            .zip(&descriptor.shape)
-            .enumerate()
+        for (axis, (actual, expected_dim)) in
+            actual_shape.iter().copied().zip(expected_shape).enumerate()
         {
             match expected_dim {
                 Dimension::Static(expected) => {
@@ -163,7 +167,7 @@ mod tests {
     fn input_desc(shape: Vec<Dimension>) -> OperandDescriptor {
         OperandDescriptor {
             data_type: DataType::Float32,
-            shape,
+            shape: crate::graph::TensorShape::Known(shape),
             pending_permutation: vec![],
         }
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -70,6 +70,16 @@ impl<'a> GraphValidator<'a> {
         if !crate::graph::dynamic_inputs_enabled() && self.graph.has_dynamic_dimensions() {
             return Err(GraphError::DynamicInputsFeatureDisabled);
         }
+        for (operand_id, operand) in self.graph.operands.iter().enumerate() {
+            if operand.descriptor.shape.is_unknown() {
+                log::warn!(
+                    "validation continuing with unknown shape for operand {} (name={:?}, kind={:?}); backend lowering may reject it",
+                    operand_id,
+                    operand.name,
+                    operand.kind,
+                );
+            }
+        }
         if self.graph.operands.len() >= u32::MAX as usize {
             return Err(GraphError::TooManyOperands {
                 count: self.graph.operands.len(),
@@ -85,6 +95,14 @@ impl<'a> GraphValidator<'a> {
         for (idx, operand) in self.graph.operands.iter().enumerate() {
             let operand_id = idx as u32;
             let descriptor = &operand.descriptor;
+            if descriptor.shape.is_unknown() {
+                log::warn!(
+                    "skipping byte-limit validation for unknown shape on operand {} (name={:?})",
+                    operand_id,
+                    operand.name,
+                );
+                continue;
+            }
             let byte_length =
                 descriptor
                     .byte_length()
@@ -483,8 +501,8 @@ mod tests {
     use crate::graph::{ConstantData, GraphInfo, Operand};
     use crate::operators::Operation;
 
-    fn s(shape: &[u32]) -> Vec<crate::graph::Dimension> {
-        crate::graph::to_dimension_vector(shape)
+    fn s(shape: &[u32]) -> crate::graph::TensorShape {
+        crate::graph::TensorShape::Known(crate::graph::to_dimension_vector(shape))
     }
 
     fn constant_data_for(descriptor: &OperandDescriptor) -> ConstantData {
@@ -509,7 +527,7 @@ mod tests {
             kind: OperandKind::Input,
             descriptor: OperandDescriptor {
                 data_type: input_dtype,
-                shape: input_shape.clone(),
+                shape: crate::graph::TensorShape::Known(input_shape.clone()),
                 pending_permutation: Vec::new(),
             },
             name: Some("input".to_string()),
@@ -517,7 +535,7 @@ mod tests {
 
         let scale_descriptor = OperandDescriptor {
             data_type: scale_dtype,
-            shape: scale_shape.clone(),
+            shape: crate::graph::TensorShape::Known(scale_shape.clone()),
             pending_permutation: Vec::new(),
         };
         let scale_operand = Operand {
@@ -528,7 +546,7 @@ mod tests {
 
         let zero_point_descriptor = OperandDescriptor {
             data_type: zero_point_dtype,
-            shape: scale_shape.clone(),
+            shape: crate::graph::TensorShape::Known(scale_shape.clone()),
             pending_permutation: Vec::new(),
         };
         let zero_point_operand = Operand {
@@ -543,7 +561,7 @@ mod tests {
             } else {
                 DataType::Float32
             },
-            shape: input_shape.clone(),
+            shape: crate::graph::TensorShape::Known(input_shape.clone()),
             pending_permutation: Vec::new(),
         };
         let output_operand = Operand {
@@ -606,7 +624,7 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: dynamic_shape.clone(),
+                        shape: crate::graph::TensorShape::Known(dynamic_shape.clone()),
                         pending_permutation: vec![],
                     },
                     name: Some("input".to_string()),
@@ -615,7 +633,7 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: dynamic_shape,
+                        shape: crate::graph::TensorShape::Known(dynamic_shape),
                         pending_permutation: vec![],
                     },
                     name: Some("output".to_string()),
@@ -758,7 +776,7 @@ mod tests {
             kind: OperandKind::Intermediate,
             descriptor: OperandDescriptor {
                 data_type: DataType::Float32,
-                shape: vec![],
+                shape: crate::graph::TensorShape::Known(vec![]),
                 pending_permutation: Vec::new(),
             },
             name: Some("intermediate".to_string()),
@@ -768,7 +786,7 @@ mod tests {
             kind: OperandKind::Output,
             descriptor: OperandDescriptor {
                 data_type: DataType::Uint8,
-                shape: vec![],
+                shape: crate::graph::TensorShape::Known(vec![]),
                 pending_permutation: Vec::new(),
             },
             name: Some("output".to_string()),

--- a/src/webnn_json.rs
+++ b/src/webnn_json.rs
@@ -20,7 +20,7 @@ use crate::debug_print;
 use crate::error::GraphError;
 use crate::graph::{
     ConstantData, DataType, Dimension, DynamicDimension, GraphInfo, Operand, OperandDescriptor,
-    OperandKind, to_dimension_vector,
+    OperandKind, TensorShape, to_dimension_vector,
 };
 use crate::operator_enums::MLOperandDataType;
 use crate::operators::Operation;
@@ -417,7 +417,7 @@ pub fn from_graph_json(graph_json: &GraphJson) -> Result<GraphInfo, GraphError> 
             name: Some(name.clone()),
             descriptor: OperandDescriptor {
                 data_type: from_webnn_datatype(&const_decl.data_type),
-                shape: to_dimension_vector(&const_decl.shape),
+                shape: TensorShape::Known(to_dimension_vector(&const_decl.shape)),
                 pending_permutation: Vec::new(),
             },
             kind: OperandKind::Constant,
@@ -470,7 +470,7 @@ pub fn from_graph_json(graph_json: &GraphJson) -> Result<GraphInfo, GraphError> 
                         name: Some(name.clone()),
                         descriptor: OperandDescriptor {
                             data_type: DataType::Float32, // Default, will be inferred
-                            shape: Vec::new(),            // Will be inferred
+                            shape: crate::graph::TensorShape::Unknown(()),
                             pending_permutation: Vec::new(),
                         },
                         kind: OperandKind::Intermediate,
@@ -523,7 +523,7 @@ pub fn from_graph_json(graph_json: &GraphJson) -> Result<GraphInfo, GraphError> 
 }
 
 /// Infer output shapes for all operations in the graph
-fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
+pub fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
     use crate::shape_inference::*;
 
     fn parse_dtype(value: &serde_json::Value) -> Option<DataType> {
@@ -630,7 +630,8 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             {
                 let inp = &mut graph.operands[*input_id as usize];
                 if inp.descriptor.shape.len() != repeats_len {
-                    inp.descriptor.shape = vec![Dimension::Static(1); repeats_len];
+                    inp.descriptor.shape =
+                        TensorShape::Known(vec![Dimension::Static(1); repeats_len]);
                     made_progress = true;
                 }
             }
@@ -649,7 +650,13 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             let input_shapes: Vec<Vec<Dimension>> = op
                 .input_operands()
                 .iter()
-                .map(|&id| graph.operands[id as usize].descriptor.shape.clone())
+                .map(|&id| {
+                    graph.operands[id as usize]
+                        .descriptor
+                        .known_shape()
+                        .unwrap_or_default()
+                        .to_vec()
+                })
                 .collect();
             let input_types: Vec<DataType> = op
                 .input_operands()
@@ -759,6 +766,26 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     }
                 }
 
+                "unsqueeze" => {
+                    if input_shapes.len() == 1 {
+                        let axes = match &op {
+                            Operation::Unsqueeze { options, .. } => {
+                                options.as_ref().map(|options| options.axes.as_slice())
+                            }
+                            _ => None,
+                        }
+                        .unwrap_or(&[]);
+                        infer_unsqueeze_shape_dimensions(&input_shapes[0], axes).ok()
+                    } else {
+                        None
+                    }
+                }
+
+                "triangular" => input_shapes.first().cloned(),
+
+                // scatterND modifies values in-place, so its result has the data input's shape.
+                "scatternd" | "scatter_nd" => input_shapes.first().cloned(),
+
                 // MatMul
                 "matmul" => {
                     if input_shapes.len() >= 2 {
@@ -865,7 +892,7 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                     // to back-propagate indices shape and as the result.
                     let existing_output_shape = op.output_operand().and_then(|id| {
                         let o = graph.operands.get(id as usize)?;
-                        (!o.descriptor.shape.is_empty()).then_some(o.descriptor.shape.clone())
+                        o.descriptor.known_shape().map(ToOwned::to_owned)
                     });
 
                     if let Some(shape_override) = existing_output_shape {
@@ -884,9 +911,9 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
                                     if indices_operand.descriptor.shape.is_empty()
                                         && shape_override.len() >= tail_len
                                     {
-                                        indices_operand.descriptor.shape = shape_override
+                                        indices_operand.descriptor.shape = TensorShape::Known(shape_override
                                             [..shape_override.len() - tail_len]
-                                            .to_vec();
+                                            .to_vec());
                                         made_progress = true;
                                     }
                                 }
@@ -1071,7 +1098,7 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
             if let Some(shape) = output_shape
                 && let Some(output_id) = op.output_operand()
             {
-                graph.operands[output_id as usize].descriptor.shape = shape;
+                graph.operands[output_id as usize].descriptor.shape = TensorShape::Known(shape);
                 made_progress = true;
             }
 
@@ -1211,20 +1238,20 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
         }
     }
 
-    // Summary: count operands with empty shapes
-    let empty_shape_count = graph
+    // Unknown is distinct from a known rank-0 scalar (`Known([])`).
+    let unknown_shape_count = graph
         .operands
         .iter()
-        .filter(|op| op.descriptor.shape.is_empty())
+        .filter(|op| op.descriptor.shape.is_unknown())
         .count();
     debug_print!(
         "[SHAPE INFERENCE] Completed: {} operands still have empty shapes",
-        empty_shape_count
+        unknown_shape_count
     );
-    if empty_shape_count > 0 {
+    if unknown_shape_count > 0 {
         debug_print!("[SHAPE INFERENCE] WARNING: Some operands could not have shapes inferred!");
         for (idx, op) in graph.operands.iter().enumerate() {
-            if op.descriptor.shape.is_empty() {
+            if op.descriptor.shape.is_unknown() {
                 debug_print!("  operand_{}: name={:?}, kind={:?}", idx, op.name, op.kind);
             }
         }
@@ -1236,6 +1263,10 @@ fn infer_output_shapes(graph: &mut GraphInfo) -> Result<(), GraphError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn to_dimension_vector(shape: &[u32]) -> TensorShape {
+        TensorShape::Known(super::to_dimension_vector(shape))
+    }
     use webnn_graph::serialize::{SerializeOptions, serialize_graph_to_wg_text};
 
     fn wshape(shape: &[u32]) -> Vec<webnn_graph::ast::Dimension> {
@@ -1545,7 +1576,10 @@ mod tests {
         assert_eq!(graph_info.operands.len(), 1);
         assert!(matches!(graph_info.operands[0].kind, OperandKind::Constant));
         let empty_shape: Vec<Dimension> = vec![];
-        assert_eq!(graph_info.operands[0].descriptor.shape, empty_shape);
+        assert_eq!(
+            graph_info.operands[0].descriptor.shape,
+            TensorShape::Known(empty_shape)
+        );
     }
 
     #[test]
@@ -2066,7 +2100,7 @@ mod tests {
         let out_desc = &graph_info.operands[out_id].descriptor;
         assert_eq!(
             out_desc.shape,
-            vec![Dimension::Static(2), Dimension::Static(3)]
+            TensorShape::Known(vec![Dimension::Static(2), Dimension::Static(3)])
         );
         assert_eq!(out_desc.data_type, DataType::Uint8);
     }
@@ -2123,7 +2157,7 @@ mod tests {
         let out_desc = &graph_info.operands[out_id].descriptor;
         assert_eq!(
             out_desc.shape,
-            vec![Dimension::Static(2), Dimension::Static(3)]
+            TensorShape::Known(vec![Dimension::Static(2), Dimension::Static(3)])
         );
         assert_eq!(out_desc.data_type, DataType::Float32);
     }
@@ -2213,7 +2247,7 @@ mod tests {
         let out_desc = &graph_info.operands[out_id].descriptor;
         assert_eq!(
             out_desc.shape,
-            vec![Dimension::Static(3), Dimension::Static(4)]
+            TensorShape::Known(vec![Dimension::Static(3), Dimension::Static(4)])
         );
         assert_eq!(out_desc.data_type, DataType::Float32);
     }
@@ -2277,13 +2311,13 @@ mod tests {
                     kind: OperandKind::Input,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: TensorShape::Known(vec![
                             Dimension::Dynamic(DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             Dimension::Static(3),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                     name: Some("x".to_string()),
@@ -2292,13 +2326,13 @@ mod tests {
                     kind: OperandKind::Output,
                     descriptor: OperandDescriptor {
                         data_type: DataType::Float32,
-                        shape: vec![
+                        shape: TensorShape::Known(vec![
                             Dimension::Dynamic(DynamicDimension {
                                 name: "batch".to_string(),
                                 max_size: 8,
                             }),
                             Dimension::Static(3),
-                        ],
+                        ]),
                         pending_permutation: vec![],
                     },
                     name: Some("y".to_string()),
@@ -2341,10 +2375,10 @@ mod tests {
                 kind: OperandKind::Constant,
                 descriptor: OperandDescriptor {
                     data_type: DataType::Float32,
-                    shape: vec![Dimension::Dynamic(DynamicDimension {
+                    shape: TensorShape::Known(vec![Dimension::Dynamic(DynamicDimension {
                         name: "n".to_string(),
                         max_size: 4,
-                    })],
+                    })]),
                     pending_permutation: vec![],
                 },
                 name: Some("const_dynamic".to_string()),

--- a/tests/test_trtx_execution.rs
+++ b/tests/test_trtx_execution.rs
@@ -11,13 +11,17 @@ mod tests {
     use rustnn::converters::{GraphConverter, TrtxConverter};
     use rustnn::graph::{
         ConstantData, DataType, GraphInfo, Operand, OperandDescriptor, OperandKind,
-        get_static_or_max_size, to_dimension_vector,
+        get_static_or_max_size, to_dimension_vector as dimensions,
     };
     use rustnn::operator_options::MLConv2dOptions;
     use rustnn::operators::Operation;
     use std::collections::HashMap;
     use trtx::cuda::DeviceBuffer;
     use trtx::{Logger, Runtime};
+
+    fn to_dimension_vector(shape: &[u32]) -> rustnn::graph::TensorShape {
+        rustnn::graph::TensorShape::Known(dimensions(shape))
+    }
 
     /// Build [`Operation`] from WebNN op name, operand wiring, JSON attributes, and optional options label.
     fn trtx_operation(


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

Support dynamic shapes and `shape` operator in TRT. Still draft because no good way to validate dynamic shapes behavior expect for selected onnx conversions.

There is also a problem for sequence length 0 in the smollm example

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

