### PR TITLE
Fix CoreML concurrency

### DIFF
--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -483,4 +483,53 @@ mod test {
         context.read_tensor(&out, &mut result).unwrap();
         assert_eq!(result, &[11, 22, 33, 44]);
     }
+
+    /// Regression guard for the `rustnn_coreml_predict` output-provider lifetime
+    /// bug: the shim returned the prediction result through a plain `__bridge`
+    /// cast, so ARC deallocated it when the shim returned and the very next use
+    /// (reading outputs in `run_coreml_bytes`) SIGSEGVed. The crash only
+    /// manifests in optimized builds (`cargo test --release`); in debug builds
+    /// the freed memory happened to survive long enough to read.
+    #[test]
+    fn coreml_repeated_dispatch_provider_lifetime() {
+        let _ = pretty_env_logger::try_init();
+
+        let desc = MLOperandDescriptor::new(MLOperandDataType::Float32, [4].to_vec());
+        for _ in 0..5 {
+            let Some(mut context) = coreml_context() else {
+                return;
+            };
+            let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+            let a = builder.input("a", &desc).unwrap();
+            let b = builder.input("b", &desc).unwrap();
+            let y = builder.add(a, b).unwrap();
+            let mut outputs = MLNamedOperands::new();
+            outputs.insert("y", y);
+            let mut graph = builder.build(&outputs).unwrap();
+
+            let mut io_desc = MLTensorDescriptor::from_operand_descriptor(&desc);
+            io_desc.set_writable(true);
+            io_desc.set_readable(true);
+
+            let a = context.create_tensor(&io_desc).unwrap();
+            let b = context.create_tensor(&io_desc).unwrap();
+            let out = context.create_tensor(&io_desc).unwrap();
+            context.write_tensor(&a, &[1.0f32, 2., 3., 4.]).unwrap();
+            context.write_tensor(&b, &[10.0f32, 20., 30., 40.]).unwrap();
+
+            let mut inputs = MLNamedTensors::new();
+            inputs.insert("a", &a);
+            inputs.insert("b", &b);
+            let mut out_bindings = MLNamedTensors::new();
+            out_bindings.insert("y", &out);
+
+            context
+                .dispatch(&mut graph, &inputs, &out_bindings)
+                .unwrap();
+
+            let mut result = vec![0.0f32; 4];
+            context.read_tensor(&out, &mut result).unwrap();
+            assert_eq!(result, &[11.0f32, 22., 33., 44.]);
+        }
+    }
 }

--- a/src/executors/coreml.rs
+++ b/src/executors/coreml.rs
@@ -86,6 +86,19 @@ pub unsafe extern "C" fn rustnn_coreml_predict(
     1
 }
 
+/// Releases an owned (+1) Objective-C object when dropped (including on early
+/// `return`/`?`), balancing the retain transferred to us by the shim's
+/// `__bridge_retained` cast.
+struct ReleaseOnDrop(*mut Object);
+
+impl Drop for ReleaseOnDrop {
+    fn drop(&mut self) {
+        unsafe {
+            let _: () = msg_send![self.0, release];
+        }
+    }
+}
+
 fn shim_error_to_string(buffer: &[u8]) -> String {
     let end = buffer
         .iter()
@@ -559,6 +572,10 @@ pub(crate) fn run_coreml_bytes(
                 reason: format!("prediction failed: {}", shim_error_to_string(&error)),
             });
         }
+        // `rustnn_coreml_predict` (coreml_shim.mm) hands back `output_provider`
+        // already retained (`__bridge_retained`) -- we own this reference and
+        // must release it once we're done extracting outputs.
+        let _output_provider_guard = ReleaseOnDrop(output_provider);
 
         let mut result = HashMap::with_capacity(output_descriptors.len());
         for (name, descriptor) in output_descriptors {
@@ -1157,6 +1174,8 @@ fn run_impl_zeroed_with_weights(
                 });
                 continue;
             }
+            // The shim returns a retained provider; release it after collecting.
+            let _output_provider_guard = ReleaseOnDrop(output_provider);
 
             match collect_outputs(output_provider) {
                 Ok(outputs) => attempts.push(CoremlRunAttempt {
@@ -1338,6 +1357,8 @@ fn run_impl_with_inputs_with_weights(
                 });
                 continue;
             }
+            // The shim returns a retained provider; release it after collecting.
+            let _output_provider_guard = ReleaseOnDrop(output_provider);
 
             match collect_outputs(output_provider) {
                 Ok(outputs) => attempts.push(CoremlRunAttempt {

--- a/src/executors/coreml_shim.mm
+++ b/src/executors/coreml_shim.mm
@@ -88,8 +88,18 @@ int rustnn_coreml_load(void *compiled_url, void *config, void **out_model, char 
     }
 }
 
-// Run a prediction. On success `*out_provider` is a borrowed (autoreleased)
-// output feature provider valid for the caller's current autorelease pool.
+// Run a prediction. On success `*out_provider` is a RETAINED output feature
+// provider; the caller owns it and must release it when done.
+//
+// `-predictionFromFeatures:error:` returns its result at +0 (autoreleased);
+// under ARC, `out` (a strong local) picks up a retain for the duration of this
+// function and ARC releases it again when `out` goes out of scope at `return`.
+// A plain `__bridge` cast here does not add a matching retain of its own, so by
+// the time control returns to the caller the object can already be
+// deallocated -- reproduced 100% of the time in optimized (non-debug) builds as
+// a SIGSEGV (garbage receiver in `objc_msgSend`) on the very next use of
+// `*out_provider`. `__bridge_retained` performs the retain the caller needs to
+// keep the object alive past this function returning.
 int rustnn_coreml_predict(void *model, void *features, void **out_provider, char *err,
                           size_t err_len) {
     *out_provider = NULL;
@@ -103,7 +113,7 @@ int rustnn_coreml_predict(void *model, void *features, void **out_provider, char
                             nserr ? [nserr localizedDescription] : @"prediction returned nil");
             return 1;
         }
-        *out_provider = (__bridge void *)out;
+        *out_provider = (__bridge_retained void *)out;
         return 0;
     } @catch (NSException *e) {
         rustnn_copy_err(err, err_len,


### PR DESCRIPTION
## Summary

`MLContext::dispatch()` SIGSEGVs on every CoreML-dispatched graph when rustnn is built with any optimization (opt-level >= 1). Debug builds are unaffected, which is why cargo test CI stayed green while downstream consumers running `cargo test --release` (e.g. onnx2webnn's macOS CI) crashed on every test.

## Fix

- Shim: `__bridge_retained`, transferring an owned (+1) reference to the caller.
- Rust: a `ReleaseOnDrop` guard releases the provider after outputs are extracted, on all exit paths, at all three `rustnn_coreml_predict` call sites.

## Validation

- New regression test `backends::coreml::test::coreml_repeated_dispatch_provider_lifetime` — SIGSEGVs (signal 11) with the old shim under `--release`, passes with the fix.
- `cargo test --lib --features coreml-runtime`: 346 passed (debug), 22/22 CoreML tests also pass under `--release`.
- WPT CoreML conformance: 2436 passed, 46 skipped, 0 failed.

