### PR TITLE
Refresh WPT subgraph snapshots

### DIFF
--- a/tests/snapshots/run_wpt_conformance__litert_identity___relu.snap
+++ b/tests/snapshots/run_wpt_conformance__litert_identity___relu.snap
@@ -1,0 +1,10 @@
+---
+source: tests/run_wpt_conformance.rs
+expression: "(&file_name, &test_name, &backend_prefix, \"PASS\")"
+---
+(
+    "subgraph.https.any.js",
+    "identity + relu",
+    "litert",
+    "PASS",
+)

--- a/tests/snapshots/run_wpt_conformance__onnx_conv2d_default___gather___float16.snap
+++ b/tests/snapshots/run_wpt_conformance__onnx_conv2d_default___gather___float16.snap
@@ -1,0 +1,10 @@
+---
+source: tests/run_wpt_conformance.rs
+expression: "(&file_name, &test_name, &backend_prefix, \"PASS\")"
+---
+(
+    "subgraph.https.any.js",
+    "conv2d default + gather / float16",
+    "onnx",
+    "PASS",
+)

--- a/tests/snapshots/run_wpt_conformance__onnx_identity___relu.snap
+++ b/tests/snapshots/run_wpt_conformance__onnx_identity___relu.snap
@@ -1,0 +1,10 @@
+---
+source: tests/run_wpt_conformance.rs
+expression: "(&file_name, &test_name, &backend_prefix, \"PASS\")"
+---
+(
+    "subgraph.https.any.js",
+    "identity + relu",
+    "onnx",
+    "PASS",
+)

--- a/tests/snapshots/run_wpt_conformance__onnx_identity___relu___float16.snap
+++ b/tests/snapshots/run_wpt_conformance__onnx_identity___relu___float16.snap
@@ -1,0 +1,10 @@
+---
+source: tests/run_wpt_conformance.rs
+expression: "(&file_name, &test_name, &backend_prefix, \"PASS\")"
+---
+(
+    "subgraph.https.any.js",
+    "identity + relu / float16",
+    "onnx",
+    "PASS",
+)


### PR DESCRIPTION
## Summary

Refresh the committed WPT pass baselines for three subgraph cases added to the live upstream corpus.

The WPT checkout used by CI advanced from 2,482 to 2,485 WebNN cases. All three new cases execute correctly, but `insta` treats a missing snapshot as a test failure. This caused the ONNX and LiteRT WPT jobs to fail even though result validation passed.

## Changes

- add ONNX PASS snapshots for `identity + relu` in float32 and float16
- add the LiteRT PASS snapshot for the supported float32 `identity + relu` case
- add the ONNX PASS snapshot for `conv2d default + gather` in float16
- leave unsupported LiteRT float16 cases under the existing backend dtype policy

No converter, executor, or expected-failure behavior changes.

## Validation

- `make test-wpt`: 2,485 passed, 0 failed on ONNX
- focused ONNX `conv2d default + gather / float16`: 1 passed, 0 failed
- focused ONNX identity-to-ReLU WPT run: 2 passed, 0 failed
- focused LiteRT identity-to-ReLU WPT run: 1 passed, 1 existing float16 skip, 0 failed
- snapshots refreshed through upstream WPT `4a01b83e3b93b3e394f9f4f503b3152cf54098b8`
