### PR TITLE
Onnx2webnn fixes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -170,6 +170,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "src/converters/trtx_gru.rs",
         "src/converters/trtx_lstm.rs",
         "src/converters/trtx_rnn.rs",
+        "src/backends/trtx.rs",
     ]);
     Ok(())
 }

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -483,4 +483,53 @@ mod test {
         context.read_tensor(&out, &mut result).unwrap();
         assert_eq!(result, &[11, 22, 33, 44]);
     }
+
+    /// Regression guard for the `rustnn_coreml_predict` output-provider lifetime
+    /// bug: the shim returned the prediction result through a plain `__bridge`
+    /// cast, so ARC deallocated it when the shim returned and the very next use
+    /// (reading outputs in `run_coreml_bytes`) SIGSEGVed. The crash only
+    /// manifests in optimized builds (`cargo test --release`); in debug builds
+    /// the freed memory happened to survive long enough to read.
+    #[test]
+    fn coreml_repeated_dispatch_provider_lifetime() {
+        let _ = pretty_env_logger::try_init();
+
+        let desc = MLOperandDescriptor::new(MLOperandDataType::Float32, [4].to_vec());
+        for _ in 0..5 {
+            let Some(mut context) = coreml_context() else {
+                return;
+            };
+            let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+            let a = builder.input("a", &desc).unwrap();
+            let b = builder.input("b", &desc).unwrap();
+            let y = builder.add(a, b).unwrap();
+            let mut outputs = MLNamedOperands::new();
+            outputs.insert("y", y);
+            let mut graph = builder.build(&outputs).unwrap();
+
+            let mut io_desc = MLTensorDescriptor::from_operand_descriptor(&desc);
+            io_desc.set_writable(true);
+            io_desc.set_readable(true);
+
+            let a = context.create_tensor(&io_desc).unwrap();
+            let b = context.create_tensor(&io_desc).unwrap();
+            let out = context.create_tensor(&io_desc).unwrap();
+            context.write_tensor(&a, &[1.0f32, 2., 3., 4.]).unwrap();
+            context.write_tensor(&b, &[10.0f32, 20., 30., 40.]).unwrap();
+
+            let mut inputs = MLNamedTensors::new();
+            inputs.insert("a", &a);
+            inputs.insert("b", &b);
+            let mut out_bindings = MLNamedTensors::new();
+            out_bindings.insert("y", &out);
+
+            context
+                .dispatch(&mut graph, &inputs, &out_bindings)
+                .unwrap();
+
+            let mut result = vec![0.0f32; 4];
+            context.read_tensor(&out, &mut result).unwrap();
+            assert_eq!(result, &[11.0f32, 22., 33., 44.]);
+        }
+    }
 }

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -98,6 +98,16 @@ fn supports_in_memory_asset(graph: &GraphInfo) -> bool {
         Operation::Neg { input, .. } => graph
             .operand(*input)
             .is_some_and(|operand| operand.descriptor.data_type == DataType::Int32),
+        // The in-memory compiler constant-folds integer `real_div` chains with
+        // float division (200/16 stays 12.5 through subsequent folded ops)
+        // instead of truncating, corrupting e.g. packed-nibble unpack chains
+        // (div/mul/sub); the URL compiler folds with integer semantics.
+        Operation::Div { a, .. } => graph.operand(*a).is_some_and(|operand| {
+            !matches!(
+                operand.descriptor.data_type,
+                DataType::Float32 | DataType::Float16
+            )
+        }),
         _ => false,
     })
 }

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -69,8 +69,8 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for CoremlBuilder 
             .convert(&graph_info)
             .map_err(|e| Error::GraphBuildError { source: e.into() })?;
         let model = compile_model(
-            &converted.data,
-            converted.weights_data.as_deref(),
+            converted.data,
+            converted.weights_data,
             self.device_type,
             supports_in_memory_asset(&graph_info),
         )

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -98,16 +98,6 @@ fn supports_in_memory_asset(graph: &GraphInfo) -> bool {
         Operation::Neg { input, .. } => graph
             .operand(*input)
             .is_some_and(|operand| operand.descriptor.data_type == DataType::Int32),
-        // The in-memory compiler constant-folds integer `real_div` chains with
-        // float division (200/16 stays 12.5 through subsequent folded ops)
-        // instead of truncating, corrupting e.g. packed-nibble unpack chains
-        // (div/mul/sub); the URL compiler folds with integer semantics.
-        Operation::Div { a, .. } => graph.operand(*a).is_some_and(|operand| {
-            !matches!(
-                operand.descriptor.data_type,
-                DataType::Float32 | DataType::Float16
-            )
-        }),
         _ => false,
     })
 }

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -583,7 +583,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                     let consumers: Vec<String> = graph
                         .operations
                         .iter()
-                        .filter(|op| op.input_operands().contains(id))
+                        .filter(|op| op.all_input_operands().contains(id))
                         .map(|op| op.op_type().to_string())
                         .collect();
                     TrtxError::ConstantRefitFailed {

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -279,6 +279,10 @@ impl<'context> TrtxContext<'context> {
         // (mostly scalars)
         config.set_flag(trtx::trtx_sys::BuilderFlag::kREFIT_INDIVIDUAL);
         config.set_flag(trtx::trtx_sys::BuilderFlag::kSTRIP_PLAN);
+        // Keep float32 math at full precision, matching the GraphConverter path:
+        // TF32 matmul/conv rounds mantissas to 10 bits and drifts many ULP from
+        // CPU references (WebNN conformance compares against strict IEEE fp32).
+        config.clear_flag(trtx::trtx_sys::BuilderFlag::kTF32);
         if std::env::var(TRTX_JSON_DUMP_PATH_ENV_VAR).is_ok() {
             config.set_profiling_verbosity(trtx::ProfilingVerbosity::kDETAILED);
         }
@@ -419,6 +423,12 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
 
         let non_refittable_constants =
             crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
+        // Dead constants (no consumer) are eliminated by the TensorRT builder and
+        // have no refit prototype; they are neither marked refittable nor refitted.
+        // They do not take part in the caching decision: their values cannot
+        // influence the engine's outputs.
+        let unused_constants =
+            crate::converters::TrtxConverter::unused_constant_operand_ids(&graph);
 
         // no caching for non_refittable_constants for now, non_refittable_constants will end up in
         // the engine and potentially grow our cache to much. We should only consider including
@@ -456,7 +466,9 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
             let non_refittable_constants =
                 crate::converters::TrtxConverter::gather_baked_constant_operand_ids(&graph);
             for constant_id in graph.constant_operand_ids_to_handles.keys() {
-                if !non_refittable_constants.contains(constant_id) {
+                if !non_refittable_constants.contains(constant_id)
+                    && !unused_constants.contains(constant_id)
+                {
                     network.mark_weights_refittable(&format!("{constant_id}"))?;
                 }
             }
@@ -512,7 +524,7 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
         let mut refitter = Refitter::new(&engine, &LOGGER)?;
 
         for (id, constant) in graph.constant_operand_ids_to_handles.iter() {
-            if non_refittable_constants.contains(id) {
+            if non_refittable_constants.contains(id) || unused_constants.contains(id) {
                 continue;
             }
             let operand = graph.operands.get(*id as usize);
@@ -549,8 +561,29 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                         },
                         // TODO: register and upload during build, refit with device location
                         trtx::trtx_sys::nvinfer1::TensorLocation::kHOST,
-                    )?
-                };
+                    )
+                }
+                .map_err(|e| {
+                    // Name the operand: TensorRT only reports the weight name, and
+                    // "cannot be refitted" means the builder folded the constant.
+                    let consumers: Vec<String> = graph
+                        .operations
+                        .iter()
+                        .filter(|op| op.input_operands().contains(id))
+                        .map(|op| op.op_type().to_string())
+                        .collect();
+                    crate::error::Error::GraphBuildError {
+                        source: crate::GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!(
+                                "refit of constant operand {id} ({:?} {:?}, consumed by {consumers:?}) failed: {e}",
+                                operand.descriptor.data_type,
+                                operand.descriptor.static_or_max_shape()
+                            ),
+                        }
+                        .into(),
+                    }
+                })?;
             } else {
                 return Err(GraphBuilderError::InconsistentGraphInfo {
                     message: format!(

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -91,6 +91,22 @@ pub enum TrtxError {
         "Engine cache miss: cache_key={cache_key:?}. Failed engine build because TrtxOptions::fail_on_cache_miss options was enabled"
     )]
     TrtxEngineCacheMiss { cache_key: Option<String> },
+    /// TensorRT rejected the refit of a constant operand. TensorRT itself only
+    /// reports the weight name; "cannot be refitted" means the builder folded
+    /// the constant into its consumers, which the converter must then mark as
+    /// non-refittable.
+    #[error(
+        "Failed to refit constant operand {operand_id} ({:?} {:?}, consumed by {consumers:?}): {source}",
+        .operand.descriptor.data_type,
+        .operand.descriptor.static_or_max_shape()
+    )]
+    ConstantRefitFailed {
+        operand_id: u32,
+        operand: crate::Operand,
+        consumers: Vec<String>,
+        #[source]
+        source: trtx::Error,
+    },
 }
 pub type TrtxResult<T> = std::result::Result<T, TrtxError>;
 
@@ -563,25 +579,18 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
                         trtx::trtx_sys::nvinfer1::TensorLocation::kHOST,
                     )
                 }
-                .map_err(|e| {
-                    // Name the operand: TensorRT only reports the weight name, and
-                    // "cannot be refitted" means the builder folded the constant.
+                .map_err(|source| {
                     let consumers: Vec<String> = graph
                         .operations
                         .iter()
                         .filter(|op| op.input_operands().contains(id))
                         .map(|op| op.op_type().to_string())
                         .collect();
-                    crate::error::Error::GraphBuildError {
-                        source: crate::GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!(
-                                "refit of constant operand {id} ({:?} {:?}, consumed by {consumers:?}) failed: {e}",
-                                operand.descriptor.data_type,
-                                operand.descriptor.static_or_max_shape()
-                            ),
-                        }
-                        .into(),
+                    TrtxError::ConstantRefitFailed {
+                        operand_id: *id,
+                        operand: (*operand).clone(),
+                        consumers,
+                        source,
                     }
                 })?;
             } else {

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -560,6 +560,47 @@ impl CoremlMlProgramConverter {
         let output_type =
             Self::create_named_value_type(name, dtype, &operand.descriptor.shape, false);
 
+        // Non-scalar weight-carrying constants go into the blob weight file
+        // (BlobFileValue), never as immediate proto values: CoreML's on-device
+        // compiler re-serializes immediate constants through its textual MIL
+        // writer (MIL::Text::BasicSerializer), which takes minutes and
+        // gigabytes for large weights. Mirrors Chromium's
+        // graph_builder_coreml.cc, which blob-writes all non-scalar weights.
+        let blob_type = match operand.descriptor.data_type {
+            crate::graph::DataType::Float16 => {
+                Some(super::weight_file_builder::blob_data_type::FLOAT16)
+            }
+            crate::graph::DataType::Float32 => {
+                Some(super::weight_file_builder::blob_data_type::FLOAT32)
+            }
+            crate::graph::DataType::Uint8 => {
+                Some(super::weight_file_builder::blob_data_type::UINT8)
+            }
+            crate::graph::DataType::Int8 => Some(super::weight_file_builder::blob_data_type::INT8),
+            _ => None,
+        };
+        if let Some(mil_data_type) = blob_type.filter(|_| !operand.descriptor.shape.is_empty()) {
+            let offset =
+                weight_builder.add_weight(operand_id, mil_data_type, &constant_data.data)?;
+            let blob_file_value = Value {
+                doc_string: String::new(),
+                r#type: output_type.r#type.clone(),
+                value: Some(value::Value::BlobFileValue(value::BlobFileValue {
+                    file_name: "@model_path/weights/weights.bin".to_string(),
+                    offset,
+                })),
+            };
+            let mut attributes = HashMap::new();
+            attributes.insert("val".to_string(), blob_file_value);
+            return Ok(MilOperation {
+                r#type: "const".to_string(),
+                inputs: HashMap::new(),
+                outputs: vec![output_type],
+                attributes,
+                ..Default::default()
+            });
+        }
+
         // Create tensor value from constant data
         let tensor_value = match operand.descriptor.data_type {
             crate::graph::DataType::Float32 => {
@@ -600,57 +641,13 @@ impl CoremlMlProgramConverter {
                     })),
                 }
             }
-            crate::graph::DataType::Float16 => {
-                // CoreML MLProgram (MIL) requires non-scalar Float16 constants to be stored
-                // in a separate weight file with BlobFileValue references, not as immediate values.
-                // Only scalar (0D) Float16 can be stored as immediate bytes.
-                //
-                // Chromium's implementation uses WeightsFileHandle::Write() which:
-                // - For scalars (empty shape): stores as immediate value
-                // - For non-scalars: writes to weights.bin with 64-byte alignment
-                //
-                // Reference: chromium/src/services/webnn/coreml/graph_builder_coreml.cc
-
-                let is_scalar = operand.descriptor.shape.is_empty();
-
-                if !is_scalar {
-                    // Non-scalar Float16: add to weight file and return BlobFileValue
-                    let offset = weight_builder.add_weight(
-                        operand_id,
-                        super::weight_file_builder::blob_data_type::FLOAT16,
-                        &constant_data.data,
-                    )?;
-
-                    // Create BlobFileValue reference
-                    let blob_file_value = Value {
-                        doc_string: String::new(),
-                        r#type: output_type.r#type.clone(),
-                        value: Some(value::Value::BlobFileValue(value::BlobFileValue {
-                            file_name: "@model_path/weights/weights.bin".to_string(),
-                            offset,
-                        })),
-                    };
-
-                    // Create const operation with BlobFileValue
-                    let mut attributes = HashMap::new();
-                    attributes.insert("val".to_string(), blob_file_value);
-
-                    return Ok(MilOperation {
-                        r#type: "const".to_string(),
-                        inputs: HashMap::new(),
-                        outputs: vec![output_type],
-                        attributes,
-                        ..Default::default()
-                    });
-                }
-
-                // Scalar Float16: store as immediate bytes
-                TensorValue {
-                    value: Some(tensor_value::Value::Bytes(tensor_value::RepeatedBytes {
-                        values: constant_data.data.clone().into(),
-                    })),
-                }
-            }
+            // Non-scalar Float16 went to the weight file above; only scalar
+            // (0D) Float16 can be stored as immediate bytes.
+            crate::graph::DataType::Float16 => TensorValue {
+                value: Some(tensor_value::Value::Bytes(tensor_value::RepeatedBytes {
+                    values: constant_data.data.clone().into(),
+                })),
+            },
             crate::graph::DataType::Int8 | crate::graph::DataType::Uint8 => TensorValue {
                 value: Some(tensor_value::Value::Bytes(tensor_value::RepeatedBytes {
                     values: constant_data.data.clone().into(),
@@ -4821,6 +4818,17 @@ impl super::GraphConverter for CoremlMlProgramConverter {
 
         // Create weight file builder for Float16 constants
         let mut weight_builder = super::WeightFileBuilder::new();
+        // Upper bound: every constant blob-written, plus a 64-byte metadata
+        // block and up-to-64-byte alignment padding each. Reserved capacity is
+        // virtual until written, so overshooting for immediate-value constants
+        // costs nothing.
+        weight_builder.reserve(
+            graph_info
+                .constant_operand_ids_to_handles
+                .values()
+                .map(|c| c.data.len() + 128)
+                .sum(),
+        );
 
         // Create MLProgram
         let mut program = Program {
@@ -10114,8 +10122,10 @@ mod tests {
     }
 
     #[test]
-    fn test_float32_constant_no_weight_file() {
-        // Create a graph with Float32 constant (should NOT use weight file)
+    fn test_float32_constant_uses_weight_file() {
+        // Non-scalar Float32 constants go to the weight file like Float16:
+        // immediate values are re-serialized through CoreML's textual MIL
+        // writer at compile time, which is pathological for large weights.
         let mut graph = GraphInfo {
             input_operands: vec![],
             output_operands: vec![1],
@@ -10165,11 +10175,17 @@ mod tests {
         let converter = CoremlMlProgramConverter;
         let result = converter.convert(&graph).unwrap();
 
-        // Verify NO weights_data (Float32 uses immediate values)
-        assert!(
-            result.weights_data.is_none(),
-            "Float32 constants should not use weight file"
+        // Non-scalar Float32 lands in the weight file with FLOAT32 metadata.
+        let weights = result
+            .weights_data
+            .expect("non-scalar Float32 constants should use the weight file");
+        assert_eq!(
+            &weights[68..72],
+            &2u32.to_le_bytes(),
+            "BlobDataType::FLOAT32"
         );
+        assert_eq!(&weights[72..80], &4u64.to_le_bytes(), "size_in_bytes = 4");
+        assert_eq!(&weights[128..132], &1.0f32.to_le_bytes(), "payload data");
     }
 
     #[test]

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -2145,6 +2145,342 @@ impl CoremlMlProgramConverter {
         Ok((interleaved_input, interleaved_scale))
     }
 
+    /// Whether a `dequantizeLinear` should be emitted as MIL's
+    /// `constexpr_affine_dequantize`: quantized data, scale and zeroPoint are
+    /// all graph constants (a compressed weight), the data is non-scalar
+    /// int8/uint8, and the scale layout is one the native op could express
+    /// (per-tensor scalar or single-axis per-channel).
+    ///
+    /// Espresso constant-folds a regular `dequantize` (or the elementwise
+    /// decomposition) over a constant into a dense float tensor at compile
+    /// time — minutes of CPU and GBs of RAM for transformer-sized weights.
+    /// The constexpr form is CoreML's weight-compression representation and
+    /// keeps the weight packed through compilation.
+    fn constexpr_dequantize_supported(graph: &GraphInfo, op: &Operation) -> bool {
+        let Operation::DequantizeLinear {
+            input,
+            scale,
+            zero_point,
+            ..
+        } = op
+        else {
+            return false;
+        };
+        // qdq_should_decompose == false already guarantees const scale/zp and
+        // a scalar or single-axis per-channel scale.
+        if Self::qdq_should_decompose(graph, op) {
+            return false;
+        }
+        let (Some(input_op), Some(scale_op)) = (graph.operand(*input), graph.operand(*scale))
+        else {
+            return false;
+        };
+        if input_op.kind != crate::graph::OperandKind::Constant {
+            return false;
+        }
+        if !matches!(
+            input_op.descriptor.data_type,
+            DataType::Int8 | DataType::Uint8
+        ) {
+            return false;
+        }
+        if input_op.descriptor.shape.is_empty() {
+            return false;
+        }
+        // constexpr_affine_dequantize requires scale and zero_point to be both
+        // scalar or both per-channel vectors; a synthesized zero point is
+        // always scalar, so a missing zeroPoint pairs only with a scalar scale.
+        match zero_point {
+            None => {
+                let per_channel = scale_op
+                    .descriptor
+                    .static_or_max_shape()
+                    .iter()
+                    .any(|&d| d != 1);
+                if per_channel {
+                    return false;
+                }
+            }
+            Some(zp) => {
+                // The blob payload was written with the zero point's own dtype;
+                // a dtype-coerced zero point (e.g. int32) would mismatch it.
+                let Some(zp_op) = graph.operand(*zp) else {
+                    return false;
+                };
+                if zp_op.descriptor.data_type != input_op.descriptor.data_type {
+                    return false;
+                }
+            }
+        }
+        // A per-channel scale must exactly cover the derived axis: a
+        // single-axis BLOCKWISE scale (length that merely divides some input
+        // dim) can slip through qdq_native_supported's contains() check but
+        // constexpr_affine_dequantize cannot express it.
+        let scale_shape = scale_op.descriptor.static_or_max_shape();
+        let input_shape = input_op.descriptor.static_or_max_shape();
+        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
+        if let Some(&len) = squeezed.first() {
+            if squeezed.len() != 1 {
+                return false;
+            }
+            let axis = if scale_shape.len() == input_shape.len() {
+                scale_shape.iter().position(|&d| d != 1).unwrap_or(0)
+            } else {
+                input_shape.iter().position(|&d| d == len).unwrap_or(0)
+            };
+            if input_shape.get(axis) != Some(&len) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// A compile-time `Value` for one `constexpr_affine_dequantize` parameter:
+    /// a `BlobFileValue` when the constant's payload is already in the weight
+    /// file (all non-scalar weight dtypes are), otherwise an immediate tensor
+    /// built from the graph's constant bytes.
+    fn constexpr_param_value(
+        graph: &GraphInfo,
+        weight_builder: &super::WeightFileBuilder,
+        operand_id: u32,
+        dims: &[u32],
+    ) -> Result<crate::protos::coreml::mil_spec::Value, GraphError> {
+        use crate::protos::coreml::mil_spec::{
+            Dimension, TensorType, TensorValue, Value, ValueType, dimension, tensor_value, value,
+            value_type,
+        };
+
+        let operand = graph
+            .operand(operand_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "coreml_mlprogram".to_string(),
+                reason: format!("constexpr operand {} not found", operand_id),
+            })?;
+        let mil_type = Self::mil_data_type(&operand.descriptor.data_type)?;
+        let dimensions: Vec<Dimension> = dims
+            .iter()
+            .map(|&d| Dimension {
+                dimension: Some(dimension::Dimension::Constant(
+                    dimension::ConstantDimension { size: d as u64 },
+                )),
+            })
+            .collect();
+        let value_type = ValueType {
+            r#type: Some(value_type::Type::TensorType(TensorType {
+                rank: dimensions.len() as i64,
+                data_type: mil_type,
+                dimensions,
+                attributes: HashMap::new(),
+            })),
+        };
+
+        let inner = if let Some(offset) = weight_builder.get_offset(operand_id) {
+            value::Value::BlobFileValue(value::BlobFileValue {
+                file_name: "@model_path/weights/weights.bin".to_string(),
+                offset,
+            })
+        } else {
+            let constant = graph
+                .constant_operand_ids_to_handles
+                .get(&operand_id)
+                .ok_or_else(|| GraphError::ConversionFailed {
+                    format: "coreml_mlprogram".to_string(),
+                    reason: format!("constexpr operand {} has no constant data", operand_id),
+                })?;
+            let tensor_value = match operand.descriptor.data_type {
+                DataType::Float32 => TensorValue {
+                    value: Some(tensor_value::Value::Floats(tensor_value::RepeatedFloats {
+                        values: constant
+                            .data
+                            .chunks_exact(4)
+                            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                            .collect(),
+                    })),
+                },
+                DataType::Float16 | DataType::Int8 | DataType::Uint8 => TensorValue {
+                    value: Some(tensor_value::Value::Bytes(tensor_value::RepeatedBytes {
+                        values: constant.data.clone().into(),
+                    })),
+                },
+                other => {
+                    return Err(GraphError::ConversionFailed {
+                        format: "coreml_mlprogram".to_string(),
+                        reason: format!("unsupported constexpr parameter dtype {other:?}"),
+                    });
+                }
+            };
+            value::Value::ImmediateValue(value::ImmediateValue {
+                value: Some(value::immediate_value::Value::Tensor(tensor_value)),
+            })
+        };
+        Ok(Value {
+            doc_string: String::new(),
+            r#type: Some(value_type),
+            value: Some(inner),
+        })
+    }
+
+    /// Immediate rank-0 zero of the given quantized dtype (int8/uint8), the
+    /// synthesized `zero_point` for `constexpr_affine_dequantize`.
+    fn constexpr_zero_value(
+        data_type: &DataType,
+    ) -> Result<crate::protos::coreml::mil_spec::Value, GraphError> {
+        use crate::protos::coreml::mil_spec::{
+            TensorType, TensorValue, Value, ValueType, tensor_value, value, value_type,
+        };
+
+        let mil_type = match data_type {
+            DataType::Int8 | DataType::Uint8 => Self::mil_data_type(data_type)?,
+            other => {
+                return Err(GraphError::ConversionFailed {
+                    format: "coreml_mlprogram".to_string(),
+                    reason: format!("no quantized zero-point immediate for {other:?}"),
+                });
+            }
+        };
+        Ok(Value {
+            doc_string: String::new(),
+            r#type: Some(ValueType {
+                r#type: Some(value_type::Type::TensorType(TensorType {
+                    data_type: mil_type,
+                    rank: 0,
+                    dimensions: vec![],
+                    attributes: HashMap::new(),
+                })),
+            }),
+            value: Some(value::Value::ImmediateValue(value::ImmediateValue {
+                value: Some(value::immediate_value::Value::Tensor(TensorValue {
+                    value: Some(tensor_value::Value::Bytes(tensor_value::RepeatedBytes {
+                        values: vec![0u8].into(),
+                    })),
+                })),
+            })),
+        })
+    }
+
+    /// Emit `constexpr_affine_dequantize` (dequantized = scale * (data - zp))
+    /// for a dequantizeLinear over constant weights. CoreML requires constexpr
+    /// parameters as compile-time value ATTRIBUTES (immediate or blob-file),
+    /// not name-bound inputs; large payloads reuse the blob offsets the const
+    /// emission pass already wrote.
+    fn emit_constexpr_affine_dequantize(
+        graph: &GraphInfo,
+        op: &Operation,
+        overrides: &HashMap<u32, String>,
+        weight_builder: &super::WeightFileBuilder,
+        main_block: &mut Block,
+    ) -> Result<(), GraphError> {
+        let Operation::DequantizeLinear {
+            input,
+            scale,
+            zero_point,
+            ..
+        } = op
+        else {
+            return Err(GraphError::ConversionFailed {
+                format: "coreml_mlprogram".to_string(),
+                reason: "emit_constexpr_affine_dequantize called on non-dequantize op".to_string(),
+            });
+        };
+        let output_id = op
+            .output_operand()
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "coreml_mlprogram".to_string(),
+                reason: "dequantizeLinear has no output operand".to_string(),
+            })?;
+        let (_output_name, output_type) = Self::create_output_value(graph, output_id, overrides)?;
+
+        let input_op = graph
+            .operand(*input)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "coreml_mlprogram".to_string(),
+                reason: format!("dequantize input operand {} not found", input),
+            })?;
+        let scale_op = graph
+            .operand(*scale)
+            .ok_or_else(|| GraphError::ConversionFailed {
+                format: "coreml_mlprogram".to_string(),
+                reason: format!("dequantize scale operand {} not found", scale),
+            })?;
+
+        // The constant pre-scan squeezes scale/zeroPoint const ops; use the
+        // same squeezed layout here (scalar, or 1-D of the channel length).
+        let scale_shape = scale_op.descriptor.static_or_max_shape();
+        let input_shape = input_op.descriptor.static_or_max_shape();
+        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
+        // Per-channel: derive the axis from the scale layout; 0 for per-tensor.
+        // A rank-aligned scale (e.g. [1, N] against [K, N]) names its axis by
+        // position — unambiguous even for square weights. Only a rank-mismatched
+        // scale falls back to the first input dim matching the channel count
+        // (mirrors the native dequantize path).
+        let axis = match squeezed.first() {
+            Some(&len) if squeezed.len() == 1 && len > 1 => {
+                if scale_shape.len() == input_shape.len() {
+                    scale_shape.iter().position(|&d| d != 1).unwrap_or(0) as u32
+                } else {
+                    input_shape.iter().position(|&d| d == len).unwrap_or(0) as u32
+                }
+            }
+            _ => 0,
+        };
+        let param_shape: &[u32] = if squeezed.len() == 1 && squeezed[0] > 1 {
+            &squeezed
+        } else {
+            &[]
+        };
+
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "quantized_data".to_string(),
+            Self::constexpr_param_value(graph, weight_builder, *input, &input_shape)?,
+        );
+        attributes.insert(
+            "scale".to_string(),
+            Self::constexpr_param_value(graph, weight_builder, *scale, param_shape)?,
+        );
+        let zp_value = match zero_point {
+            Some(zp) => Self::constexpr_param_value(graph, weight_builder, *zp, param_shape)?,
+            None => Self::constexpr_zero_value(&input_op.descriptor.data_type)?,
+        };
+        attributes.insert("zero_point".to_string(), zp_value);
+        attributes.insert("axis".to_string(), Self::constexpr_axis_value(axis));
+
+        main_block.operations.push(MilOperation {
+            r#type: "constexpr_affine_dequantize".to_string(),
+            inputs: HashMap::new(),
+            outputs: vec![output_type],
+            attributes,
+            ..Default::default()
+        });
+        Ok(())
+    }
+
+    /// Immediate int32 scalar `Value` (attribute form of `create_immediate_int`).
+    fn constexpr_axis_value(axis: u32) -> crate::protos::coreml::mil_spec::Value {
+        use crate::protos::coreml::mil_spec::{
+            DataType as MilDataType, TensorType, TensorValue, Value, ValueType, tensor_value,
+            value, value_type,
+        };
+        Value {
+            doc_string: String::new(),
+            r#type: Some(ValueType {
+                r#type: Some(value_type::Type::TensorType(TensorType {
+                    data_type: MilDataType::Int32 as i32,
+                    rank: 0,
+                    dimensions: vec![],
+                    attributes: HashMap::new(),
+                })),
+            }),
+            value: Some(value::Value::ImmediateValue(value::ImmediateValue {
+                value: Some(value::immediate_value::Value::Tensor(TensorValue {
+                    value: Some(tensor_value::Value::Ints(tensor_value::RepeatedInts {
+                        values: vec![axis as i32],
+                    })),
+                })),
+            })),
+        }
+    }
+
     /// Lower `dequantizeLinear` as `(input - zeroPoint) * scale` in elementwise form.
     ///
     /// Handles quantized types and scale shapes CoreML's native `dequantize` cannot:
@@ -7852,6 +8188,30 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 continue;
             }
 
+            // dequantize over constant weights becomes constexpr_affine_dequantize:
+            // Espresso keeps the packed representation through compilation instead of
+            // constant-folding into a dense float tensor.
+            if op_type_lower == "dequantizelinear"
+                && Self::constexpr_dequantize_supported(graph_info, op)
+            {
+                Self::emit_constexpr_affine_dequantize(
+                    graph_info,
+                    op,
+                    &operand_name_overrides,
+                    &weight_builder,
+                    &mut main_block,
+                )?;
+                // A dequantized conv filter carries a deferred layout transpose
+                // keyed on this output; flush it like every other emission path.
+                if let Some(output_id) = op.output_operand()
+                    && let Some((pending_ops, transposed_name)) =
+                        deferred_transposes.remove(&output_id)
+                {
+                    main_block.operations.extend(pending_ops);
+                    operand_name_overrides.insert(output_id, transposed_name);
+                }
+                continue;
+            }
             // quantize/dequantize that CoreML's native op can't express (int32 tensors,
             // block-wise or multi-axis scales) is lowered to elementwise arithmetic.
             // int4/uint4 tensors can't be materialized at all, so leave those to the native
@@ -7863,6 +8223,13 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                     &operand_name_overrides,
                     &mut main_block,
                 )?;
+                if let Some(output_id) = op.output_operand()
+                    && let Some((pending_ops, transposed_name)) =
+                        deferred_transposes.remove(&output_id)
+                {
+                    main_block.operations.extend(pending_ops);
+                    operand_name_overrides.insert(output_id, transposed_name);
+                }
                 continue;
             }
             if op_type_lower == "quantizelinear" && Self::qdq_should_decompose(graph_info, op) {

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -7276,6 +7276,100 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 }
             }
 
+            // tile / expand over int8/uint8: MIL `tile` only accepts
+            // bool/int32/fp16/fp32 (WebNN expand lowers to tile). Cast to int32,
+            // run the op, cast back — exact for all 8-bit values.
+            if matches!(op, Operation::Tile { .. } | Operation::Expand { .. })
+                && let Some(&tile_in_id) = op.input_operands().first()
+                && let Some(tile_in_op) = graph_info.operand(tile_in_id)
+                && matches!(
+                    tile_in_op.descriptor.data_type,
+                    DataType::Int8 | DataType::Uint8
+                )
+                && let Some(out_id) = op.output_operand()
+                && !tile_in_op.descriptor.shape.is_empty()
+            {
+                let (out_name, out_type) =
+                    Self::create_output_value(graph_info, out_id, &operand_name_overrides)?;
+                let int32 = crate::protos::coreml::mil_spec::DataType::Int32 as i32;
+                let in_shape = tile_in_op.descriptor.static_or_max_shape();
+
+                let cast_in_name = format!("{out_name}_int_in");
+                let cast_in_type =
+                    Self::value_type_for_static_shape(cast_in_name.clone(), int32, &in_shape);
+                main_block.operations.push(Self::create_cast_operation(
+                    Self::output_name_for_operand(graph_info, tile_in_id, &operand_name_overrides),
+                    cast_in_type,
+                    "int32",
+                ));
+
+                // Expand with a rank-raising input consumes a helper reshape named
+                // after this op's output (see the expand emission); emit it here
+                // with the int32 dtype so the reference resolves.
+                if matches!(op, Operation::Expand { .. }) {
+                    let out_shape = graph_info
+                        .operand(out_id)
+                        .map(|o| o.descriptor.static_or_max_shape())
+                        .unwrap_or_default();
+                    if in_shape.len() < out_shape.len() {
+                        let output_rank = out_shape.len();
+                        let mut reshaped_dims = vec![1u32; output_rank];
+                        for i in 0..in_shape.len() {
+                            reshaped_dims[output_rank - i - 1] = in_shape[in_shape.len() - i - 1];
+                        }
+                        let rs_name =
+                            format!("{}_expand_reshaped", operand_name(graph_info, out_id));
+                        let rs_type = Self::value_type_for_static_shape(
+                            rs_name.clone(),
+                            int32,
+                            &reshaped_dims,
+                        );
+                        let mut rs_in: HashMap<String, Argument> = HashMap::new();
+                        rs_in.insert(
+                            "x".to_string(),
+                            Self::create_name_argument(cast_in_name.clone()),
+                        );
+                        rs_in.insert(
+                            "shape".to_string(),
+                            Self::create_int_array_argument(
+                                reshaped_dims.iter().map(|&v| v as i32).collect(),
+                            ),
+                        );
+                        main_block.operations.push(Self::create_mil_operation(
+                            "reshape",
+                            rs_in,
+                            vec![rs_type],
+                        ));
+                    }
+                }
+
+                let int_out_name = format!("{out_name}_int_out");
+                let mut int_overrides = operand_name_overrides.clone();
+                int_overrides.insert(tile_in_id, cast_in_name);
+                int_overrides.insert(out_id, int_out_name.clone());
+                let mut mil =
+                    self.convert_operation_with_overrides(graph_info, op, &int_overrides)?;
+                // The generic emission types the output after the operand (int8/
+                // uint8); the tile actually produces int32 here.
+                for nv in &mut mil.outputs {
+                    if let Some(vt) = nv.r#type.as_mut()
+                        && let Some(crate::protos::coreml::mil_spec::value_type::Type::TensorType(
+                            tt,
+                        )) = vt.r#type.as_mut()
+                    {
+                        tt.data_type = int32;
+                    }
+                }
+                main_block.operations.push(mil);
+
+                main_block.operations.push(Self::create_cast_operation(
+                    int_out_name,
+                    out_type,
+                    Self::cast_dtype_string_for_graph_type(&tile_in_op.descriptor.data_type)?,
+                ));
+                continue;
+            }
+
             // conv2d / convTranspose2d with a runtime (non-constant) bias: MIL
             // declares conv bias const, and CoreML silently miscompiles instead of
             // rejecting (conv2d consumes the bias buffer as weights; convTranspose2d

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -7276,6 +7276,50 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 }
             }
 
+            // identity over a constant: CoreML's compiler elides `identity`
+            // ops, and for a const input the plan builder then fails with
+            // "Variable is not associated with a name" (error -5) because the
+            // alias name was dropped. Emit an exact `mul(x, 1)` instead, which
+            // survives compilation. Identity of non-const values is unaffected.
+            if matches!(op, Operation::Identity { .. })
+                && let Some(&id_in) = op.input_operands().first()
+                && let Some(id_in_op) = graph_info.operand(id_in)
+                && id_in_op.kind == crate::graph::OperandKind::Constant
+                // Scalars keep the plain identity: they pass CoreML's lax
+                // identity type-check, while mul's strict inference rejects
+                // the rank-1 [1] type the graph declares for them.
+                && !id_in_op.descriptor.shape.is_empty()
+                && matches!(
+                    id_in_op.descriptor.data_type,
+                    DataType::Float32 | DataType::Float16 | DataType::Int32
+                )
+                && let Some(out_id) = op.output_operand()
+            {
+                let (_, out_type) =
+                    Self::create_output_value(graph_info, out_id, &operand_name_overrides)?;
+                let one = match id_in_op.descriptor.data_type {
+                    DataType::Float16 => Self::create_immediate_float16(1.0),
+                    DataType::Int32 => Self::create_immediate_int(1),
+                    _ => Self::create_immediate_float(1.0),
+                };
+                let mut mul_in = HashMap::new();
+                mul_in.insert(
+                    "x".to_string(),
+                    Self::create_name_argument(Self::output_name_for_operand(
+                        graph_info,
+                        id_in,
+                        &operand_name_overrides,
+                    )),
+                );
+                mul_in.insert("y".to_string(), one);
+                main_block.operations.push(Self::create_mil_operation(
+                    mil_ops::MUL,
+                    mul_in,
+                    vec![out_type],
+                ));
+                continue;
+            }
+
             // tile / expand over int8/uint8: MIL `tile` only accepts
             // bool/int32/fp16/fp32 (WebNN expand lowers to tile). Cast to int32,
             // run the op, cast back — exact for all 8-bit values.

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -3971,7 +3971,9 @@ impl CoremlMlProgramConverter {
 
                 // WebNN averagePool2d excludes padded elements from the divisor (a
                 // boundary window covering N real elements divides by N, not the kernel
-                // area). Only average pooling accepts this parameter.
+                // area). Only average pooling accepts this parameter. Do NOT
+                // switch this to false: CoreML then miscounts the divisor for
+                // asymmetric custom padding (end-side excluded, begin included).
                 if matches!(&op, Operation::AveragePool2d { .. }) {
                     inputs.insert(
                         "exclude_padding_from_average".to_string(),
@@ -4239,9 +4241,14 @@ impl CoremlMlProgramConverter {
 
                         // Determine input name for tile operation
                         let tile_input_name = if input_rank < output_rank {
-                            // A reshape was added, use the reshaped output name
-                            // The reshape output name is: {input_name}_expand_reshaped
-                            format!("{}_expand_reshaped", input_names[0])
+                            // Matches the producer site's output-derived name.
+                            format!(
+                                "{}_expand_reshaped",
+                                operand_name(
+                                    graph,
+                                    op.output_operand().unwrap_or(op.input_operands()[0])
+                                )
+                            )
                         } else {
                             // No reshape, use original input
                             input_names[0].clone()
@@ -5160,7 +5167,14 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                     if filter_layout != expected_layout {
                         let filter_operand_id = op.input_operands()[1];
 
-                        if let Some(filter_operand) = graph_info.operand(filter_operand_id) {
+                        // Dedup: two convs sharing one filter (tied weights) must
+                        // not both define {filter}_transposed. This reuses the FIRST
+                        // consumer's permutation; sharing a filter under different
+                        // layouts would need per-consumer names.
+                        if !operand_name_overrides.contains_key(&filter_operand_id)
+                            && !deferred_transposes.contains_key(&filter_operand_id)
+                            && let Some(filter_operand) = graph_info.operand(filter_operand_id)
+                        {
                             // Calculate transpose permutation
                             let perm = match (op_type_lower.as_str(), filter_layout) {
                                 // Conv2d conversions to oihw [O, I, H, W]
@@ -5260,8 +5274,10 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 if input_layout == "nhwc" && !op.input_operands().is_empty() {
                     let input_operand_id = op.input_operands()[0];
 
-                    // Only transpose if not already transposed
+                    // Only transpose if not already transposed (deferred entries
+                    // only insert their override at flush time, so check both).
                     if !operand_name_overrides.contains_key(&input_operand_id)
+                        && !deferred_transposes.contains_key(&input_operand_id)
                         && let Some(input_operand) = graph_info.operand(input_operand_id)
                     {
                         // NHWC -> NCHW transposition: [0, 3, 1, 2]
@@ -5332,9 +5348,67 @@ impl super::GraphConverter for CoremlMlProgramConverter {
             }
         }
 
+        // CoreML's model compiler fuses a `pad` op that directly feeds a pool into
+        // the pool's own padding. The fused pool drops the pad's constant value
+        // and, for asymmetric padding, miscounts the average divisor (end-side
+        // padding is dropped from the denominator regardless of
+        // exclude_padding_from_average). Insert a mul-by-1.0 between the pad and
+        // the pool to defeat the fusion (a MIL identity op is itself elided by
+        // the compiler and does not help).
+        let pad_output_ids: std::collections::HashSet<u32> = graph_info
+            .operations
+            .iter()
+            .filter(|p| matches!(p, Operation::Pad { .. }))
+            .filter_map(|p| p.output_operand())
+            .collect();
+        let mut pad_unfused: std::collections::HashSet<u32> = std::collections::HashSet::new();
+
         // Convert all operations to MIL operations
         for op in &graph_info.operations {
             let op_type_lower = op.op_type().to_lowercase();
+
+            if matches!(
+                op,
+                Operation::AveragePool2d { .. }
+                    | Operation::MaxPool2d { .. }
+                    | Operation::L2Pool2d { .. }
+            ) && let Some(&pool_in_id) = op.input_operands().first()
+                && pad_output_ids.contains(&pool_in_id)
+                && !pad_unfused.contains(&pool_in_id)
+                && let Some(pool_in_operand) = graph_info.operand(pool_in_id)
+                && matches!(
+                    pool_in_operand.descriptor.data_type,
+                    DataType::Float32 | DataType::Float16
+                )
+            {
+                let in_name =
+                    Self::output_name_for_operand(graph_info, pool_in_id, &operand_name_overrides);
+                let unfused_name = format!("{in_name}_pad_unfused");
+                let out_type = Self::create_value_with_mil_type(
+                    graph_info,
+                    pool_in_id,
+                    unfused_name.clone(),
+                    Self::mil_data_type(&pool_in_operand.descriptor.data_type)?,
+                )?;
+                let mut mul_inputs = HashMap::new();
+                mul_inputs.insert("x".to_string(), Self::create_name_argument(in_name));
+                mul_inputs.insert(
+                    "y".to_string(),
+                    if matches!(pool_in_operand.descriptor.data_type, DataType::Float16) {
+                        Self::create_immediate_float16(1.0)
+                    } else {
+                        Self::create_immediate_float(1.0)
+                    },
+                );
+                main_block.operations.push(Self::create_mil_operation(
+                    mil_ops::MUL,
+                    mul_inputs,
+                    vec![out_type],
+                ));
+                operand_name_overrides.insert(pool_in_id, unfused_name);
+                pad_unfused.insert(pool_in_id);
+                // Fall through: the pool below consumes the un-fusable mul output.
+            }
 
             // Rank-0 (scalar) no-ops: transpose/tile/slice/expand/pad/reshape that map a
             // 0D scalar to a 0D scalar. CoreML rejects those ops on rank-0 tensors, so emit
@@ -5460,7 +5534,7 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                             // from another comparison/logical op ("Block
                             // redefines I/O name").
                             let bool_input_name =
-                                format!("{}_bool_{}", input_names[index], output_id);
+                                format!("{}_bool_{}_{}", input_names[index], output_id, index);
                             let bool_input_type = Self::create_value_with_mil_type(
                                 graph_info,
                                 input_id,
@@ -5930,9 +6004,21 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                     }
 
                     //Create reshape operation
-                    let input_name = operand_name(graph_info, op.input_operands()[0]);
-                    // Use input name to create unique intermediate name (don't rely on output_operands)
-                    let reshape_output_name = format!("{}_expand_reshaped", input_name);
+                    let input_name = Self::output_name_for_operand(
+                        graph_info,
+                        op.input_operands()[0],
+                        &operand_name_overrides,
+                    );
+                    // Named after this expand's own output (unique per op; an
+                    // input-derived name collides when two expands share an input).
+                    // The consumer site derives the same name.
+                    let reshape_output_name = format!(
+                        "{}_expand_reshaped",
+                        operand_name(
+                            graph_info,
+                            op.output_operand().unwrap_or(op.input_operands()[0])
+                        )
+                    );
 
                     let mut reshape_inputs: HashMap<String, Argument> = HashMap::new();
                     reshape_inputs.insert("x".to_string(), Self::create_name_argument(input_name));
@@ -5943,8 +6029,8 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                         ),
                     );
 
-                    // Create tensor type for reshape output
-                    let dtype = Self::mil_data_type(&input_operand.descriptor.data_type)?;
+                    // graph_value_mil_type: wide ints travel as int32 proxies.
+                    let dtype = Self::graph_value_mil_type(&input_operand.descriptor.data_type)?;
                     let dimensions: Vec<Dimension> = reshaped_dims
                         .iter()
                         .map(|&d| Dimension {
@@ -6287,8 +6373,20 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                         }
                     })?;
                 {
-                    let input_name = operand_name(graph_info, op.input_operands()[0]);
-                    let hardsigmoid_output_name = format!("{}_hardswish_hardsigmoid", input_name);
+                    let input_name = Self::output_name_for_operand(
+                        graph_info,
+                        op.input_operands()[0],
+                        &operand_name_overrides,
+                    );
+                    // Named after this op's output: shared inputs must not collide.
+                    let hardsigmoid_output_name = format!(
+                        "{}_hardswish_hardsigmoid",
+                        Self::output_name_for_operand(
+                            graph_info,
+                            op.output_operand().unwrap_or(op.input_operands()[0]),
+                            &operand_name_overrides,
+                        )
+                    );
 
                     // Create hardsigmoid operation with alpha=1/6, beta=0.5
                     let mut hardsigmoid_inputs: HashMap<String, Argument> = HashMap::new();
@@ -7178,6 +7276,117 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 }
             }
 
+            // conv2d / convTranspose2d with a runtime (non-constant) bias: MIL
+            // declares conv bias const, and CoreML silently miscompiles instead of
+            // rejecting (conv2d consumes the bias buffer as weights; convTranspose2d
+            // drops the bias). Emit the conv without bias and add it explicitly,
+            // reshaped to [1, C_out, 1, 1]. NCHW-only: NHWC convs take a dedicated
+            // transpose-wrapped path below that this pre-pass would bypass.
+            if matches!(
+                op,
+                Operation::Conv2d { .. } | Operation::ConvTranspose2d { .. }
+            ) {
+                let (conv_bias_id, layout_default) = match op {
+                    Operation::Conv2d { options, .. } => (
+                        options.as_ref().and_then(|o| o.bias),
+                        options
+                            .as_ref()
+                            .map(|o| {
+                                o.input_layout.is_empty()
+                                    || o.input_layout.eq_ignore_ascii_case("nchw")
+                            })
+                            .unwrap_or(true),
+                    ),
+                    Operation::ConvTranspose2d { options, .. } => (
+                        options.as_ref().and_then(|o| o.bias),
+                        options
+                            .as_ref()
+                            .map(|o| {
+                                o.input_layout.is_empty()
+                                    || o.input_layout.eq_ignore_ascii_case("nchw")
+                            })
+                            .unwrap_or(true),
+                    ),
+                    _ => (None, true),
+                };
+                let bias_runtime = conv_bias_id
+                    .and_then(|id| graph_info.operand(id))
+                    .map(|o| o.kind != crate::graph::OperandKind::Constant)
+                    .unwrap_or(false);
+                if bias_runtime && layout_default {
+                    let bias_id = conv_bias_id.unwrap();
+                    let out_id =
+                        op.output_operand()
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "coreml_mlprogram".to_string(),
+                                reason: format!("{} has no output operand", op.op_type()),
+                            })?;
+                    let out_op =
+                        graph_info
+                            .operand(out_id)
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "coreml_mlprogram".to_string(),
+                                reason: format!("output operand {out_id} not found"),
+                            })?;
+                    let out_rank = out_op.descriptor.shape.len();
+                    let mil_dtype = Self::graph_value_mil_type(&out_op.descriptor.data_type)?;
+                    let (out_name, out_type) =
+                        Self::create_output_value(graph_info, out_id, &operand_name_overrides)?;
+
+                    let bias_name =
+                        Self::output_name_for_operand(graph_info, bias_id, &operand_name_overrides);
+                    let c_out = graph_info
+                        .operand(bias_id)
+                        .map(|o| o.descriptor.static_or_max_shape())
+                        .and_then(|sh| sh.first().copied())
+                        .unwrap_or(1);
+                    let mut bias_shape = vec![1u32; out_rank.max(1)];
+                    let c_idx = if out_rank >= 2 { 1 } else { 0 };
+                    bias_shape[c_idx] = c_out;
+
+                    let mut stripped = op.clone();
+                    match &mut stripped {
+                        Operation::Conv2d { options, .. } => {
+                            if let Some(o) = options {
+                                o.bias = None;
+                            }
+                        }
+                        Operation::ConvTranspose2d { options, .. } => {
+                            if let Some(o) = options {
+                                o.bias = None;
+                            }
+                        }
+                        _ => {}
+                    }
+                    let nobias_name = format!("{out_name}_nobias_{out_id}");
+                    let mut nobias_overrides = operand_name_overrides.clone();
+                    nobias_overrides.insert(out_id, nobias_name.clone());
+                    let mil = self.convert_operation_with_overrides(
+                        graph_info,
+                        &stripped,
+                        &nobias_overrides,
+                    )?;
+                    main_block.operations.push(mil);
+
+                    let bias_bcast = Self::rnn_reshape(
+                        &mut main_block,
+                        &bias_name,
+                        &bias_shape,
+                        format!("{out_name}_bias_bcast_{out_id}"),
+                        mil_dtype,
+                    );
+                    let mut add_in = HashMap::new();
+                    add_in.insert("x".to_string(), Self::create_name_argument(nobias_name));
+                    add_in.insert("y".to_string(), Self::create_name_argument(bias_bcast));
+                    main_block.operations.push(Self::create_mil_operation(
+                        "add",
+                        add_in,
+                        vec![out_type],
+                    ));
+                    continue;
+                }
+            }
+
             // `where` (MIL: select) — CoreML requires the condition to be bool,
             // but WebNN encodes booleans as uint8. Insert a cast when needed.
             if op_type_lower == "where" {
@@ -7608,13 +7817,26 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 if let Some(&input_id) = op.input_operands().first() {
                     if let Some(input_op) = graph_info.operand(input_id) {
                         let input_rank = input_op.descriptor.shape.len();
-                        let mean_is_nonconstant_for_rank_check = op
-                            .input_operands()
-                            .get(1)
-                            .and_then(|&mid| graph_info.operand(mid))
-                            .map(|o| o.kind != crate::graph::OperandKind::Constant)
-                            .unwrap_or(false);
-                        if input_rank < 3 && !mean_is_nonconstant_for_rank_check {
+                        // Runtime params route to the decomposition below; this
+                        // path's native batch_norm requires them all const.
+                        let nonconst_param = |id: Option<u32>| {
+                            id.and_then(|pid| graph_info.operand(pid))
+                                .map(|o| o.kind != crate::graph::OperandKind::Constant)
+                                .unwrap_or(false)
+                        };
+                        let (bn_scale_id, bn_bias_id) = match op {
+                            Operation::BatchNormalization { options, .. } => (
+                                options.as_ref().and_then(|o| o.scale),
+                                options.as_ref().and_then(|o| o.bias),
+                            ),
+                            _ => (None, None),
+                        };
+                        let any_param_nonconstant =
+                            nonconst_param(op.input_operands().get(1).copied())
+                                || nonconst_param(op.input_operands().get(2).copied())
+                                || nonconst_param(bn_scale_id)
+                                || nonconst_param(bn_bias_id);
+                        if input_rank < 3 && !any_param_nonconstant {
                             let axis = match op {
                                 Operation::BatchNormalization { options, .. } => {
                                     options.as_ref().map(|o| o.axis as usize).unwrap_or(1)
@@ -8133,18 +8355,25 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                     let epsilon = options.as_ref().map(|o| o.epsilon as f32).unwrap_or(1e-5);
                     let axis = options.as_ref().map(|o| o.axis as usize).unwrap_or(1);
 
-                    let mean_is_nonconstant = mean_id
-                        .and_then(|id| graph_info.operand(id))
-                        .map(|o| o.kind != crate::graph::OperandKind::Constant)
-                        .unwrap_or(false);
+                    let is_runtime_param = |id: Option<u32>| {
+                        id.and_then(|id| graph_info.operand(id))
+                            .map(|o| o.kind != crate::graph::OperandKind::Constant)
+                            .unwrap_or(false)
+                    };
+                    let mean_is_nonconstant = is_runtime_param(mean_id);
 
                     let input_id = op.input_operands().first().copied();
                     let input_operand = input_id.and_then(|id| graph_info.operand(id));
                     let input_rank = input_operand.map(|o| o.descriptor.shape.len()).unwrap_or(0);
 
-                    // Use decomposition when mean is non-constant or axis is non-standard (not 1).
-                    // For axis==1 with constant mean, the native batch_norm path (fallthrough) works.
-                    let use_decomposition = mean_is_nonconstant || (axis != 1 && input_rank >= 2);
+                    // Decompose when any of mean/variance/gamma/beta is a runtime
+                    // value (native batch_norm requires them all const) or when
+                    // axis is non-standard (not 1).
+                    let use_decomposition = mean_is_nonconstant
+                        || is_runtime_param(variance_id)
+                        || is_runtime_param(scale_id)
+                        || is_runtime_param(bias_id)
+                        || (axis != 1 && input_rank >= 2);
 
                     if use_decomposition {
                         if let (Some(input_id), Some(mean_id_v), Some(variance_id_v)) =
@@ -8186,35 +8415,47 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                             let dtype = Self::mil_data_type(&inp_op.descriptor.data_type)?;
                             let is_f16 = inp_op.descriptor.data_type == DataType::Float16;
 
-                            // When axis is not the last dimension, reshape mean/variance for
-                            // correct broadcasting: [C] → [1, C, 1, 1, ...] with 1s elsewhere.
+                            // When axis is not the last dimension, [C]-shaped params
+                            // (mean/variance/gamma/beta) need an explicit reshape to
+                            // [1,..,C,..,1] — MIL broadcasting aligns trailing dims.
+                            let bcast: Option<(Vec<u32>, Vec<Dimension>)> =
+                                if axis != input_rank.saturating_sub(1) && input_rank > 1 {
+                                    let c_size = inp_op
+                                        .descriptor
+                                        .shape
+                                        .get(axis)
+                                        .map(|d| match d {
+                                            GraphDimension::Static(v) => *v,
+                                            GraphDimension::Dynamic(d) => d.max_size,
+                                        })
+                                        .unwrap_or(1);
+                                    let mut bcast_shape = vec![1u32; input_rank];
+                                    bcast_shape[axis] = c_size;
+                                    let bcast_dims: Vec<Dimension> = bcast_shape
+                                        .iter()
+                                        .map(|&d| Dimension {
+                                            dimension: Some(dimension::Dimension::Constant(
+                                                dimension::ConstantDimension { size: d as u64 },
+                                            )),
+                                        })
+                                        .collect();
+                                    Some((bcast_shape, bcast_dims))
+                                } else {
+                                    None
+                                };
+
+                            // Reshape mean/variance to the broadcast shape when needed.
                             // Also return the effective var shape so downstream add/sqrt types match.
-                            let (mean_for_sub, var_for_div, effective_var_shape) = if axis
-                                != input_rank.saturating_sub(1)
-                                && input_rank > 1
+                            let (mean_for_sub, var_for_div, effective_var_shape) = if let Some((
+                                bcast_shape,
+                                bcast_dims,
+                            )) = &bcast
                             {
-                                let c_size = inp_op
-                                    .descriptor
-                                    .shape
-                                    .get(axis)
-                                    .map(|d| match d {
-                                        GraphDimension::Static(v) => *v,
-                                        GraphDimension::Dynamic(d) => d.max_size,
-                                    })
-                                    .unwrap_or(1);
-                                let mut bcast_shape = vec![1u32; input_rank];
-                                bcast_shape[axis] = c_size;
+                                let bcast_shape = bcast_shape.clone();
+                                let bcast_dims = bcast_dims.clone();
                                 let effective_var_shape: Vec<GraphDimension> = bcast_shape
                                     .iter()
                                     .map(|&d| GraphDimension::Static(d))
-                                    .collect();
-                                let bcast_dims: Vec<Dimension> = bcast_shape
-                                    .iter()
-                                    .map(|&d| Dimension {
-                                        dimension: Some(dimension::Dimension::Constant(
-                                            dimension::ConstantDimension { size: d as u64 },
-                                        )),
-                                    })
                                     .collect();
 
                                 let mean_rs_name = format!("{}_bn_mean_rs", output_name);
@@ -8382,6 +8623,44 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                                 vec![make_intermediate(normed_name.clone())],
                             ));
 
+                            // Reshape a [C] param to `bcast` (same treatment as mean/var).
+                            let bcast_param = |src_name: String,
+                                               tag: &str,
+                                               ops: &mut Vec<MilOperation>|
+                             -> String {
+                                let Some((bcast_shape, bcast_dims)) = &bcast else {
+                                    return src_name;
+                                };
+                                let rs_name = format!("{}_bn_{}_rs", output_name, tag);
+                                let rs_type = NamedValueType {
+                                        name: rs_name.clone(),
+                                        r#type: Some(ValueType {
+                                            r#type: Some(
+                                                crate::protos::coreml::mil_spec::value_type::Type::TensorType(
+                                                    TensorType {
+                                                        rank: input_rank as i64,
+                                                        data_type: dtype,
+                                                        dimensions: bcast_dims.clone(),
+                                                        attributes: HashMap::new(),
+                                                    },
+                                                ),
+                                            ),
+                                        }),
+                                    };
+                                let mut rs_in: HashMap<String, Argument> = HashMap::new();
+                                rs_in.insert("x".to_string(), Self::create_name_argument(src_name));
+                                rs_in.insert(
+                                    "shape".to_string(),
+                                    Self::create_immediate_int_array(bcast_shape),
+                                );
+                                ops.push(Self::create_mil_operation(
+                                    "reshape",
+                                    rs_in,
+                                    vec![rs_type],
+                                ));
+                                rs_name
+                            };
+
                             // Apply scale (gamma) and bias (beta) if present
                             let after_scale = if let Some(sc_id) = scale_id {
                                 let sc_name = Self::output_name_for_operand(
@@ -8389,6 +8668,8 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                                     sc_id,
                                     &operand_name_overrides,
                                 );
+                                let sc_name =
+                                    bcast_param(sc_name, "gamma", &mut main_block.operations);
                                 let scaled_name = format!("{}_bn_scaled", output_name);
                                 let mut mul_in: HashMap<String, Argument> = HashMap::new();
                                 mul_in.insert(
@@ -8412,6 +8693,8 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                                     bi_id,
                                     &operand_name_overrides,
                                 );
+                                let bi_name =
+                                    bcast_param(bi_name, "beta", &mut main_block.operations);
                                 let biased_name = output_name.clone();
                                 let mut add_in: HashMap<String, Argument> = HashMap::new();
                                 add_in.insert(
@@ -8971,7 +9254,12 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                         input_id,
                         &operand_name_overrides,
                     );
-                    let reshaped_input_name = format!("{}_reduce1d", input_name);
+                    // Output-id suffix: two reduces sharing one 0-D operand must not collide.
+                    let reshaped_input_name = format!(
+                        "{}_reduce1d_{}",
+                        input_name,
+                        op.output_operand().unwrap_or(input_id)
+                    );
                     let mil_dtype = Self::mil_data_type(&input_dtype)?;
 
                     // Build the [1] dimension for the reshaped input

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -7276,6 +7276,43 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 }
             }
 
+            // Integer division: MIL `real_div` on integer operands has no
+            // reliable integer semantics — several CoreML compiler builds
+            // constant-fold it with float division (200/16 stays 12.5 through
+            // subsequent folded ops), corrupting e.g. packed-nibble unpack
+            // chains. Emit `floor_div`, which is integer-defined everywhere.
+            // (floor differs from ORT's truncation only for negative
+            // quotients, which no supported lowering produces.)
+            if matches!(op, Operation::Div { .. })
+                && let Some(&div_in) = op.input_operands().first()
+                && let Some(div_in_op) = graph_info.operand(div_in)
+                && !matches!(
+                    div_in_op.descriptor.data_type,
+                    DataType::Float32 | DataType::Float16
+                )
+                && let Some(out_id) = op.output_operand()
+            {
+                let (_, out_type) =
+                    Self::create_output_value(graph_info, out_id, &operand_name_overrides)?;
+                let names =
+                    Self::input_names_for_operation(graph_info, op, &operand_name_overrides);
+                let mut div_in_args = HashMap::new();
+                div_in_args.insert(
+                    "x".to_string(),
+                    Self::create_name_argument(names[0].clone()),
+                );
+                div_in_args.insert(
+                    "y".to_string(),
+                    Self::create_name_argument(names[1].clone()),
+                );
+                main_block.operations.push(Self::create_mil_operation(
+                    "floor_div",
+                    div_in_args,
+                    vec![out_type],
+                ));
+                continue;
+            }
+
             // identity over a constant: CoreML's compiler elides `identity`
             // ops, and for a const input the plan builder then fails with
             // "Variable is not associated with a name" (error -5) because the

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -83,6 +83,31 @@ fn convert_zp_bytes(src: &[u8], src_dtype: &DataType, tgt_dtype: &DataType) -> V
             }
             out
         }
+        // Float32 <-> Float16: quantize/dequantize scale constants whose float type
+        // doesn't match the float tensor ("input and scale must have the same data type").
+        (DataType::Float32, DataType::Float16) => {
+            let count = src.len() / 4;
+            let mut out = Vec::with_capacity(count * 2);
+            for i in 0..count {
+                let v = f32::from_le_bytes([
+                    src[i * 4],
+                    src[i * 4 + 1],
+                    src[i * 4 + 2],
+                    src[i * 4 + 3],
+                ]);
+                out.extend_from_slice(&half::f16::from_f32(v).to_bits().to_le_bytes());
+            }
+            out
+        }
+        (DataType::Float16, DataType::Float32) => {
+            let count = src.len() / 2;
+            let mut out = Vec::with_capacity(count * 4);
+            for i in 0..count {
+                let bits = u16::from_le_bytes([src[i * 2], src[i * 2 + 1]]);
+                out.extend_from_slice(&half::f16::from_bits(bits).to_f32().to_le_bytes());
+            }
+            out
+        }
         _ => src.to_vec(),
     }
 }
@@ -1525,12 +1550,22 @@ impl CoremlMlProgramConverter {
     /// CoreML's native op can't express it. int4/uint4 tensors are excluded (they cannot
     /// be materialized at all) and scalar tensors keep the native rank-0 fast path.
     fn qdq_should_decompose(graph: &GraphInfo, op: &Operation) -> bool {
-        let (quant_id, tensor_shape_id, scale_id) = match op {
+        let (quant_id, tensor_shape_id, scale_id, zero_point_id) = match op {
             // dequantize: the quantized tensor is the input; its type/shape drive the check.
-            Operation::DequantizeLinear { input, scale, .. } => (*input, *input, *scale),
+            Operation::DequantizeLinear {
+                input,
+                scale,
+                zero_point,
+                ..
+            } => (*input, *input, *scale, *zero_point),
             // quantize: the quantized tensor is the output; the float input carries the shape.
-            Operation::QuantizeLinear { input, scale, .. } => match op.output_operand() {
-                Some(out) => (out, *input, *scale),
+            Operation::QuantizeLinear {
+                input,
+                scale,
+                zero_point,
+                ..
+            } => match op.output_operand() {
+                Some(out) => (out, *input, *scale, *zero_point),
                 None => return false,
             },
             _ => return false,
@@ -1542,6 +1577,18 @@ impl CoremlMlProgramConverter {
         ) else {
             return false;
         };
+        // CoreML's native quantize/dequantize require const scale/zero_point;
+        // runtime-computed ones (e.g. DynamicQuantizeLinear lowering) must be
+        // decomposed into elementwise arithmetic.
+        if scale_op.kind != crate::graph::OperandKind::Constant {
+            return true;
+        }
+        if let Some(zp_id) = zero_point_id
+            && let Some(zp_op) = graph.operand(zp_id)
+            && zp_op.kind != crate::graph::OperandKind::Constant
+        {
+            return true;
+        }
         let quant_dt = quant_op.descriptor.data_type.clone();
         if tensor_op.descriptor.shape.is_empty() {
             // Scalars normally use the native rank-0 fast path, but int4/uint4 have no
@@ -2194,7 +2241,7 @@ impl CoremlMlProgramConverter {
         ));
 
         // 2. scale -> reshape to interleaved.
-        let scale_name = operand_name(graph, scale_id);
+        let scale_name = Self::output_name_for_operand(graph, scale_id, overrides);
         let scale_r_name = format!("{}_dq_scale_r", output_name);
         let scale_r_type =
             Self::value_type_for_static_shape(scale_r_name.clone(), out_dtype, &interleaved_scale);
@@ -2212,7 +2259,7 @@ impl CoremlMlProgramConverter {
 
         // 3. (input - zeroPoint), if a zero_point is present.
         let minus_zp_name = if let Some(zp_id) = zp_id {
-            let zp_name = operand_name(graph, zp_id);
+            let zp_name = Self::output_name_for_operand(graph, zp_id, overrides);
             let zp_f_name = format!("{}_dq_zp_f", output_name);
             let zp_f_type =
                 Self::value_type_for_static_shape(zp_f_name.clone(), out_dtype, &scale_shape);
@@ -2369,7 +2416,7 @@ impl CoremlMlProgramConverter {
         ));
 
         // 2. cast scale -> fp32, reshape to interleaved form.
-        let scale_name = operand_name(graph, scale_id);
+        let scale_name = Self::output_name_for_operand(graph, scale_id, overrides);
         let scale_f_name = format!("{}_q_scale_f", output_name);
         let scale_f_type =
             Self::value_type_for_static_shape(scale_f_name.clone(), float_dtype, &scale_shape);
@@ -2421,7 +2468,7 @@ impl CoremlMlProgramConverter {
 
         // 4. add the zero_point (cast to float, reshaped), if present.
         let biased_name = if let Some(zp_id) = zp_id {
-            let zp_name = operand_name(graph, zp_id);
+            let zp_name = Self::output_name_for_operand(graph, zp_id, overrides);
             let zp_f_name = format!("{}_q_zp_f", output_name);
             let zp_f_type =
                 Self::value_type_for_static_shape(zp_f_name.clone(), float_dtype, &scale_shape);
@@ -4927,6 +4974,31 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 if let (Some(&zp_id), Some(expected_dt)) = (input_ids.get(2), zp_expected_type) {
                     zp_id_to_dtype.insert(zp_id, expected_dt);
                 }
+                // CoreML requires scale's float type to match the float tensor
+                // (quantize: the input; dequantize: the output). Coerce constant
+                // scales that disagree (e.g. an fp16 tensor with an fp32 scale).
+                let float_dt = if op_lower == "quantizelinear" {
+                    input_ids
+                        .first()
+                        .and_then(|&id| graph_info.operand(id))
+                        .map(|o| o.descriptor.data_type.clone())
+                } else {
+                    op.output_operand()
+                        .and_then(|id| graph_info.operand(id))
+                        .map(|o| o.descriptor.data_type.clone())
+                };
+                if let (Some(&scale_id), Some(float_dt)) = (input_ids.get(1), float_dt)
+                    && matches!(float_dt, DataType::Float32 | DataType::Float16)
+                    && let Some(scale_op) = graph_info.operand(scale_id)
+                    && matches!(
+                        scale_op.descriptor.data_type,
+                        DataType::Float32 | DataType::Float16
+                    )
+                    && scale_op.descriptor.data_type != float_dt
+                    && scale_op.kind == crate::graph::OperandKind::Constant
+                {
+                    zp_id_to_dtype.insert(scale_id, float_dt);
+                }
                 // For dequantize, CoreML also requires the INPUT (index 0) to be int8 or uint8.
                 // If the input is a constant Int32 tensor, coerce its bytes to int8/uint8 so
                 // CoreML accepts it. Non-constant Int32 inputs are handled with a cast op below.
@@ -5382,7 +5454,13 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                             }
                         })?;
                         if input_operand.descriptor.data_type == DataType::Uint8 {
-                            let bool_input_name = format!("{}_bool", input_names[index]);
+                            // Suffix with the consuming op's output id: a bare
+                            // `{input}_bool` collides with the producer's own
+                            // `{output}_bool` raw result when the input comes
+                            // from another comparison/logical op ("Block
+                            // redefines I/O name").
+                            let bool_input_name =
+                                format!("{}_bool_{}", input_names[index], output_id);
                             let bool_input_type = Self::create_value_with_mil_type(
                                 graph_info,
                                 input_id,
@@ -6939,6 +7017,167 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                 }
             }
 
+            // layer/instance normalization with a runtime (non-constant) scale or
+            // bias: CoreML's native layer_norm/instance_norm require const
+            // gamma/beta ("Param 'gamma' must be const"), so run the native op
+            // without them and apply `y = norm(x) * scale + bias` with explicit
+            // mul/add, reshaping scale/bias to a broadcast-compatible shape.
+            // Both params are stripped together: the native op computes
+            // `norm * gamma + beta`, so applying one after the fact while the
+            // other stays inside would change the result.
+            if matches!(
+                op,
+                Operation::LayerNormalization { .. } | Operation::InstanceNormalization { .. }
+            ) {
+                let (scale_id, bias_id) = match op {
+                    Operation::LayerNormalization { options, .. } => (
+                        options.as_ref().and_then(|o| o.scale),
+                        options.as_ref().and_then(|o| o.bias),
+                    ),
+                    Operation::InstanceNormalization { options, .. } => (
+                        options.as_ref().and_then(|o| o.scale),
+                        options.as_ref().and_then(|o| o.bias),
+                    ),
+                    _ => (None, None),
+                };
+                let is_runtime = |id: Option<u32>| {
+                    id.and_then(|id| graph_info.operand(id))
+                        .map(|o| o.kind != crate::graph::OperandKind::Constant)
+                        .unwrap_or(false)
+                };
+                if is_runtime(scale_id) || is_runtime(bias_id) {
+                    let x_id = *op.input_operands().first().ok_or_else(|| {
+                        GraphError::ConversionFailed {
+                            format: "coreml_mlprogram".to_string(),
+                            reason: format!("{} has no input operand", op.op_type()),
+                        }
+                    })?;
+                    let x_op =
+                        graph_info
+                            .operand(x_id)
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "coreml_mlprogram".to_string(),
+                                reason: format!("input operand {x_id} not found"),
+                            })?;
+                    let x_shape = x_op.descriptor.static_or_max_shape();
+                    let rank = x_shape.len();
+                    let mil_dtype = Self::graph_value_mil_type(&x_op.descriptor.data_type)?;
+                    let out_id =
+                        op.output_operand()
+                            .ok_or_else(|| GraphError::ConversionFailed {
+                                format: "coreml_mlprogram".to_string(),
+                                reason: format!("{} has no output operand", op.op_type()),
+                            })?;
+                    let (out_name, out_type) =
+                        Self::create_output_value(graph_info, out_id, &operand_name_overrides)?;
+
+                    // Broadcast target: scale/bias expanded to the input rank with
+                    // 1s on non-normalized (layer) / non-channel (instance) dims.
+                    let target: Vec<u32> = match op {
+                        Operation::LayerNormalization { options, .. } => {
+                            let axes: Vec<usize> = options
+                                .as_ref()
+                                .and_then(|o| o.axes.as_ref())
+                                .map(|ax| ax.iter().map(|&a| a as usize).collect())
+                                .unwrap_or_else(|| {
+                                    if rank > 1 {
+                                        (1..rank).collect()
+                                    } else {
+                                        vec![0]
+                                    }
+                                });
+                            (0..rank)
+                                .map(|i| if axes.contains(&i) { x_shape[i] } else { 1 })
+                                .collect()
+                        }
+                        _ => {
+                            let nhwc = match op {
+                                Operation::InstanceNormalization { options, .. } => options
+                                    .as_ref()
+                                    .map(|o| o.layout.eq_ignore_ascii_case("nhwc"))
+                                    .unwrap_or(false),
+                                _ => false,
+                            };
+                            let c_idx = if nhwc { rank.saturating_sub(1) } else { 1 };
+                            (0..rank)
+                                .map(|i| if i == c_idx { x_shape[i] } else { 1 })
+                                .collect()
+                        }
+                    };
+
+                    let mut stripped = op.clone();
+                    match &mut stripped {
+                        Operation::LayerNormalization { options, .. } => {
+                            if let Some(o) = options {
+                                o.scale = None;
+                                o.bias = None;
+                            }
+                        }
+                        Operation::InstanceNormalization { options, .. } => {
+                            if let Some(o) = options {
+                                o.scale = None;
+                                o.bias = None;
+                            }
+                        }
+                        _ => {}
+                    }
+                    let norm_name = format!("{out_name}_nogb_{out_id}");
+                    let mut norm_overrides = operand_name_overrides.clone();
+                    norm_overrides.insert(out_id, norm_name.clone());
+                    let mil = self.convert_operation_with_overrides(
+                        graph_info,
+                        &stripped,
+                        &norm_overrides,
+                    )?;
+                    main_block.operations.push(mil);
+
+                    let mut cur = norm_name;
+                    let steps: Vec<(&str, u32, &str)> = scale_id
+                        .map(|id| ("mul", id, "gamma"))
+                        .into_iter()
+                        .chain(bias_id.map(|id| ("add", id, "beta")))
+                        .collect();
+                    let last = steps.len().saturating_sub(1);
+                    for (i, (mil_op, param_id, tag)) in steps.into_iter().enumerate() {
+                        let param_name = Self::output_name_for_operand(
+                            graph_info,
+                            param_id,
+                            &operand_name_overrides,
+                        );
+                        let bcast = Self::rnn_reshape(
+                            &mut main_block,
+                            &param_name,
+                            &target,
+                            format!("{out_name}_{tag}_bcast_{out_id}"),
+                            mil_dtype,
+                        );
+                        let (step_name, step_type) = if i == last {
+                            (out_name.clone(), out_type.clone())
+                        } else {
+                            let name = format!("{out_name}_{tag}_applied_{out_id}");
+                            let ty = Self::create_value_with_mil_type(
+                                graph_info,
+                                out_id,
+                                name.clone(),
+                                mil_dtype,
+                            )?;
+                            (name, ty)
+                        };
+                        let mut io = HashMap::new();
+                        io.insert("x".to_string(), Self::create_name_argument(cur.clone()));
+                        io.insert("y".to_string(), Self::create_name_argument(bcast));
+                        main_block.operations.push(Self::create_mil_operation(
+                            mil_op,
+                            io,
+                            vec![step_type],
+                        ));
+                        cur = step_name;
+                    }
+                    let _ = cur;
+                    continue;
+                }
+            }
+
             // `where` (MIL: select) — CoreML requires the condition to be bool,
             // but WebNN encodes booleans as uint8. Insert a cast when needed.
             if op_type_lower == "where" {
@@ -6956,7 +7195,11 @@ impl super::GraphConverter for CoremlMlProgramConverter {
                             cond_id,
                             &operand_name_overrides,
                         );
-                        let bool_cond_name = format!("{cond_name}_bool");
+                        // Suffix with this op's output id: a bare `{cond}_bool`
+                        // collides with the producing comparison's own
+                        // `{output}_bool` raw result ("Block redefines I/O name").
+                        let where_out = op.output_operand().unwrap_or(cond_id);
+                        let bool_cond_name = format!("{cond_name}_bool_{where_out}");
                         let bool_cond_type = Self::create_value_with_mil_type(
                             graph_info,
                             cond_id,
@@ -8921,6 +9164,42 @@ impl super::GraphConverter for CoremlMlProgramConverter {
             main_block.outputs.push(output_name);
         }
 
+        // CoreML rejects, at MLModel load time ("Error in declaring input X with
+        // error -1."), a function input that no operation consumes — e.g.
+        // castLike's target_type (only its dtype matters, never its values) or
+        // an input whose sole consumer was constant-folded away. Drop such
+        // inputs from the function signature and, below, from the model
+        // description. Dispatch may still bind a tensor for them: CoreML
+        // ignores extra features at prediction time.
+        let mut referenced_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        {
+            fn walk_block_names(block: &Block, names: &mut std::collections::HashSet<String>) {
+                use crate::protos::coreml::mil_spec::argument::binding::Binding;
+                for op in &block.operations {
+                    for arg in op.inputs.values() {
+                        for b in &arg.arguments {
+                            if let Some(Binding::Name(n)) = &b.binding {
+                                names.insert(n.clone());
+                            }
+                        }
+                    }
+                    for nested in &op.blocks {
+                        walk_block_names(nested, names);
+                    }
+                }
+            }
+            walk_block_names(&main_block, &mut referenced_names);
+        }
+        main_function
+            .inputs
+            .retain(|nv| referenced_names.contains(&nv.name));
+        let declared_input_names: std::collections::HashSet<String> = main_function
+            .inputs
+            .iter()
+            .map(|nv| nv.name.clone())
+            .collect();
+
         // Add block to function
         main_function.opset = "CoreML7".to_string(); // Specify the active block specialization
         main_function
@@ -8946,6 +9225,11 @@ impl super::GraphConverter for CoremlMlProgramConverter {
         for &input_id in &graph_info.input_operands {
             if let Some(operand) = graph_info.operand(input_id) {
                 let input_name = operand_name(graph_info, input_id);
+                // Unused inputs were dropped from the function signature above;
+                // the model description must match it.
+                if !declared_input_names.contains(&input_name) {
+                    continue;
+                }
                 input_descriptions.push(FeatureDescription {
                     name: input_name,
                     r#type: Some(Self::create_feature_type(&operand.descriptor)?),

--- a/src/converters/coreml_mlprogram.rs
+++ b/src/converters/coreml_mlprogram.rs
@@ -1525,11 +1525,35 @@ impl CoremlMlProgramConverter {
         Some(pad)
     }
 
+    /// Derive the per-channel axis for a single-non-unit-dim `scale_shape`
+    /// against `input_shape`. A rank-aligned scale (same rank as the input)
+    /// names its axis by the position of its non-unit dim — unambiguous even
+    /// when several input dims share the channel length (square weights);
+    /// only a rank-mismatched scale falls back to the first input dim
+    /// matching the channel count. Returns `None` unless the input dim at
+    /// the derived axis exactly equals the scale length: a single-axis
+    /// BLOCKWISE scale (length that merely divides some input dim) has no
+    /// per-channel axis.
+    fn qdq_per_channel_axis(input_shape: &[u32], scale_shape: &[u32]) -> Option<usize> {
+        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
+        if squeezed.len() != 1 {
+            return None;
+        }
+        let len = squeezed[0];
+        let axis = if scale_shape.len() == input_shape.len() {
+            scale_shape.iter().position(|&d| d != 1).unwrap_or(0)
+        } else {
+            input_shape.iter().position(|&d| d == len)?
+        };
+        (input_shape.get(axis) == Some(&len)).then_some(axis)
+    }
+
     /// Whether a quantize/dequantize with this quantized integer type and scale shape
     /// can use CoreML's native `quantize`/`dequantize`. CoreML supports only int8/uint8
-    /// quantized tensors with a scalar (per-tensor) or single-axis 1-D (per-channel)
-    /// scale; int32 tensors, block-wise scales, and multi-axis scales are not supported
-    /// and must be decomposed into elementwise arithmetic.
+    /// quantized tensors with a scalar (per-tensor) or single-axis (per-channel) scale
+    /// that exactly covers its input axis; int32 tensors, block-wise scales, and
+    /// multi-axis scales are not supported and must be decomposed into elementwise
+    /// arithmetic.
     fn qdq_native_supported(
         quant_dtype: &DataType,
         input_shape: &[u32],
@@ -1538,9 +1562,10 @@ impl CoremlMlProgramConverter {
         if !matches!(quant_dtype, DataType::Int8 | DataType::Uint8) {
             return false;
         }
-        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
-        // per-tensor (scalar), or per-channel (one non-unit dim equal to some input dim).
-        squeezed.is_empty() || (squeezed.len() == 1 && input_shape.contains(&squeezed[0]))
+        // per-tensor (scalar), or per-channel (a valid axis exactly covered by the
+        // scale — a blockwise scale that merely divides an input dim yields no axis).
+        scale_shape.iter().all(|&d| d == 1)
+            || Self::qdq_per_channel_axis(input_shape, scale_shape).is_some()
     }
 
     /// Whether a quantize/dequantize op must be lowered to elementwise arithmetic because
@@ -2212,25 +2237,16 @@ impl CoremlMlProgramConverter {
                 }
             }
         }
-        // A per-channel scale must exactly cover the derived axis: a
-        // single-axis BLOCKWISE scale (length that merely divides some input
-        // dim) can slip through qdq_native_supported's contains() check but
-        // constexpr_affine_dequantize cannot express it.
+        // A per-channel scale must exactly cover the derived axis:
+        // constexpr_affine_dequantize cannot express a single-axis BLOCKWISE
+        // scale. qdq_native_supported enforces the same rule, but re-check via
+        // the shared helper so this path never depends on that gate's internals.
         let scale_shape = scale_op.descriptor.static_or_max_shape();
         let input_shape = input_op.descriptor.static_or_max_shape();
-        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
-        if let Some(&len) = squeezed.first() {
-            if squeezed.len() != 1 {
-                return false;
-            }
-            let axis = if scale_shape.len() == input_shape.len() {
-                scale_shape.iter().position(|&d| d != 1).unwrap_or(0)
-            } else {
-                input_shape.iter().position(|&d| d == len).unwrap_or(0)
-            };
-            if input_shape.get(axis) != Some(&len) {
-                return false;
-            }
+        if scale_shape.iter().any(|&d| d != 1)
+            && Self::qdq_per_channel_axis(&input_shape, &scale_shape).is_none()
+        {
+            return false;
         }
         true
     }
@@ -2408,21 +2424,11 @@ impl CoremlMlProgramConverter {
         let scale_shape = scale_op.descriptor.static_or_max_shape();
         let input_shape = input_op.descriptor.static_or_max_shape();
         let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
-        // Per-channel: derive the axis from the scale layout; 0 for per-tensor.
-        // A rank-aligned scale (e.g. [1, N] against [K, N]) names its axis by
-        // position — unambiguous even for square weights. Only a rank-mismatched
-        // scale falls back to the first input dim matching the channel count
-        // (mirrors the native dequantize path).
-        let axis = match squeezed.first() {
-            Some(&len) if squeezed.len() == 1 && len > 1 => {
-                if scale_shape.len() == input_shape.len() {
-                    scale_shape.iter().position(|&d| d != 1).unwrap_or(0) as u32
-                } else {
-                    input_shape.iter().position(|&d| d == len).unwrap_or(0) as u32
-                }
-            }
-            _ => 0,
-        };
+        // Per-channel: derive the axis from the scale layout (rank-aligned
+        // scales name their axis by position — unambiguous even for square
+        // weights); 0 for per-tensor. constexpr_dequantize_supported already
+        // validated the axis, so None here only means per-tensor.
+        let axis = Self::qdq_per_channel_axis(&input_shape, &scale_shape).unwrap_or(0) as u32;
         let param_shape: &[u32] = if squeezed.len() == 1 && squeezed[0] > 1 {
             &squeezed
         } else {
@@ -3895,31 +3901,27 @@ impl CoremlMlProgramConverter {
                             Self::create_argument(&input_names[2]),
                         );
                     }
-                    // When scale is truly per-channel (rank-1 with >1 elements), CoreML requires
+                    // When scale is truly per-channel (one non-unit dim), CoreML requires
                     // an explicit axis. For per-tensor (scalar or single-element), omit axis.
                     // Note: single-element scales [1] are squeezed to scalar at constant emit
                     // time; emitting axis alongside a scalar scale causes a CoreML compile error.
                     // Multi-dimensional scales are squeezed to 1D at emission time (all size-1
-                    // dimensions removed). Compute the effective squeezed length here so we can
-                    // detect the per-channel case even when the WebNN descriptor says rank > 1.
+                    // dimensions removed). qdq_native_supported gated this op, so every
+                    // per-channel scale reaching here has a valid derived axis (rank-aligned
+                    // derivation disambiguates square/coincident input dims).
                     if let Some(scale_op) = graph.operand(*scale_id) {
                         let scale_shape = scale_op.descriptor.static_or_max_shape();
-                        // Effective shape after squeezing out all size-1 dims (mirrors the
-                        // constant emission pre-scan for scale_ids_to_squeeze).
-                        let squeezed: Vec<u32> = scale_shape.iter().copied().filter(|&d| d != 1).collect();
-                        let effective_rank = if squeezed.is_empty() { 0 } else { squeezed.len() };
-                        let effective_len = squeezed.first().copied().unwrap_or(scale_shape.first().copied().unwrap_or(0));
-                        let is_per_channel = effective_rank == 1 && effective_len > 1;
-                        if is_per_channel {
-                            let axis = graph.operand(*inp_id)
-                                .and_then(|inp| {
-                                    inp.descriptor.static_or_max_shape()
-                                        .iter()
-                                        .position(|&d| d == effective_len)
-                                        .map(|i| i as u32)
-                                })
-                                .unwrap_or(0);
-                            inputs.insert("axis".to_string(), Self::create_immediate_int(axis));
+                        let axis = graph.operand(*inp_id).and_then(|inp| {
+                            Self::qdq_per_channel_axis(
+                                &inp.descriptor.static_or_max_shape(),
+                                &scale_shape,
+                            )
+                        });
+                        if let Some(axis) = axis {
+                            inputs.insert(
+                                "axis".to_string(),
+                                Self::create_immediate_int(axis as u32),
+                            );
                         }
                     }
                 }
@@ -10820,6 +10822,194 @@ mod tests {
 
         assert!(main_block.operations.iter().any(|op| op.r#type == "mul"));
         assert!(main_block.operations.iter().any(|op| op.r#type == "add"));
+    }
+
+    /// Decode a converted model and return its main CoreML7 block.
+    fn decode_main_block(data: &[u8]) -> crate::protos::coreml::mil_spec::Block {
+        let model = Model::decode(data).expect("decode coreml model");
+        let program = match model.r#type.expect("model type") {
+            crate::protos::coreml::specification::model::Type::MlProgram(program) => program,
+            _ => panic!("expected MLProgram model"),
+        };
+        program
+            .functions
+            .get("main")
+            .expect("main function")
+            .block_specializations
+            .get("CoreML7")
+            .expect("CoreML7 block")
+            .clone()
+    }
+
+    /// Unpack a scalar immediate int argument (e.g. the `axis` input of a
+    /// native `dequantize` op) from a decoded MIL operation.
+    fn immediate_int_argument(arg: &Argument) -> i32 {
+        use crate::protos::coreml::mil_spec::{tensor_value, value};
+        let Some(Binding::Value(v)) = arg.arguments.first().and_then(|b| b.binding.as_ref()) else {
+            panic!("expected immediate value binding");
+        };
+        let Some(value::Value::ImmediateValue(imm)) = &v.value else {
+            panic!("expected immediate value");
+        };
+        let Some(value::immediate_value::Value::Tensor(t)) = &imm.value else {
+            panic!("expected tensor value");
+        };
+        let Some(tensor_value::Value::Ints(ints)) = &t.value else {
+            panic!("expected int tensor");
+        };
+        ints.values[0]
+    }
+
+    /// Graph: dequantizeLinear(int8 constant of `input_shape`, f32 constant
+    /// scale of `scale_shape`, no zero point) -> f32 output. Without a zero
+    /// point a per-channel scale can't use constexpr_affine_dequantize, so the
+    /// op exercises the native/decomposed dequantize paths.
+    fn create_dequantize_graph(input_shape: &[u32], scale_shape: &[u32]) -> GraphInfo {
+        let mut graph = GraphInfo {
+            input_operands: vec![],
+            output_operands: vec![2],
+            operands: vec![],
+            operations: vec![],
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: true,
+        };
+        graph.operands.push(Operand {
+            name: Some("weights".to_string()),
+            kind: OperandKind::Constant,
+            descriptor: OperandDescriptor {
+                data_type: DataType::Int8,
+                shape: s(input_shape),
+                pending_permutation: vec![],
+            },
+        });
+        let input_len = input_shape.iter().product::<u32>() as usize;
+        graph.constant_operand_ids_to_handles.insert(
+            0,
+            ConstantData {
+                data: vec![1u8; input_len],
+                label: None,
+            },
+        );
+        graph.operands.push(Operand {
+            name: Some("scale".to_string()),
+            kind: OperandKind::Constant,
+            descriptor: OperandDescriptor {
+                data_type: DataType::Float32,
+                shape: s(scale_shape),
+                pending_permutation: vec![],
+            },
+        });
+        let scale_len = scale_shape.iter().product::<u32>() as usize;
+        graph.constant_operand_ids_to_handles.insert(
+            1,
+            ConstantData {
+                data: 0.5f32.to_le_bytes().repeat(scale_len),
+                label: None,
+            },
+        );
+        graph.operands.push(Operand {
+            name: Some("output".to_string()),
+            kind: OperandKind::Output,
+            descriptor: OperandDescriptor {
+                data_type: DataType::Float32,
+                shape: s(input_shape),
+                pending_permutation: vec![],
+            },
+        });
+        graph.operations.push(op_from_operator_options(
+            "dequantizeLinear",
+            vec![0, 1],
+            Some(2),
+            vec![],
+            OperatorOptions::default(),
+        ));
+        graph
+    }
+
+    #[test]
+    fn test_qdq_per_channel_axis_rank_aligned() {
+        type C = CoremlMlProgramConverter;
+        // Square weight: both input dims match the scale length; rank
+        // alignment picks the scale's own non-unit position, not the first
+        // coincident input dim.
+        assert_eq!(C::qdq_per_channel_axis(&[4, 4], &[1, 4]), Some(1));
+        assert_eq!(C::qdq_per_channel_axis(&[4, 4], &[4, 1]), Some(0));
+        // Rank-mismatched scales fall back to the first matching input dim.
+        assert_eq!(C::qdq_per_channel_axis(&[3, 4], &[4]), Some(1));
+        // Blockwise: the scale length divides input dim 1 but coincidentally
+        // equals input dim 0 — no valid per-channel axis.
+        assert_eq!(C::qdq_per_channel_axis(&[64, 128], &[1, 64]), None);
+        // Per-tensor scales have no per-channel axis.
+        assert_eq!(C::qdq_per_channel_axis(&[4, 4], &[1, 1]), None);
+        assert_eq!(C::qdq_per_channel_axis(&[4, 4], &[]), None);
+    }
+
+    #[test]
+    fn test_qdq_native_rejects_coincident_blockwise_scale() {
+        // Input [64, 128] with rank-aligned scale [1, 64]: blockwise along
+        // axis 1 (block 2). The squeezed length 64 coincides with input dim 0,
+        // which previously passed the contains() check as "per-channel".
+        assert!(!CoremlMlProgramConverter::qdq_native_supported(
+            &DataType::Int8,
+            &[64, 128],
+            &[1, 64],
+        ));
+        // Exact per-channel and per-tensor scales stay native.
+        assert!(CoremlMlProgramConverter::qdq_native_supported(
+            &DataType::Int8,
+            &[64, 128],
+            &[1, 128],
+        ));
+        assert!(CoremlMlProgramConverter::qdq_native_supported(
+            &DataType::Int8,
+            &[64, 128],
+            &[1, 1],
+        ));
+    }
+
+    #[test]
+    fn test_dequantize_square_matrix_per_channel_axis() {
+        // Square int8 weight [4, 4] with rank-aligned scale [1, 4]: the scale
+        // names axis 1; first-match derivation would silently pick axis 0.
+        let graph = create_dequantize_graph(&[4, 4], &[1, 4]);
+        let converted = CoremlMlProgramConverter
+            .convert(&graph)
+            .expect("square-matrix per-channel dequantize should convert");
+        let block = decode_main_block(&converted.data);
+        let deq = block
+            .operations
+            .iter()
+            .find(|op| op.r#type == "dequantize")
+            .expect("per-channel int8 dequantize should use the native op");
+        let axis = deq
+            .inputs
+            .get("axis")
+            .expect("per-channel dequantize emits axis");
+        assert_eq!(immediate_int_argument(axis), 1);
+    }
+
+    #[test]
+    fn test_dequantize_coincident_blockwise_scale_decomposes() {
+        // Input [4, 8] with scale [1, 4]: blockwise along axis 1 (block 2)
+        // whose length coincides with input dim 0. Native dequantize can't
+        // express it; it must lower to the elementwise decomposition.
+        let graph = create_dequantize_graph(&[4, 8], &[1, 4]);
+        let converted = CoremlMlProgramConverter
+            .convert(&graph)
+            .expect("blockwise dequantize should convert via decomposition");
+        let block = decode_main_block(&converted.data);
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| op.r#type == "dequantize" || op.r#type == "constexpr_affine_dequantize"),
+            "coincident blockwise scale must not use native/constexpr dequantize"
+        );
+        assert!(
+            block.operations.iter().any(|op| op.r#type == "mul"),
+            "elementwise decomposition should emit mul"
+        );
     }
 
     #[cfg(not(feature = "dynamic-inputs"))]

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -5643,6 +5643,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     hidden_state_rank,
                     hidden_state_needs_reshape,
                     hidden_state_shape_ok_3d,
+                    hidden_state_dim0,
                 ) = if let Some(id) = initial_h_operand_id {
                     let desc = graph.operand(id);
                     let rank = desc.map(|o| o.descriptor.shape.len()).unwrap_or(0);
@@ -5660,7 +5661,20 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         && shape[0] == 1
                         && shape[1] as i64 == batch_size
                         && shape[2] as i64 == hidden_size as i64;
-                    (operand_name(graph, id), rank, needs_reshape, shape_ok_3d)
+                    // Per the WebNN spec, initialHiddenState is already [numDirections, batchSize,
+                    // hiddenSize]; a rank-3 state with dim0 > 1 already carries both directions.
+                    let dim0 = if rank == 3 {
+                        shape.first().copied().unwrap_or(1)
+                    } else {
+                        1
+                    };
+                    (
+                        operand_name(graph, id),
+                        rank,
+                        needs_reshape,
+                        shape_ok_3d,
+                        dim0,
+                    )
                 } else {
                     let name = format!("{}_initial_h_zero", op_name);
                     initializers.push(Self::create_vector_initializer(
@@ -5669,7 +5683,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         vec![batch_size, hidden_size as i64],
                         0.0,
                     ));
-                    (name, 2, false, false)
+                    (name, 2, false, false, 1)
                 };
 
                 // ONNX initial_h must be 3D [num_directions, batch_size, hidden_size].
@@ -5725,8 +5739,10 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     });
                 }
 
-                // For bidirectional, ONNX initial_h must be [2, batch, hidden]. WebNN sends [1, batch, hidden]; duplicate on axis 0.
-                let h_3d_final_name = if direction == "both" {
+                // For bidirectional, ONNX initial_h must be [2, batch, hidden]. Per spec the caller
+                // already supplies [numDirections, batch, hidden]; only duplicate on axis 0 as a compat
+                // shim when the incoming state is single-direction ([1, batch, hidden]).
+                let h_3d_final_name = if direction == "both" && hidden_state_dim0 == 1 {
                     let h_3d_bidi_name = format!("{}_h_3d_bidi", op_name);
                     nodes.push(NodeProto {
                         input: vec![h_3d_name.clone(), h_3d_name.clone()],
@@ -6119,7 +6135,7 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     recurrent_weight_name.clone()
                 };
                 // ONNX LSTM initial_h / initial_c must be 3D [num_directions, batch_size, hidden_size] = [1, 2, 2].
-                let (h_3d_final_name, c_3d_final_name) = {
+                let (h_3d_final_name, c_3d_final_name, initial_h_dim0, initial_c_dim0) = {
                     let zero_h = format!("{}_initial_h_zero", op_name);
                     let zero_c = format!("{}_initial_c_zero", op_name);
                     initializers.push(Self::create_vector_initializer(
@@ -6152,6 +6168,25 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         .and_then(|id| graph.operand(id))
                         .map(|o| o.descriptor.shape.len())
                         .unwrap_or(2);
+                    // Per the WebNN spec, initialHiddenState/initialCellState are already
+                    // [numDirections, batchSize, hiddenSize]; a rank-3 state with dim0 > 1
+                    // already carries both directions and must not be duplicated below.
+                    let h_dim0 = if h_rank == 3 {
+                        initial_h_operand_id
+                            .and_then(|id| graph.operand(id))
+                            .map(|o| get_static_or_max_size(&o.descriptor.shape[0]))
+                            .unwrap_or(1)
+                    } else {
+                        1
+                    };
+                    let c_dim0 = if c_rank == 3 {
+                        initial_c_operand_id
+                            .and_then(|id| graph.operand(id))
+                            .map(|o| get_static_or_max_size(&o.descriptor.shape[0]))
+                            .unwrap_or(1)
+                    } else {
+                        1
+                    };
                     if h_rank == 3 {
                         nodes.push(NodeProto {
                             input: vec![h_name.clone()],
@@ -6186,43 +6221,50 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             ..Default::default()
                         });
                     }
-                    (h_3d_name.clone(), c_3d_name.clone())
+                    (h_3d_name.clone(), c_3d_name.clone(), h_dim0, c_dim0)
                 };
-                // For bidirectional, ONNX initial_h/initial_c must be [2, batch, hidden]. WebNN sends [1, batch, hidden]; duplicate on axis 0.
-                let (lstm_initial_h_name, lstm_initial_c_name) =
-                    if direction == "both" || direction == "bidirectional" {
-                        let h_bidi = format!("{}_initial_h_bidi", op_name);
-                        let c_bidi = format!("{}_initial_c_bidi", op_name);
-                        nodes.push(NodeProto {
-                            input: vec![h_3d_final_name.clone(), h_3d_final_name.clone()],
-                            output: vec![h_bidi.clone()],
-                            name: format!("{}_concat_initial_h", op_name),
-                            op_type: "Concat".to_string(),
-                            attribute: vec![AttributeProto {
-                                name: "axis".to_string(),
-                                r#type: AttributeType::Int as i32,
-                                i: 0,
-                                ..Default::default()
-                            }],
+                // For bidirectional, ONNX initial_h/initial_c must be [2, batch, hidden]. Per spec the
+                // caller already supplies [numDirections, batch, hidden]; only duplicate on axis 0 as a
+                // compat shim when the incoming state is single-direction ([1, batch, hidden]).
+                let is_bidirectional = direction == "both" || direction == "bidirectional";
+                let lstm_initial_h_name = if is_bidirectional && initial_h_dim0 == 1 {
+                    let h_bidi = format!("{}_initial_h_bidi", op_name);
+                    nodes.push(NodeProto {
+                        input: vec![h_3d_final_name.clone(), h_3d_final_name.clone()],
+                        output: vec![h_bidi.clone()],
+                        name: format!("{}_concat_initial_h", op_name),
+                        op_type: "Concat".to_string(),
+                        attribute: vec![AttributeProto {
+                            name: "axis".to_string(),
+                            r#type: AttributeType::Int as i32,
+                            i: 0,
                             ..Default::default()
-                        });
-                        nodes.push(NodeProto {
-                            input: vec![c_3d_final_name.clone(), c_3d_final_name.clone()],
-                            output: vec![c_bidi.clone()],
-                            name: format!("{}_concat_initial_c", op_name),
-                            op_type: "Concat".to_string(),
-                            attribute: vec![AttributeProto {
-                                name: "axis".to_string(),
-                                r#type: AttributeType::Int as i32,
-                                i: 0,
-                                ..Default::default()
-                            }],
+                        }],
+                        ..Default::default()
+                    });
+                    h_bidi
+                } else {
+                    h_3d_final_name
+                };
+                let lstm_initial_c_name = if is_bidirectional && initial_c_dim0 == 1 {
+                    let c_bidi = format!("{}_initial_c_bidi", op_name);
+                    nodes.push(NodeProto {
+                        input: vec![c_3d_final_name.clone(), c_3d_final_name.clone()],
+                        output: vec![c_bidi.clone()],
+                        name: format!("{}_concat_initial_c", op_name),
+                        op_type: "Concat".to_string(),
+                        attribute: vec![AttributeProto {
+                            name: "axis".to_string(),
+                            r#type: AttributeType::Int as i32,
+                            i: 0,
                             ..Default::default()
-                        });
-                        (h_bidi, c_bidi)
-                    } else {
-                        (h_3d_final_name, c_3d_final_name)
-                    };
+                        }],
+                        ..Default::default()
+                    });
+                    c_bidi
+                } else {
+                    c_3d_final_name
+                };
                 let lstm_y_name = format!("{}_y", op_name);
                 let lstm_y_h_name = format!("{}_y_h", op_name);
                 let lstm_y_c_name = format!("{}_y_c", op_name);
@@ -6338,8 +6380,13 @@ impl crate::converters::GraphConverter for OnnxConverter {
                     }
                 } else {
                     // WPT: lstmOutput1 = Y_h, lstmOutput2 = Y_c, lstmOutput3 = sequence (Y).
+                    // Graphs that don't use that naming convention fall back to positional
+                    // WebNN spec order: outputs[0] = Y_h, outputs[1] = Y_c, outputs[2] = Y
+                    // (sequence, only present when returnSequence). Without this fallback,
+                    // Y_h/Y_c were silently dropped for any non-WPT-named output (bug: graph
+                    // output declared but no node produces it).
                     // Use out_id in node name so each Identity has a unique name.
-                    for &out_id in output_ids.iter().take(3) {
+                    for (pos, &out_id) in output_ids.iter().enumerate().take(3) {
                         let out_name = operand_name(graph, out_id);
                         let (src_name, label) = if out_name.contains("Output1") {
                             // WPT lstmOutput1 = hidden state (Y_h).
@@ -6347,10 +6394,8 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         } else if out_name.contains("Output2") {
                             // WPT lstmOutput2 = cell state (Y_c).
                             (lstm_y_c_name.clone(), "y_c")
-                        } else if out_name.contains("Output3")
-                            || (output_ids.len() >= 3 && out_id == output_ids[2])
-                        {
-                            // WPT lstmOutput3 = sequence (Y) when returnSequence is true.
+                        } else if out_name.contains("Output3") || pos == 2 {
+                            // lstmOutput3, or positional fallback: sequence (Y) when returnSequence is true.
                             if unidirectional {
                                 let seq_4d_name = format!("{}_y_seq_4d", op_name);
                                 nodes.push(NodeProto {
@@ -6364,6 +6409,12 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             } else {
                                 (seq_source.clone(), "y_seq")
                             }
+                        } else if pos == 0 {
+                            // Positional fallback: WebNN spec order puts hidden state (Y_h) first.
+                            (lstm_y_h_name.clone(), "y")
+                        } else if pos == 1 {
+                            // Positional fallback: WebNN spec order puts cell state (Y_c) second.
+                            (lstm_y_c_name.clone(), "y_c")
                         } else {
                             continue;
                         };
@@ -10333,6 +10384,7 @@ mod tests {
     use crate::graph::{
         DataType, Dimension, DynamicDimension, GraphInfo, Operand, OperandDescriptor, OperandKind,
     };
+    use crate::operator_options::MLLstmOptions;
     #[cfg(feature = "dynamic-inputs")]
     use crate::operator_options::OperatorOptions;
     use crate::operators::Operation;
@@ -11929,6 +11981,150 @@ mod tests {
             gp.node.iter().any(|n| n.name.contains("split_p")),
             "peephole path must split peephole weights"
         );
+    }
+
+    /// LSTM_BIDI_EXPORTER_BUGS.md bug 1: spec-shape [numDirections, batch, hidden]
+    /// initial states must not be duplicated on axis 0 for direction "both".
+    #[test]
+    fn test_lstm_bidirectional_spec_shape_initial_state_not_duplicated() {
+        let operands = vec![
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 1, 3]),
+                    pending_permutation: vec![],
+                },
+                name: Some("input".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 16, 3]),
+                    pending_permutation: vec![],
+                },
+                name: Some("weight".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 16, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("recurrent_weight".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    // Already spec-shaped [numDirections=2, batch=1, hidden=4].
+                    shape: s(&[2, 1, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("initial_h".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 1, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("initial_c".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 1, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("Y_h".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 1, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("Y_c".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: s(&[2, 2, 1, 4]),
+                    pending_permutation: vec![],
+                },
+                name: Some("Y".to_string()),
+            },
+        ];
+
+        let operations = vec![Operation::Lstm {
+            input: 0,
+            weight: 1,
+            recurrence: 2,
+            steps: 2,
+            hidden_size: 4,
+            options: Some(MLLstmOptions {
+                label: String::new(),
+                bias: None,
+                recurrent_bias: None,
+                peephole_weight: None,
+                initial_hidden_state: Some(3),
+                initial_cell_state: Some(4),
+                return_sequence: true,
+                direction: "both".to_string(),
+                layout: String::new(),
+                activations: None,
+            }),
+            outputs: vec![5, 6, 7],
+        }];
+
+        let graph = GraphInfo {
+            operands,
+            input_operands: vec![0, 1, 2, 3, 4],
+            output_operands: vec![5, 6, 7],
+            operations,
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model =
+            ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice()).unwrap();
+        let gp = model.graph.unwrap();
+
+        // Bug 1: spec-shaped [2, batch, hidden] initial states must pass through unduplicated.
+        assert!(
+            !gp.node
+                .iter()
+                .any(|n| n.name.contains("_concat_initial_h")
+                    || n.name.contains("_concat_initial_c")),
+            "already-bidirectional initial states must not be duplicated on axis 0"
+        );
+        let lstm_node = gp
+            .node
+            .iter()
+            .find(|n| n.op_type == "LSTM")
+            .expect("LSTM node present");
+        // Without duplication, initial_h/initial_c reach LSTM straight from the pass-through
+        // Identity nodes (lstm_0_h_3d / lstm_0_c_3d), not a Concat-doubled tensor.
+        assert_eq!(lstm_node.input[5], "lstm_0_h_3d");
+        assert_eq!(lstm_node.input[6], "lstm_0_c_3d");
+
+        // Bug 2: Y_h/Y_c/Y graph outputs must not be dropped for non-WPT-named outputs.
+        for expected in ["Y_h", "Y_c", "Y"] {
+            assert!(
+                gp.node
+                    .iter()
+                    .any(|n| n.output.iter().any(|o| o == expected)),
+                "graph output {expected} must be produced by some node"
+            );
+        }
     }
 
     #[cfg(feature = "onnx-runtime")]

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -5024,34 +5024,29 @@ impl crate::converters::GraphConverter for OnnxConverter {
                             Self::invalid_operand("where true input", *true_id, Some((op, idx)))
                         })?;
 
-                    let true_cast_name = format!("{}_true_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_true_{}", op_name, cast_counter),
-                        inputs[1].clone(),
-                        true_cast_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs[1] = true_cast_name;
+                    // target_type is the true input's dtype, so only the false input
+                    // may need a cast. Identity casts must be avoided: ORT's fp16
+                    // InsertedPrecisionFreeCast transform mishandles f16->f16 casts
+                    // feeding Where when optimizations are disabled.
+                    let false_operand = graph.operand(*false_id).ok_or_else(|| {
+                        Self::invalid_operand("where false input", *false_id, Some((op, idx)))
+                    })?;
 
-                    // Validate false operand exists for clearer converter errors.
-                    if graph.operand(*false_id).is_none() {
-                        return Err(Self::invalid_operand(
-                            "where false input",
-                            *false_id,
-                            Some((op, idx)),
+                    let false_type = type_overrides
+                        .get(false_id)
+                        .copied()
+                        .unwrap_or(false_operand.descriptor.data_type);
+                    if false_type != target_type {
+                        let false_cast_name = format!("{}_false_cast_{}", op_name, cast_counter);
+                        nodes.push(Self::create_cast_node(
+                            &format!("{}_cast_false_{}", op_name, cast_counter),
+                            inputs[2].clone(),
+                            false_cast_name.clone(),
+                            Self::data_type_code(target_type),
                         ));
+                        cast_counter += 1;
+                        inputs[2] = false_cast_name;
                     }
-
-                    let false_cast_name = format!("{}_false_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_false_{}", op_name, cast_counter),
-                        inputs[2].clone(),
-                        false_cast_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs[2] = false_cast_name;
 
                     if let Some(output_id) = op.output_operand() {
                         type_overrides.insert(output_id, target_type);
@@ -9611,37 +9606,37 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         .ok_or_else(|| {
                             Self::invalid_operand("where true input", true_id, Some((op, idx)))
                         })?;
-                    if graph.operand(false_id).is_none() {
-                        return Err(Self::invalid_operand(
-                            "where false input",
-                            false_id,
-                            Some((op, idx)),
-                        ));
-                    }
+                    let false_operand = graph.operand(false_id).ok_or_else(|| {
+                        Self::invalid_operand("where false input", false_id, Some((op, idx)))
+                    })?;
 
                     let target_type = true_type;
 
-                    let true_input_name = operand_name(graph, true_id);
-                    let true_cast_output_name = format!("{}_true_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_true_{}", op_name, cast_counter),
-                        true_input_name,
-                        true_cast_output_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs.push(true_cast_output_name);
+                    // target_type is the true input's dtype, so only the false input
+                    // may need a cast. Identity casts must be avoided: ORT's fp16
+                    // InsertedPrecisionFreeCast transform mishandles f16->f16 casts
+                    // feeding Where when optimizations are disabled.
+                    inputs.push(operand_name(graph, true_id));
 
+                    let false_type = type_overrides
+                        .get(&false_id)
+                        .copied()
+                        .unwrap_or(false_operand.descriptor.data_type);
                     let false_input_name = operand_name(graph, false_id);
-                    let false_cast_output_name = format!("{}_false_cast_{}", op_name, cast_counter);
-                    cast_counter += 1;
-                    nodes.push(Self::create_cast_node(
-                        &format!("{}_cast_false_{}", op_name, cast_counter),
-                        false_input_name,
-                        false_cast_output_name.clone(),
-                        Self::data_type_code(target_type),
-                    ));
-                    inputs.push(false_cast_output_name);
+                    if false_type != target_type {
+                        let false_cast_output_name =
+                            format!("{}_false_cast_{}", op_name, cast_counter);
+                        nodes.push(Self::create_cast_node(
+                            &format!("{}_cast_false_{}", op_name, cast_counter),
+                            false_input_name,
+                            false_cast_output_name.clone(),
+                            Self::data_type_code(target_type),
+                        ));
+                        cast_counter += 1;
+                        inputs.push(false_cast_output_name);
+                    } else {
+                        inputs.push(false_input_name);
+                    }
 
                     let output_operand_id = op
                         .output_operand()
@@ -10861,6 +10856,86 @@ mod tests {
         let converter = OnnxConverter;
         let result = converter.convert(&graph);
         result.unwrap();
+    }
+
+    #[test]
+    fn test_where_same_dtype_inputs_emit_no_value_casts() {
+        // Identity casts on Where value inputs break ORT fp16 graphs at
+        // GraphOptimizationLevel::Disable (InsertedPrecisionFreeCast quirk).
+        let operands = vec![
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Uint8,
+                    shape: s(&[2]),
+                    pending_permutation: vec![],
+                },
+                name: Some("cond".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float16,
+                    shape: s(&[2]),
+                    pending_permutation: vec![],
+                },
+                name: Some("t".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float16,
+                    shape: s(&[2]),
+                    pending_permutation: vec![],
+                },
+                name: Some("f".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float16,
+                    shape: s(&[2]),
+                    pending_permutation: vec![],
+                },
+                name: Some("out".to_string()),
+            },
+        ];
+
+        let operations = vec![Operation::Where {
+            condition: 0,
+            true_value: 1,
+            false_value: 2,
+            options: None,
+            outputs: vec![3],
+        }];
+
+        let graph = GraphInfo {
+            operands,
+            input_operands: vec![0, 1, 2],
+            output_operands: vec![3],
+            operations,
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model =
+            ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice()).unwrap();
+        let gp = model.graph.unwrap();
+
+        let where_node = gp
+            .node
+            .iter()
+            .find(|n| n.op_type == "Where")
+            .expect("Where node present");
+        assert_eq!(where_node.input[1], "t");
+        assert_eq!(where_node.input[2], "f");
+        assert!(
+            !gp.node
+                .iter()
+                .any(|n| n.name.contains("_cast_true_") || n.name.contains("_cast_false_")),
+            "same-dtype Where value inputs must not get identity casts",
+        );
     }
 
     #[cfg(not(feature = "dynamic-inputs"))]

--- a/src/converters/onnx.rs
+++ b/src/converters/onnx.rs
@@ -9250,9 +9250,14 @@ impl crate::converters::GraphConverter for OnnxConverter {
                         .static_or_max_shape()
                 });
 
-                // Get axes from typed options (unsqueeze). Typed options required.
+                // Get axes from typed options. Empty axes stay axes-less: for Squeeze that
+                // means "remove all unit dims" per ONNX semantics.
                 let axes_i64 = match &op {
                     Operation::Unsqueeze { options, .. } => options
+                        .as_ref()
+                        .filter(|o| !o.axes.is_empty())
+                        .map(|o| o.axes.iter().map(|&u| u as i64).collect::<Vec<i64>>()),
+                    Operation::Squeeze { options, .. } => options
                         .as_ref()
                         .filter(|o| !o.axes.is_empty())
                         .map(|o| o.axes.iter().map(|&u| u as i64).collect::<Vec<i64>>()),
@@ -11471,6 +11476,83 @@ mod tests {
             !gp.node.iter().any(|n| n.name.ends_with("_scalar_reshape")),
             "unsqueeze-tracked tensors should not be treated as scalars before expand",
         );
+    }
+
+    #[test]
+    fn test_squeeze_with_axes_emits_axes_input() {
+        // Regression: squeeze(input [1,2,1,3], axes=[2]) must export an ONNX Squeeze
+        // with an explicit axes input. An axes-less Squeeze removes ALL unit dims,
+        // silently changing the output shape from [1,2,3] to [2,3].
+        let operands = vec![
+            Operand {
+                kind: OperandKind::Input,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: vec![
+                        Dimension::Static(1),
+                        Dimension::Static(2),
+                        Dimension::Static(1),
+                        Dimension::Static(3),
+                    ],
+                    pending_permutation: vec![],
+                },
+                name: Some("input".to_string()),
+            },
+            Operand {
+                kind: OperandKind::Output,
+                descriptor: OperandDescriptor {
+                    data_type: DataType::Float32,
+                    shape: vec![
+                        Dimension::Static(1),
+                        Dimension::Static(2),
+                        Dimension::Static(3),
+                    ],
+                    pending_permutation: vec![],
+                },
+                name: Some("squeezed".to_string()),
+            },
+        ];
+
+        let operations = vec![Operation::Squeeze {
+            input: 0,
+            options: Some(crate::operator_options::MLSqueezeOptions {
+                label: String::new(),
+                axes: vec![2],
+            }),
+            outputs: vec![1],
+        }];
+
+        let graph = GraphInfo {
+            operands,
+            input_operands: vec![0],
+            output_operands: vec![1],
+            operations,
+            constant_operand_ids_to_handles: HashMap::new(),
+            id_to_constant_tensor_operand_map: HashMap::new(),
+            quantized: false,
+        };
+
+        let model =
+            ModelProto::decode(OnnxConverter.convert(&graph).unwrap().data.as_slice()).unwrap();
+        let gp = model.graph.unwrap();
+
+        let squeeze_node = gp
+            .node
+            .iter()
+            .find(|n| n.op_type == "Squeeze")
+            .expect("Squeeze node present");
+        assert_eq!(
+            squeeze_node.input.len(),
+            2,
+            "Squeeze with explicit axes must carry a second (axes) input, got {:?}",
+            squeeze_node.input
+        );
+        let axes_init = gp
+            .initializer
+            .iter()
+            .find(|t| t.name == squeeze_node.input[1])
+            .expect("axes initializer present");
+        assert_eq!(axes_init.int64_data, vec![2]);
     }
 
     #[cfg(feature = "dynamic-inputs")]

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -244,10 +244,13 @@ impl TrtxConverter {
     /// Their values cannot influence outputs, so skipping them is always sound,
     /// including for cached engines.
     pub fn unused_constant_operand_ids(graph: &GraphInfo) -> HashSet<u32> {
+        // Option operands (gemm.c, normalization scale/bias, RNN biases and
+        // states) count as consumers: a constant wrongly classified as dead is
+        // baked into the engine and then served stale to every cached build.
         let consumed: HashSet<u32> = graph
             .operations
             .iter()
-            .flat_map(|op| op.input_operands().to_vec())
+            .flat_map(|op| op.all_input_operands())
             .collect();
         graph
             .operands
@@ -531,7 +534,7 @@ impl TrtxConverter {
 
     /// Cast BOOL tensor to Uint8 (false → 0, true → 1) per WebNN logical/comparison output type.
     ///
-    /// TensorRT 3.16+ restricts internal `kUINT8` to network I/O and DQ outputs; comparison only
+    /// TensorRT restricts internal `kUINT8` to network I/O and DQ outputs; comparison only
     /// produces 0/1, so we emit `kINT8` (WebNN-compatible for this value range).
     fn cast_bool_to_uint8<'a>(
         network: &mut trtx::NetworkDefinition<'a>,
@@ -572,7 +575,7 @@ impl TrtxConverter {
 
     /// Promote uint8/int8 mask operands to float32 before TRT shuffle/resize/identity.
     ///
-    /// TensorRT 3.16+ allows UINT8 only at network I/O, not on internal broadcast ops.
+    /// TensorRT allows UINT8 only at network I/O, not on internal broadcast ops.
     /// Returns a promoted tensor when needed; callers use `promoted.as_ref().unwrap_or(input)`.
     fn promote_mask_for_trt_broadcast<'a>(
         graph: &GraphInfo,
@@ -685,8 +688,8 @@ impl TrtxConverter {
 
     /// Materialize a computed uint8 value held in a float/int32 tensor. Graph
     /// outputs become kUINT8 (legal at network I/O and matching the binding's
-    /// byte layout); internal tensors stay kINT32 because TensorRT (>= 3.16)
-    /// rejects a Cast-produced kUINT8 tensor anywhere else. Consumers read the
+    /// byte layout); internal tensors stay kINT32 because TensorRT rejects a
+    /// Cast-produced kUINT8 tensor anywhere else. Consumers read the
     /// WebNN dtype and cast from whatever storage they find (`add_cast_op`, the
     /// manual dequantize path, `cast_uint8_to_int32`).
     fn store_uint8_result<'a>(
@@ -1852,7 +1855,7 @@ impl TrtxConverter {
     /// Add logical operation: broadcast inputs, cast to BOOL, elementwise kAND/kOR/kXOR, Uint8 output.
     ///
     /// TensorRT elementwise `kAND` / `kOR` / `kXOR` require BOOL inputs. [`ensure_broadcast_compatible`]
-    /// uses shuffle/resize, which reject internal UINT8/INT8 (TRT 3.16+), so mask operands are
+    /// uses shuffle/resize, which reject internal UINT8/INT8, so mask operands are
     /// promoted to Float32 before broadcast, then cast to BOOL.
     fn add_logical_binary_op<'a>(
         graph: &GraphInfo,
@@ -3127,7 +3130,7 @@ impl TrtxConverter {
             return Ok(());
         }
 
-        // TensorRT (>= 3.16) rejects internal kUINT8 tensors unless a Constant or
+        // TensorRT rejects internal kUINT8 tensors unless a Constant or
         // Dequantize layer produces them, and int8 tensors may only feed DQ. An
         // integer tensor narrowed to int8/uint8/int4/uint4 solely to be dequantized
         // (packed-weight unpacking: GatherBlockQuantized nibbles, MatMulNBits) or to
@@ -3181,7 +3184,7 @@ impl TrtxConverter {
         // Non-int8/uint8 or scalar promoted: direct cast.
         let mut trt_dtype = Self::webnn_to_trt_dtype(target_dtype)?;
         // Internal uint8 tensors follow the converter's mask convention and are
-        // stored as kINT8 (see `cast_bool_to_uint8`): TensorRT (>= 3.16) rejects a
+        // stored as kINT8 (see `cast_bool_to_uint8`): TensorRT rejects a
         // Cast-produced kUINT8 tensor that is not network I/O, and Shuffle accepts
         // Int8 but not UInt8. Consumers read the WebNN dtype and reinterpret.
         // Graph outputs keep kUINT8 so the binding's byte layout is exact.
@@ -11042,7 +11045,7 @@ impl TrtxConverter {
                 .all(|wi| pre_padding[wi] == 0 && post_padding[wi] == 0)
         };
 
-        // `IPaddingLayer` / 4D shuffle path rejects UINT8, INT32, INT64 (TRT 3.16+).
+        // `IPaddingLayer` / 4D shuffle path rejects UINT8, INT32, INT64.
         let input_trt_dtype = input.get_type(&*network);
         let ipadding_dtype_ok = Self::trtx_ipadding_layer_supports_dtype(input_trt_dtype);
 
@@ -11057,7 +11060,7 @@ impl TrtxConverter {
             let in_id = operation.input_operands()[0];
             let out_id = operation.output_operands_slice()[0];
 
-            // UINT8 internal concat tensors do not expose dimensions (TRT 3.16+); pad via INT32.
+            // UINT8 internal concat tensors do not expose dimensions; pad via INT32.
             let uint8_i32_holder;
             let (start_key, pad_via_int32) = if input_trt_dtype == TrtDataType::kUINT8 {
                 let i32_in = Self::cast_uint8_to_int32(network, input)?;
@@ -15273,6 +15276,51 @@ mod tests {
         let m = TrtxConverter::engine_io_binding_names(&graph);
         assert_eq!(m.get(&0).map(String::as_str), Some("lhs"));
         assert_eq!(m.get(&2).map(String::as_str), Some("sum"));
+    }
+
+    #[test]
+    fn test_unused_constants_count_option_operands_as_consumers() {
+        use crate::graph::to_dimension_vector;
+        use crate::graph::{Operand, OperandDescriptor, OperandKind};
+        use crate::operator_options::MLGemmOptions;
+        use crate::operators::Operation;
+        let desc = OperandDescriptor {
+            data_type: DataType::Float32,
+            shape: to_dimension_vector(&[2, 2]),
+            pending_permutation: vec![],
+        };
+        let operand = |kind: OperandKind| Operand {
+            kind,
+            descriptor: desc.clone(),
+            name: None,
+        };
+        let graph = GraphInfo {
+            operands: vec![
+                operand(OperandKind::Input),
+                operand(OperandKind::Constant),
+                operand(OperandKind::Constant),
+                operand(OperandKind::Output),
+                operand(OperandKind::Constant),
+            ],
+            input_operands: vec![0],
+            output_operands: vec![3],
+            operations: vec![Operation::Gemm {
+                a: 0,
+                b: 1,
+                options: Some(MLGemmOptions {
+                    c: Some(2),
+                    ..Default::default()
+                }),
+                outputs: vec![3],
+            }],
+            constant_operand_ids_to_handles: Default::default(),
+            id_to_constant_tensor_operand_map: Default::default(),
+            quantized: false,
+        };
+        let unused = TrtxConverter::unused_constant_operand_ids(&graph);
+        assert!(!unused.contains(&1), "positional constant b is consumed");
+        assert!(!unused.contains(&2), "option constant c is consumed");
+        assert!(unused.contains(&4), "dangling constant is dead");
     }
 
     #[test]

--- a/src/converters/trtx.rs
+++ b/src/converters/trtx.rs
@@ -198,6 +198,68 @@ impl TrtxConverter {
         cast_to_i32 == 1
     }
 
+    /// True when every consumer of `operand_id` is a `cast` (and there is at least one).
+    fn constant_only_feeds_casts(graph: &GraphInfo, operand_id: u32) -> bool {
+        let mut consumers = graph
+            .operations
+            .iter()
+            .filter(|op| op.input_operands().contains(&operand_id))
+            .peekable();
+        consumers.peek().is_some() && consumers.all(|op| op.op_type() == "cast")
+    }
+
+    /// True when `operand_id` is an int8/uint8/int4/uint4 constant with a consumer
+    /// other than quantizeLinear/dequantizeLinear (gather data, a uint8 mask that is
+    /// reshaped/expanded, integer arithmetic, ...). TensorRT's
+    /// QuantizedConstantValidator only allows kINT8/kINT4 constants directly before a
+    /// DQ or plugin, so such constants are widened to kINT32 (TRT's own suggestion for
+    /// non-quantized integer constants). Zero points stay kINT8: the Q/DQ paths run
+    /// them through an identity DQ, which is the accepted Constant -> DQ shape.
+    fn int8_family_constant_needs_int32_storage(graph: &GraphInfo, operand_id: u32) -> bool {
+        let Some(operand) = graph.operand(operand_id) else {
+            return false;
+        };
+        if operand.kind != OperandKind::Constant
+            || !matches!(
+                operand.descriptor.data_type,
+                DataType::Int8 | DataType::Uint8 | DataType::Int4 | DataType::Uint4
+            )
+        {
+            return false;
+        }
+        graph.operations.iter().any(|op| {
+            op.input_operands().contains(&operand_id)
+                && !matches!(
+                    op,
+                    Operation::DequantizeLinear { .. } | Operation::QuantizeLinear { .. }
+                )
+        })
+    }
+
+    /// Constants no operation consumes. onnx2webnn registers every ONNX
+    /// initializer eagerly and some lowerings read them at conversion time
+    /// (Range bounds, GQA sequence lengths, pinned If gates), leaving dead
+    /// constants. TensorRT eliminates the dead constant layers, so they must not
+    /// be marked refittable nor refitted ("The weights cannot be refitted").
+    /// Their values cannot influence outputs, so skipping them is always sound,
+    /// including for cached engines.
+    pub fn unused_constant_operand_ids(graph: &GraphInfo) -> HashSet<u32> {
+        let consumed: HashSet<u32> = graph
+            .operations
+            .iter()
+            .flat_map(|op| op.input_operands().to_vec())
+            .collect();
+        graph
+            .operands
+            .iter()
+            .enumerate()
+            .filter(|(id, operand)| {
+                operand.kind == OperandKind::Constant && !consumed.contains(&(*id as u32))
+            })
+            .map(|(id, _)| id as u32)
+            .collect()
+    }
+
     /// Parse WPT bigint / JSON integer clamp bound, saturating to `i64` range.
     fn parse_clamp_i64_bound(v: &serde_json::Value, default: i64) -> i64 {
         if let Some(s) = v.as_str() {
@@ -621,6 +683,43 @@ impl TrtxConverter {
             })
     }
 
+    /// Materialize a computed uint8 value held in a float/int32 tensor. Graph
+    /// outputs become kUINT8 (legal at network I/O and matching the binding's
+    /// byte layout); internal tensors stay kINT32 because TensorRT (>= 3.16)
+    /// rejects a Cast-produced kUINT8 tensor anywhere else. Consumers read the
+    /// WebNN dtype and cast from whatever storage they find (`add_cast_op`, the
+    /// manual dequantize path, `cast_uint8_to_int32`).
+    fn store_uint8_result<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        output_id: u32,
+        value: &trtx::Tensor<'a>,
+    ) -> Result<trtx::Tensor<'a>, GraphError> {
+        let is_graph_output = graph
+            .operand(output_id)
+            .is_some_and(|o| o.kind == OperandKind::Output);
+        if is_graph_output {
+            return Self::cast_int32_to_uint8(network, value);
+        }
+        let map_err = |e: trtx::Error| GraphError::ConversionFailed {
+            format: "trtx".to_string(),
+            reason: format!("uint8 result as int32 storage: {e}"),
+        };
+        if value.get_type(&*network) == TrtDataType::kINT32 {
+            network
+                .add_identity(value)
+                .map_err(map_err)?
+                .output(&*network, 0)
+                .map_err(map_err)
+        } else {
+            network
+                .add_cast(value, TrtDataType::kINT32)
+                .map_err(map_err)?
+                .output(&*network, 0)
+                .map_err(map_err)
+        }
+    }
+
     /// Cast INT32 tensor to INT64 (WebNN argMin/argMax `outputDataType: int64`).
     fn cast_int32_to_int64<'a>(
         network: &mut trtx::NetworkDefinition<'a>,
@@ -679,9 +778,13 @@ impl TrtxConverter {
                 ids.insert(id as u32);
             }
         }
+        // TensorRT folds `Cast(constant)` into a new constant, so a constant whose
+        // consumers are all casts loses its refit prototype ("The weights cannot be
+        // refitted"); e.g. a scalar fp16 epsilon cast to float32 in every layer norm.
         for (id, operand) in graph.operands.iter().enumerate() {
             if operand.kind == OperandKind::Constant
-                && Self::integer_constant_only_casts_to_int32(graph, id as u32)
+                && (Self::integer_constant_only_casts_to_int32(graph, id as u32)
+                    || Self::constant_only_feeds_casts(graph, id as u32))
             {
                 ids.insert(id as u32);
             }
@@ -879,7 +982,8 @@ impl TrtxConverter {
                 );
 
                 let promote_integer_cast_i32 =
-                    Self::integer_constant_only_casts_to_int32(graph, operand_id as u32);
+                    Self::integer_constant_only_casts_to_int32(graph, operand_id as u32)
+                        || Self::int8_family_constant_needs_int32_storage(graph, operand_id as u32);
 
                 // TensorRT add_constant does not support kINT64; bake int64/uint64 via add_small_constant_copied.
                 let promote_wide_int = matches!(
@@ -926,11 +1030,21 @@ impl TrtxConverter {
                             ),
                         }
                     })?;
-                    let i32_bytes = Self::int8_uint8_bytes_to_int32_le(
-                        data,
-                        operand.descriptor.data_type,
-                        element_count,
-                    );
+                    let i32_bytes: Vec<u8> = match operand.descriptor.data_type {
+                        DataType::Int4 => unpack_int4(data, element_count)
+                            .into_iter()
+                            .flat_map(|v| (v as i32).to_le_bytes())
+                            .collect(),
+                        DataType::Uint4 => unpack_uint4(data, element_count)
+                            .into_iter()
+                            .flat_map(|v| (v as i32).to_le_bytes())
+                            .collect(),
+                        _ => Self::int8_uint8_bytes_to_int32_le(
+                            data,
+                            operand.descriptor.data_type,
+                            element_count,
+                        ),
+                    };
                     non_refittable_constants.insert(operand_id as u32);
                     network.add_small_constant_copied(
                         &add_dims,
@@ -1007,6 +1121,16 @@ impl TrtxConverter {
                         reason: format!("Output operand {} not found in tensor map", operand_id),
                     }
                 })?;
+
+                // Computed uint8 values travel as kINT32 internally (see
+                // `store_uint8_result`); a network output may be kUINT8 and the
+                // binding expects one byte per element.
+                let expected = Self::webnn_to_trt_dtype(operand.descriptor.data_type)?;
+                if expected == TrtDataType::kUINT8
+                    && tensor.get_type(&*network) == TrtDataType::kINT32
+                {
+                    *tensor = Self::cast_int32_to_uint8(network, tensor)?;
+                }
 
                 let trt_io_name = io_binding_names
                     .get(&(operand_id as u32))
@@ -1210,8 +1334,8 @@ impl TrtxConverter {
             // Shape manipulation operations
             "slice" => Self::add_slice_op(network, tensor_map, operation)?,
             "split" => Self::add_split_op(network, tensor_map, operation)?,
-            "squeeze" => Self::add_squeeze_op(network, tensor_map, operation)?,
-            "unsqueeze" => Self::add_unsqueeze_op(network, tensor_map, operation)?,
+            "squeeze" => Self::add_squeeze_op(graph, network, tensor_map, operation)?,
+            "unsqueeze" => Self::add_unsqueeze_op(graph, network, tensor_map, operation)?,
             "expand" => Self::add_expand_op(graph, network, tensor_map, operation)?,
             "tile" => Self::add_tile_op(network, tensor_map, operation)?,
 
@@ -1524,19 +1648,26 @@ impl TrtxConverter {
                 });
         }
 
-        let mut resize_layer =
-            network
-                .add_resize(cur)
-                .map_err(|e| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: format!("{op_label} broadcast resize: {e}"),
-                })?;
-        resize_layer.set_output_dimensions(network, target_dims);
-        resize_layer
+        // Broadcast via a stride-0 Slice (same construction as add_expand_op):
+        // ISliceLayer preserves the element type (int32/int64 included), whereas
+        // IResizeLayer rejects integer inputs.
+        let start: Vec<i64> = vec![0i64; target_dims.len()];
+        let stride: Vec<i64> = dims
+            .iter()
+            .zip(target_dims.iter())
+            .map(|(&d, &t)| if d == t { 1 } else { 0 })
+            .collect();
+        let slice_layer = network
+            .add_slice(cur, &start, target_dims, &stride)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("{op_label} broadcast slice: {e}"),
+            })?;
+        slice_layer
             .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("{op_label} broadcast resize output: {e}"),
+                reason: format!("{op_label} broadcast slice output: {e}"),
             })
     }
 
@@ -1653,9 +1784,8 @@ impl TrtxConverter {
                 format: "trtx".to_string(),
                 reason: format!("Failed to get UINT8 elementwise output: {}", e),
             })?;
-        let output = Self::cast_int32_to_uint8(network, &i32_out)?;
-
         let output_id = operation.output_operands_slice()[0];
+        let output = Self::store_uint8_result(graph, network, output_id, &i32_out)?;
         tensor_map.insert(output_id, output);
         Ok(())
     }
@@ -2927,20 +3057,21 @@ impl TrtxConverter {
                     });
                 }
             };
-            let output = if input.get_type(&*network) == TrtDataType::kUINT8 {
-                match fp_trt {
-                    TrtDataType::kFLOAT => Self::cast_to_float32(network, input)?,
-                    TrtDataType::kHALF => Self::cast_to_float16(network, input)?,
-                    _ => unreachable!(),
-                }
-            } else {
-                Self::trtx_int8_uint8_identity_dequantize(
+            let output = match input.get_type(&*network) {
+                TrtDataType::kINT8 => Self::trtx_int8_uint8_identity_dequantize(
                     network,
                     input,
                     fp_trt,
                     "cast integer to float",
                     input_dtype,
-                )?
+                )?,
+                // kUINT8 (network input) or an already widened storage type
+                // (int32/float mask promoted upstream): a plain cast is exact.
+                _ => match fp_trt {
+                    TrtDataType::kFLOAT => Self::cast_to_float32(network, input)?,
+                    TrtDataType::kHALF => Self::cast_to_float16(network, input)?,
+                    _ => unreachable!(),
+                },
             };
             tensor_map.insert(output_id, output);
             return Ok(());
@@ -2996,8 +3127,67 @@ impl TrtxConverter {
             return Ok(());
         }
 
+        // TensorRT (>= 3.16) rejects internal kUINT8 tensors unless a Constant or
+        // Dequantize layer produces them, and int8 tensors may only feed DQ. An
+        // integer tensor narrowed to int8/uint8/int4/uint4 solely to be dequantized
+        // (packed-weight unpacking: GatherBlockQuantized nibbles, MatMulNBits) or to
+        // serve as a quantize/dequantize zero point (DynamicQuantizeLinear) can skip
+        // the cast: both manual paths cast any integer input to float, and the values
+        // are integral and in range by construction.
+        let narrow_int_target = matches!(
+            target_dtype,
+            DataType::Int8 | DataType::Uint8 | DataType::Int4 | DataType::Uint4
+        );
+        let input_is_wide_int = matches!(
+            input.get_type(&*network),
+            TrtDataType::kINT32 | TrtDataType::kINT64
+        );
+        if narrow_int_target && input_is_wide_int && output_operand.kind != OperandKind::Output {
+            let mut consumers = graph
+                .operations
+                .iter()
+                .filter(|op| op.input_operands().contains(&output_id))
+                .peekable();
+            let only_dequantize_input = consumers.peek().is_some()
+                && consumers.all(|op| {
+                    let ins = op.input_operands();
+                    let is_zero_point = ins.get(2) == Some(&output_id) && ins[1] != output_id;
+                    match op {
+                        Operation::DequantizeLinear { .. } => {
+                            (ins.first() == Some(&output_id) && !ins[1..].contains(&output_id))
+                                || (is_zero_point && ins[0] != output_id)
+                        }
+                        Operation::QuantizeLinear { .. } => is_zero_point && ins[0] != output_id,
+                        _ => false,
+                    }
+                });
+            if only_dequantize_input {
+                let output = network
+                    .add_identity(input)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("cast to {target_dtype:?} before dequantize: {e}"),
+                    })?
+                    .output(&*network, 0)
+                    .map_err(|e| GraphError::ConversionFailed {
+                        format: "trtx".to_string(),
+                        reason: format!("cast to {target_dtype:?} before dequantize output: {e}"),
+                    })?;
+                tensor_map.insert(output_id, output);
+                return Ok(());
+            }
+        }
+
         // Non-int8/uint8 or scalar promoted: direct cast.
-        let trt_dtype = Self::webnn_to_trt_dtype(target_dtype)?;
+        let mut trt_dtype = Self::webnn_to_trt_dtype(target_dtype)?;
+        // Internal uint8 tensors follow the converter's mask convention and are
+        // stored as kINT8 (see `cast_bool_to_uint8`): TensorRT (>= 3.16) rejects a
+        // Cast-produced kUINT8 tensor that is not network I/O, and Shuffle accepts
+        // Int8 but not UInt8. Consumers read the WebNN dtype and reinterpret.
+        // Graph outputs keep kUINT8 so the binding's byte layout is exact.
+        if target_dtype == DataType::Uint8 && output_operand.kind != OperandKind::Output {
+            trt_dtype = TrtDataType::kINT8;
+        }
 
         let layer =
             network
@@ -3576,6 +3766,21 @@ impl TrtxConverter {
         webnn_integer_dtype: DataType,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         let input_ty = tensor.get_type(&*network);
+        // IDequantizeLayer rejects kUINT8 inputs (only FP8/FP4/INT4/INT8). A plain
+        // Cast is a legal kUINT8 consumer and exact for 0..255; the values are
+        // already unsigned, so no sign-reinterpret fixup applies.
+        if input_ty == TrtDataType::kUINT8 {
+            return match dq_out_ty {
+                TrtDataType::kFLOAT => Self::cast_to_float32(network, tensor),
+                TrtDataType::kHALF => Self::cast_to_float16(network, tensor),
+                other => Err(GraphError::ConversionFailed {
+                    format: "trtx".to_string(),
+                    reason: format!(
+                        "{label} identity DQ expects kFLOAT/kHALF output, got {other:?}"
+                    ),
+                }),
+            };
+        }
         // Always use a **scalar** (0D) scale for identity DQ. Matching zp rank (e.g. `[1,1]`) hits
         // TensorRT `ScaleMode is illegal`; per-tensor scale broadcasts. Myelin: data rank >= scale rank.
         let scale_shape: Vec<i64> = vec![];
@@ -3619,52 +3824,6 @@ impl TrtxConverter {
         match (webnn_integer_dtype, input_ty) {
             (DataType::Uint8, TrtDataType::kINT8) => {
                 Self::trtx_int8_dq_reinterpret_uint8_storage(network, &dq_out, dq_out_ty, label)
-            }
-            (DataType::Uint8, TrtDataType::kUINT8) => {
-                let dq_dims =
-                    dq_out
-                        .dimensions(&*network)
-                        .map_err(|e| GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("{label} kUINT8 DQ+128 dimensions: {e}"),
-                        })?;
-                let bias_shape: Vec<i64> = if dq_dims.is_empty() {
-                    vec![]
-                } else {
-                    vec![1_i64; dq_dims.len()]
-                };
-                let bias_bytes: Vec<u8> = match dq_out_ty {
-                    TrtDataType::kFLOAT => 128.0f32.to_le_bytes().to_vec(),
-                    TrtDataType::kHALF => f16::from_f32(128.0f32).to_le_bytes().to_vec(),
-                    _ => {
-                        return Err(GraphError::ConversionFailed {
-                            format: "trtx".to_string(),
-                            reason: format!("{label} kUINT8 DQ+128: unexpected DQ dtype"),
-                        });
-                    }
-                };
-                let bias_t = network
-                    .add_small_constant_copied(&bias_shape, &bias_bytes, dq_out_ty, None)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{label} kUINT8 +128 bias: {e}"),
-                    })?
-                    .output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{label} kUINT8 +128 tensor: {e}"),
-                    })?;
-                network
-                    .add_elementwise(&dq_out, &bias_t, ElementWiseOperation::kSUM)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{label} kUINT8 +128 sum: {e}"),
-                    })?
-                    .output(&*network, 0)
-                    .map_err(|e| GraphError::ConversionFailed {
-                        format: "trtx".to_string(),
-                        reason: format!("{label} kUINT8 +128 output: {e}"),
-                    })
             }
             _ => Ok(dq_out),
         }
@@ -3929,6 +4088,7 @@ impl TrtxConverter {
         out_dtype: DataType,
         fp_trt: TrtDataType,
         out_trt: TrtDataType,
+        output_id: u32,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         let in_operand = graph
             .operand(in_id)
@@ -4086,6 +4246,7 @@ impl TrtxConverter {
             fp_trt,
             out_trt,
             out_dtype,
+            output_id,
         )
     }
 
@@ -4406,6 +4567,7 @@ impl TrtxConverter {
         fp_trt: TrtDataType,
         out_trt: TrtDataType,
         out_dtype: DataType,
+        output_id: u32,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
         let (qmin_f32, qmax_f32) = match out_dtype {
             DataType::Int8 => (-128.0_f32, 127.0_f32),
@@ -4604,6 +4766,11 @@ impl TrtxConverter {
             );
         }
 
+        // A uint8 result may only be a kUINT8 tensor at network I/O.
+        if out_dtype == DataType::Uint8 {
+            return Self::store_uint8_result(graph, network, output_id, &clamped);
+        }
+
         let out = network
             .add_cast(&clamped, out_trt)
             .map_err(|e| GraphError::ConversionFailed {
@@ -4727,6 +4894,7 @@ impl TrtxConverter {
                 out_dtype,
                 fp_trt,
                 out_trt,
+                output_id,
             )?;
             tensor_map.insert(output_id, out);
             return Ok(());
@@ -4797,16 +4965,18 @@ impl TrtxConverter {
                 )?;
                 Self::add_quantize_linear_elementwise_manual(
                     graph, network, in_id, sc_id, zid, input, &scale_a, &zp_a, fp_trt, out_trt,
-                    out_dtype,
+                    out_dtype, output_id,
                 )?
             } else {
                 let (zdt, zp_bytes): (TrtDataType, &[u8]) = match out_dtype {
                     DataType::Int8 => (TrtDataType::kINT8, &[0u8][..]),
-                    DataType::Uint8 => (TrtDataType::kUINT8, &[0u8][..]),
+                    // A kUINT8 constant may only feed Cast, never the identity DQ the
+                    // manual path uses; a zero byte reads identically as kINT8.
+                    DataType::Uint8 => (TrtDataType::kINT8, &[0u8][..]),
                     // Scalar default zp `[0]` must not use kINT4 with `add_small_constant_copied` (trtx-rs
                     // byte-size check). kINT8 zero is fine: manual path casts zp to float.
                     DataType::Int4 => (TrtDataType::kINT8, &[0u8][..]),
-                    DataType::Uint4 => (TrtDataType::kUINT8, &[0u8][..]),
+                    DataType::Uint4 => (TrtDataType::kINT8, &[0u8][..]),
                     DataType::Int32 | DataType::Uint32 => {
                         (TrtDataType::kINT32, &[0u8, 0u8, 0u8, 0u8][..])
                     }
@@ -4877,7 +5047,7 @@ impl TrtxConverter {
                 )?;
                 Self::add_quantize_linear_elementwise_manual(
                     graph, network, in_id, sc_id, in_id, input, &scale_a, &zp_a, fp_trt, out_trt,
-                    out_dtype,
+                    out_dtype, output_id,
                 )?
             };
             tensor_map.insert(output_id, out);
@@ -5022,10 +5192,17 @@ impl TrtxConverter {
         // same-rank scale (e.g. [1,2] on a [5,2] weight) miscomputes elements outside the first
         // block, so restrict IDequantizeLayer to per-tensor scales and route per-channel/block
         // scales through the deterministic manual elementwise (cast * broadcast-scale) path.
+        // Uint8 is also excluded: its constants are stored as kINT8 raw bytes, so a
+        // direct IDequantizeLayer reads values >= 128 as negative (off by -256). The
+        // manual path applies the +256 reinterpret fix (trtx_int8_dq_reinterpret_uint8_storage).
         let use_idq = Self::trtx_input_supports_idq_dequantize(&*network, input)
             && !matches!(
                 input_operand.descriptor.data_type,
-                DataType::Int32 | DataType::Uint32 | DataType::Int4 | DataType::Uint4
+                DataType::Int32
+                    | DataType::Uint32
+                    | DataType::Int4
+                    | DataType::Uint4
+                    | DataType::Uint8
             )
             && Self::trtx_dq_scale_idq_compatible(&in_shape_web, &sc_shape_web)
             && Self::trtx_scale_is_per_tensor_broadcast(&sc_shape_web);
@@ -5843,13 +6020,21 @@ impl TrtxConverter {
             .filter(|s| !s.is_empty())
             .unwrap_or("nchw");
 
-        // For NCHW: normalize over H, W (axes 2,3)
-        // For NHWC: normalize over H, W (axes 1,2)
-        let axes = if layout == "nchw" {
-            vec![2u32, 3u32]
+        // Normalize over the spatial axes: everything after (N, C) for NCHW, and
+        // everything between N and the trailing C for NHWC. Derive them from the
+        // rank so 3-D (N, C, L) audio inputs and 5-D volumes work too.
+        let rank = input_dims.len() as u32;
+        let axes: Vec<u32> = if layout == "nchw" {
+            (2..rank).collect()
         } else {
-            vec![1u32, 2u32]
+            (1..rank.saturating_sub(1)).collect()
         };
+        if axes.is_empty() {
+            return Err(GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("InstanceNorm: input rank {rank} has no spatial axes"),
+            });
+        }
 
         // Compute mean: E[x]
         let mut axes_mask: u32 = 0;
@@ -7620,52 +7805,33 @@ impl TrtxConverter {
 
     /// Add squeeze operation (remove dimensions of size 1)
     fn add_squeeze_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
     ) -> Result<(), GraphError> {
-        let input = tensor_map
-            .get(&operation.input_operands()[0])
-            .ok_or_else(|| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Input operand {} not found", operation.input_operands()[0]),
-            })?;
-
-        // Get axes from attributes (optional - if not provided, squeeze all size-1 dims)
-        let _axes_opt = operation.attributes().get("axes");
-
-        // For squeeze, we need to reshape the tensor to remove dimensions of size 1
-        // We'll use IShuffleLayer with setReshapeDimensions
-        let layer = network
-            .add_shuffle(input)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to add shuffle layer for squeeze: {}", e),
-            })?;
-
-        // Note: Setting reshape dimensions requires accessing layer methods
-        // This is a simplified implementation - full implementation requires
-        // calling layer.set_reshape_dimensions() with the squeezed shape
-        // For now, this creates the layer structure correctly
-
-        let output = layer
-            .output(&*network, 0)
-            .map_err(|e| GraphError::ConversionFailed {
-                format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
-            })?;
-
-        let output_ids = operation.output_operands_slice();
-        let output_id = output_ids[0];
-        tensor_map.insert(output_id, output);
-        Ok(())
+        Self::add_reshape_to_output_shape_op(graph, network, tensor_map, operation, "squeeze")
     }
 
     /// Add unsqueeze operation (add dimensions of size 1)
     fn add_unsqueeze_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
+    ) -> Result<(), GraphError> {
+        Self::add_reshape_to_output_shape_op(graph, network, tensor_map, operation, "unsqueeze")
+    }
+
+    /// Reshape the input to the operation's output descriptor shape. Squeeze and
+    /// unsqueeze are pure reshapes whose target shape the graph builder already
+    /// inferred from the axes, so the output descriptor is authoritative.
+    fn add_reshape_to_output_shape_op<'a>(
+        graph: &GraphInfo,
+        network: &mut trtx::NetworkDefinition<'a>,
+        tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
+        operation: &Operation,
+        op_label: &str,
     ) -> Result<(), GraphError> {
         let input = tensor_map
             .get(&operation.input_operands()[0])
@@ -7674,48 +7840,42 @@ impl TrtxConverter {
                 reason: format!("Input operand {} not found", operation.input_operands()[0]),
             })?;
 
-        // Get axes from attributes
-        let axes_value =
-            operation
-                .attributes()
-                .get("axes")
-                .ok_or_else(|| GraphError::ConversionFailed {
-                    format: "trtx".to_string(),
-                    reason: "Unsqueeze operation missing 'axes' attribute".to_string(),
-                })?;
-
-        let _axes: Vec<u32> = if let Some(arr) = axes_value.as_array() {
-            arr.iter()
-                .filter_map(|v| v.as_u64().map(|u| u as u32))
-                .collect()
-        } else {
-            return Err(GraphError::ConversionFailed {
+        let output_ids = operation.output_operands_slice();
+        let output_id = output_ids[0];
+        let out_operand = graph
+            .operand(output_id)
+            .ok_or_else(|| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: "Invalid 'axes' attribute format".to_string(),
-            });
-        };
+                reason: format!("{op_label}: output operand {output_id} not found"),
+            })?;
+        // An empty shape is a valid reshape to a rank-0 scalar.
+        let dims: Vec<i64> = out_operand
+            .descriptor
+            .static_or_max_shape()
+            .iter()
+            .map(|&d| d as i64)
+            .collect();
 
-        // Use IShuffleLayer to add dimensions
-        let layer = network
+        let mut layer = network
             .add_shuffle(input)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to add shuffle layer for unsqueeze: {}", e),
+                reason: format!("Failed to add shuffle layer for {op_label}: {e}"),
             })?;
-
-        // Note: Setting reshape dimensions requires accessing layer methods
-        // Full implementation requires calling layer.set_reshape_dimensions()
-        // with the expanded shape (inserting 1s at specified axes)
+        layer
+            .set_reshape_dimensions(network, &dims)
+            .map_err(|e| GraphError::ConversionFailed {
+                format: "trtx".to_string(),
+                reason: format!("Failed to set {op_label} reshape dimensions: {e}"),
+            })?;
 
         let output = layer
             .output(&*network, 0)
             .map_err(|e| GraphError::ConversionFailed {
                 format: "trtx".to_string(),
-                reason: format!("Failed to get layer output: {}", e),
+                reason: format!("Failed to get layer output: {e}"),
             })?;
 
-        let output_ids = operation.output_operands_slice();
-        let output_id = output_ids[0];
         tensor_map.insert(output_id, output);
         Ok(())
     }
@@ -8374,6 +8534,28 @@ impl TrtxConverter {
         clamp_max_val: i32,
         label: &str,
     ) -> Result<trtx::Tensor<'a>, GraphError> {
+        // The clamp bounds below are kINT32 and TensorRT elementwise kMIN/kMAX
+        // require identical input types; int64 indices (Range/position ids, cast
+        // chains) are narrowed first. Every dimension fits in i32.
+        let indices_i32: Option<trtx::Tensor<'a>> =
+            if indices.get_type(&*network) == TrtDataType::kINT64 {
+                Some(
+                    network
+                        .add_cast(indices, TrtDataType::kINT32)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("{label}: int64 indices to int32: {e}"),
+                        })?
+                        .output(&*network, 0)
+                        .map_err(|e| GraphError::ConversionFailed {
+                            format: "trtx".to_string(),
+                            reason: format!("{label}: int64 indices to int32 output: {e}"),
+                        })?,
+                )
+            } else {
+                None
+            };
+        let indices: &trtx::Tensor<'a> = indices_i32.as_ref().unwrap_or(indices);
         let num_elements: usize = if indices_shape_i64.is_empty() {
             1
         } else {
@@ -9547,6 +9729,7 @@ impl TrtxConverter {
     /// Clamp int8/uint8 via INT32 (TRT rejects UINT8/kINT8 constants on elementwise MIN/MAX).
     #[allow(clippy::too_many_arguments)]
     fn add_clamp_int8_uint8_op<'a>(
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -9565,6 +9748,7 @@ impl TrtxConverter {
         let i32_in = Self::cast_quantized_int8_uint8_to_int32(network, input, input_dtype)?;
         let clamped_i32 =
             Self::trtx_clamp_i32_tensor(network, &i32_in, broadcast_shape, min_i, max_i)?;
+        let output_id = operation.output_operands_slice()[0];
         let output = match input_dtype {
             DataType::Int8 => network
                 .add_cast(&clamped_i32, TrtDataType::kINT8)
@@ -9577,10 +9761,9 @@ impl TrtxConverter {
                     format: "trtx".to_string(),
                     reason: format!("clamp i32->int8 output: {e}"),
                 })?,
-            DataType::Uint8 => Self::cast_int32_to_uint8(network, &clamped_i32)?,
+            DataType::Uint8 => Self::store_uint8_result(graph, network, output_id, &clamped_i32)?,
             _ => unreachable!(),
         };
-        let output_id = operation.output_operands_slice()[0];
         tensor_map.insert(output_id, output);
         Ok(())
     }
@@ -9855,6 +10038,7 @@ impl TrtxConverter {
                 (min_i, max_i)
             };
             return Self::add_clamp_int8_uint8_op(
+                graph,
                 network,
                 tensor_map,
                 operation,
@@ -10730,7 +10914,7 @@ impl TrtxConverter {
 
     /// Add pad operation (pad tensor with constant/edge/reflection values)
     fn add_pad_op<'a>(
-        _graph: &GraphInfo,
+        graph: &GraphInfo,
         network: &mut trtx::NetworkDefinition<'a>,
         tensor_map: &mut HashMap<u32, trtx::Tensor<'a>>,
         operation: &Operation,
@@ -10932,7 +11116,7 @@ impl TrtxConverter {
                     })?;
             if pad_via_int32 {
                 let _ = tensor_map.remove(&start_key);
-                final_t = Self::cast_int32_to_uint8(network, &final_t)?;
+                final_t = Self::store_uint8_result(graph, network, out_id, &final_t)?;
             }
             tensor_map.insert(out_id, final_t);
             return Ok(());
@@ -14038,10 +14222,12 @@ impl TrtxConverter {
         layer.set_resize_mode(network, resize_mode);
         // WebNN `resample2d` uses the half-pixel grid; TensorRT default is kASYMMETRIC.
         layer.set_coordinate_transformation(network, ResizeCoordinateTransformation::kHALF_PIXEL);
-        // WebNN nearest: `ceil(coord - 0.5)` == `floor(coord + 0.5)` on the sampling grid; TRT default
-        // `kFLOOR` uses `floor(coord)` and mis-aligns upsampling (e.g. 2x nearest on float grid).
+        // Nearest rounding: ONNX/ORT `round_prefer_floor` is `ceil(coord - 0.5)`,
+        // i.e. ties resolve downward -> kHALF_DOWN. TRT's default `kFLOOR` uses
+        // `floor(coord)` and mis-aligns upsampling; kHALF_UP flips every tie
+        // (e.g. 1.5x upsample or 2x downsample on the half-pixel grid).
         if resize_mode == ResizeMode::kNEAREST {
-            layer.set_nearest_rounding(network, ResizeRoundMode::kHALF_UP);
+            layer.set_nearest_rounding(network, ResizeRoundMode::kHALF_DOWN);
         }
 
         let output = layer

--- a/src/converters/weight_file_builder.rs
+++ b/src/converters/weight_file_builder.rs
@@ -9,11 +9,8 @@ const FILE_VERSION: u32 = 2;
 /// Matches the enum from Chromium's graph_builder_coreml.cc.
 pub mod blob_data_type {
     pub const FLOAT16: u32 = 1;
-    #[allow(dead_code)]
     pub const FLOAT32: u32 = 2;
-    #[allow(dead_code)]
     pub const UINT8: u32 = 3;
-    #[allow(dead_code)]
     pub const INT8: u32 = 4;
 }
 
@@ -98,6 +95,13 @@ impl WeightFileBuilder {
 
         self.entry_count += 1;
         Ok(metadata_offset)
+    }
+
+    /// Pre-allocate for the expected payload volume. Weight files reach
+    /// hundreds of MB; growing by amortized doubling briefly holds ~3x the
+    /// final size during the last realloc.
+    pub fn reserve(&mut self, additional: usize) {
+        self.data.reserve(additional);
     }
 
     /// Returns the file offset for a previously added weight.

--- a/src/executors/coreml.rs
+++ b/src/executors/coreml.rs
@@ -87,8 +87,9 @@ pub unsafe extern "C" fn rustnn_coreml_predict(
 }
 
 /// Releases an owned (+1) Objective-C object when dropped (including on early
-/// `return`/`?`), balancing the retain transferred to us by the shim's
-/// `__bridge_retained` cast.
+/// `return`/`?`), balancing any +1 ownership we hold: the retain transferred by
+/// the shim's `__bridge_retained` casts, or objects we created via
+/// `new`/`alloc`+`init`.
 struct ReleaseOnDrop(*mut Object);
 
 impl ReleaseOnDrop {
@@ -333,6 +334,7 @@ pub(crate) fn compile_model(
         let mut last_error = String::from("MLModel load failed");
         for (code, name) in candidates {
             let config: *mut Object = msg_send![class!(MLModelConfiguration), new];
+            let _config_guard = ReleaseOnDrop(config);
             let () = msg_send![config, setComputeUnits: code];
             match load_model_asset(asset, config) {
                 Ok(model) => {
@@ -387,6 +389,7 @@ fn compile_model_from_url(
         let mut last_error = String::from("MLModel load failed");
         for (code, name) in candidates {
             let config: *mut Object = msg_send![class!(MLModelConfiguration), new];
+            let _config_guard = ReleaseOnDrop(config);
             let () = msg_send![config, setComputeUnits: code];
             let mut model: *mut Object = ptr::null_mut();
             let mut error = [0u8; 1024];
@@ -569,6 +572,7 @@ pub(crate) fn run_coreml_bytes(
                 reason: ns_error_to_string(create_error, "MLDictionaryFeatureProvider init failed"),
             });
         }
+        let _provider_guard = ReleaseOnDrop(provider);
 
         let mut output_provider: *mut Object = ptr::null_mut();
         let mut error = [0u8; 1024];
@@ -1075,13 +1079,15 @@ fn run_impl_zeroed_with_weights(
         // Try only Neural Engine + GPU (best performance on Apple Silicon)
         // Fallback to ALL if that fails
         let targets = [
-            (3i64, "CPU_AND_NE"), // Neural Engine + GPU (best for Apple Silicon)
-            (0i64, "ALL"),        // Fallback to all available compute units
+            (3i64, "CPU_AND_NE"), // CPU + Neural Engine (best for Apple Silicon)
+            (2i64, "ALL"),        // All available compute units
+            (0i64, "CPU_ONLY"),   // Guaranteed-to-load last resort
         ];
         let mut attempts = Vec::new();
 
         for (code, name) in targets {
             let config: *mut Object = msg_send![class!(MLModelConfiguration), new];
+            let _config_guard = ReleaseOnDrop(config);
             let () = msg_send![config, setComputeUnits: code];
             let mut model: *mut Object = ptr::null_mut();
             let mut error = [0u8; 1024];
@@ -1170,6 +1176,7 @@ fn run_impl_zeroed_with_weights(
                 });
                 continue;
             }
+            let _provider_guard = ReleaseOnDrop(provider);
 
             let mut output_provider: *mut Object = ptr::null_mut();
             let mut error = [0u8; 1024];
@@ -1254,13 +1261,15 @@ fn run_impl_with_inputs_with_weights(
         // Try only Neural Engine + GPU (best performance on Apple Silicon)
         // Fallback to ALL if that fails
         let targets = [
-            (3i64, "CPU_AND_NE"), // Neural Engine + GPU (best for Apple Silicon)
-            (0i64, "ALL"),        // Fallback to all available compute units
+            (3i64, "CPU_AND_NE"), // CPU + Neural Engine (best for Apple Silicon)
+            (2i64, "ALL"),        // All available compute units
+            (0i64, "CPU_ONLY"),   // Guaranteed-to-load last resort
         ];
         let mut attempts = Vec::new();
 
         for (code, name) in targets {
             let config: *mut Object = msg_send![class!(MLModelConfiguration), new];
+            let _config_guard = ReleaseOnDrop(config);
             let () = msg_send![config, setComputeUnits: code];
             let mut model: *mut Object = ptr::null_mut();
             let mut error = [0u8; 1024];
@@ -1357,6 +1366,7 @@ fn run_impl_with_inputs_with_weights(
                 });
                 continue;
             }
+            let _provider_guard = ReleaseOnDrop(provider);
 
             let mut output_provider: *mut Object = ptr::null_mut();
             let mut error = [0u8; 1024];
@@ -1588,7 +1598,11 @@ pub(crate) unsafe fn prepare_compiled_model_with_weights(
         if path.exists() {
             let _ = std::fs::remove_dir_all(path);
         }
-        if let Err(err) = copy_dir_recursively(&compiled_src_path, path) {
+        let copy_result = copy_dir_recursively(&compiled_src_path, path);
+        // Drop CoreML's temp .mlmodelc either way; the non-cached paths delete
+        // it via their callers.
+        let _ = std::fs::remove_dir_all(&compiled_src_path);
+        if let Err(err) = copy_result {
             return Err(GraphError::CoremlRuntimeFailed {
                 reason: format!("failed to persist compiled model: {}", err),
             });
@@ -1843,6 +1857,9 @@ unsafe fn create_multi_array(shape: &[i64], data_type: i32) -> Result<*mut Objec
             reason: unsafe { ns_error_to_string(error, "MLMultiArray init failed") },
         });
     }
+    // Hand callers a pool-backed reference; MLFeatureValue retains the array
+    // for as long as the feature dictionary needs it.
+    let array: *mut Object = msg_send![array, autorelease];
     Ok(array)
 }
 

--- a/src/executors/coreml.rs
+++ b/src/executors/coreml.rs
@@ -91,6 +91,16 @@ pub unsafe extern "C" fn rustnn_coreml_predict(
 /// `__bridge_retained` cast.
 struct ReleaseOnDrop(*mut Object);
 
+impl ReleaseOnDrop {
+    /// Take the pointer back out without releasing, handing ownership (+1)
+    /// to the caller.
+    fn into_inner(self) -> *mut Object {
+        let ptr = self.0;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
 impl Drop for ReleaseOnDrop {
     fn drop(&mut self) {
         unsafe {
@@ -366,6 +376,8 @@ fn compile_model_from_url(
     autoreleasepool(|| unsafe {
         let (compiled_url, compiled_dir, temp_model) =
             prepare_compiled_model_with_weights(model_bytes, weights_data, None)?;
+        // Owned (+1) by us; released when this function returns on any path.
+        let _compiled_url_guard = ReleaseOnDrop(compiled_url);
         let (preferred_code, preferred_name) = compute_unit_for_device(device_type);
         let mut candidates = vec![(preferred_code, preferred_name)];
         if preferred_code != 0 {
@@ -389,8 +401,8 @@ fn compile_model_from_url(
                 last_error = format!("MLModel load failed: {}", shim_error_to_string(&error));
                 continue;
             }
-            // The shim returns a borrowed model. Retain it beyond this pool.
-            let _: *mut Object = msg_send![model, retain];
+            // The shim returns an owned (+1) model; `CompiledCoremlModel`'s
+            // Drop releases it.
             return Ok(CompiledCoremlModel {
                 model,
                 compute_unit: name,
@@ -1057,6 +1069,8 @@ fn run_impl_zeroed_with_weights(
     unsafe {
         let (compiled_url, compiled_path_buf, temp_mlmodel) =
             prepare_compiled_model_with_weights(model_bytes, weights_data, compiled_path)?;
+        // Owned (+1) by us; released when this function returns on any path.
+        let _compiled_url_guard = ReleaseOnDrop(compiled_url);
 
         // Try only Neural Engine + GPU (best performance on Apple Silicon)
         // Fallback to ALL if that fails
@@ -1088,6 +1102,8 @@ fn run_impl_zeroed_with_weights(
                 });
                 continue;
             }
+            // Owned (+1) by us for this attempt; released at end of iteration.
+            let _model_guard = ReleaseOnDrop(model);
             let model_description: *mut Object = msg_send![model, modelDescription];
             let input_descs: *mut Object = msg_send![model_description, inputDescriptionsByName];
 
@@ -1232,6 +1248,8 @@ fn run_impl_with_inputs_with_weights(
     unsafe {
         let (compiled_url, compiled_path_buf, temp_mlmodel) =
             prepare_compiled_model_with_weights(model_bytes, weights_data, cache_path)?;
+        // Owned (+1) by us; released when this function returns on any path.
+        let _compiled_url_guard = ReleaseOnDrop(compiled_url);
 
         // Try only Neural Engine + GPU (best performance on Apple Silicon)
         // Fallback to ALL if that fails
@@ -1263,6 +1281,8 @@ fn run_impl_with_inputs_with_weights(
                 });
                 continue;
             }
+            // Owned (+1) by us for this attempt; released at end of iteration.
+            let _model_guard = ReleaseOnDrop(model);
 
             // Get model input descriptions to query expected data types
             let model_description: *mut Object = msg_send![model, modelDescription];
@@ -1531,6 +1551,10 @@ unsafe fn prepare_compiled_model(
     unsafe { prepare_compiled_model_with_weights(model_bytes, None, cached_compiled) }
 }
 
+/// Compile a model to a `.mlmodelc`, optionally persisting it to `cached_compiled`.
+///
+/// On success the returned NSURL is owned (+1); the caller must release it
+/// (e.g. via [`ReleaseOnDrop`]) once the model has been loaded.
 pub(crate) unsafe fn prepare_compiled_model_with_weights(
     model_bytes: &[u8],
     weights_data: Option<&[u8]>,
@@ -1553,6 +1577,9 @@ pub(crate) unsafe fn prepare_compiled_model_with_weights(
             reason: format!("MLModel compile failed: {}", shim_error_to_string(&error)),
         });
     }
+    // The shim returns an owned (+1) URL; the guard releases it on every path
+    // that doesn't hand it back to the caller.
+    let compiled_url_guard = ReleaseOnDrop(compiled_url);
 
     let compiled_path_obj: *mut Object = msg_send![compiled_url, path];
     let compiled_src_path = PathBuf::from(unsafe { nsstring_to_string(compiled_path_obj) });
@@ -1567,10 +1594,17 @@ pub(crate) unsafe fn prepare_compiled_model_with_weights(
             });
         }
         let persisted_url = unsafe { nsurl_from_path(path)? };
+        // `nsurl_from_path` returns an autoreleased URL; retain it so both
+        // branches hand the caller an owned (+1) reference.
+        let _: *mut Object = msg_send![persisted_url, retain];
         return Ok((persisted_url, path.to_path_buf(), Some(temp_mlmodel)));
     }
 
-    Ok((compiled_url, compiled_src_path, Some(temp_mlmodel)))
+    Ok((
+        compiled_url_guard.into_inner(),
+        compiled_src_path,
+        Some(temp_mlmodel),
+    ))
 }
 
 #[allow(dead_code)]

--- a/src/executors/coreml.rs
+++ b/src/executors/coreml.rs
@@ -86,6 +86,19 @@ pub unsafe extern "C" fn rustnn_coreml_predict(
     1
 }
 
+/// Releases an owned (+1) Objective-C object when dropped (including on early
+/// `return`/`?`), balancing the retain transferred to us by the shim's
+/// `__bridge_retained` cast.
+struct ReleaseOnDrop(*mut Object);
+
+impl Drop for ReleaseOnDrop {
+    fn drop(&mut self) {
+        unsafe {
+            let _: () = msg_send![self.0, release];
+        }
+    }
+}
+
 fn shim_error_to_string(buffer: &[u8]) -> String {
     let end = buffer
         .iter()
@@ -559,6 +572,10 @@ pub(crate) fn run_coreml_bytes(
                 reason: format!("prediction failed: {}", shim_error_to_string(&error)),
             });
         }
+        // `rustnn_coreml_predict` (coreml_shim.mm) hands back `output_provider`
+        // already retained (`__bridge_retained`) -- we own this reference and
+        // must release it once we're done extracting outputs.
+        let _output_provider_guard = ReleaseOnDrop(output_provider);
 
         let mut result = HashMap::with_capacity(output_descriptors.len());
         for (name, descriptor) in output_descriptors {
@@ -1157,6 +1174,8 @@ fn run_impl_zeroed_with_weights(
                 });
                 continue;
             }
+            // The shim returns a retained provider; release it after collecting.
+            let _output_provider_guard = ReleaseOnDrop(output_provider);
 
             match collect_outputs(output_provider) {
                 Ok(outputs) => attempts.push(CoremlRunAttempt {
@@ -1338,6 +1357,8 @@ fn run_impl_with_inputs_with_weights(
                 });
                 continue;
             }
+            // The shim returns a retained provider; release it after collecting.
+            let _output_provider_guard = ReleaseOnDrop(output_provider);
 
             match collect_outputs(output_provider) {
                 Ok(outputs) => attempts.push(CoremlRunAttempt {

--- a/src/executors/coreml.rs
+++ b/src/executors/coreml.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 use std::os::raw::{c_char, c_void};
 use std::path::{Path, PathBuf};
 use std::ptr;
+use std::sync::Arc;
 use std::sync::mpsc;
 
 use block::ConcreteBlock;
@@ -313,17 +314,26 @@ fn compute_unit_for_device(
 /// Load a CoreML model directly from protobuf bytes and retain it for repeated
 /// dispatch, falling back to CPU-only if the preferred compute units fail.
 pub(crate) fn compile_model(
-    model_bytes: &[u8],
-    weights_data: Option<&[u8]>,
+    model_bytes: Vec<u8>,
+    weights_data: Option<Vec<u8>>,
     device_type: crate::backend_selection::DeviceType,
     use_in_memory_asset: bool,
 ) -> Result<CompiledCoremlModel, GraphError> {
+    // Owned so the in-memory path can hand the buffers to NSData without
+    // copying (weight blobs reach hundreds of MB); the Arcs keep them valid
+    // for the URL fallback below even after the NSData objects are released.
+    let model_bytes = Arc::new(model_bytes);
+    let weights_data = weights_data.map(Arc::new);
     if !use_in_memory_asset {
-        return compile_model_from_url(model_bytes, weights_data, device_type);
+        return compile_model_from_url(
+            &model_bytes,
+            weights_data.as_deref().map(Vec::as_slice),
+            device_type,
+        );
     }
     let memory_result = autoreleasepool(|| unsafe {
         let (asset, specification_data, retained_weights_data) =
-            create_in_memory_model_asset(model_bytes, weights_data)?;
+            create_in_memory_model_asset(&model_bytes, weights_data.as_ref())?;
 
         let (preferred_code, preferred_name) = compute_unit_for_device(device_type);
         let mut candidates: Vec<(i64, &'static str)> = vec![(preferred_code, preferred_name)];
@@ -360,12 +370,15 @@ pub(crate) fn compile_model(
         Err(GraphError::CoremlRuntimeFailed { reason: last_error })
     });
     memory_result.or_else(|memory_error| {
-        compile_model_from_url(model_bytes, weights_data, device_type).map_err(|url_error| {
-            GraphError::CoremlRuntimeFailed {
-                reason: format!(
-                    "in-memory model load failed ({memory_error}); URL fallback failed ({url_error})"
-                ),
-            }
+        compile_model_from_url(
+            &model_bytes,
+            weights_data.as_deref().map(Vec::as_slice),
+            device_type,
+        )
+        .map_err(|url_error| GraphError::CoremlRuntimeFailed {
+            reason: format!(
+                "in-memory model load failed ({memory_error}); URL fallback failed ({url_error})"
+            ),
         })
     })
 }
@@ -423,12 +436,41 @@ fn compile_model_from_url(
     })
 }
 
+/// Wrap an `Arc`-owned buffer in an `NSData` WITHOUT copying. The NSData's
+/// deallocator drops an `Arc` clone, so the bytes stay valid for as long as
+/// EITHER the caller's `Arc` or the `NSData` lives — however long CoreML
+/// internally retains the latter. Returns an owned (+1) object.
+unsafe fn nsdata_from_arc(buffer: &Arc<Vec<u8>>) -> Result<*mut Object, GraphError> {
+    let bytes = buffer.as_ptr() as *mut c_void;
+    let length = buffer.len();
+    let raw = Arc::into_raw(Arc::clone(buffer)) as usize;
+    // NSData calls the deallocator exactly once, when its storage is freed.
+    let deallocator = ConcreteBlock::new(move |_bytes: *mut c_void, _length: usize| {
+        drop(unsafe { Arc::from_raw(raw as *const Vec<u8>) });
+    })
+    .copy();
+    let data: *mut Object = msg_send![class!(NSData), alloc];
+    let data: *mut Object = msg_send![data,
+        initWithBytesNoCopy: bytes
+        length: length
+        deallocator: &*deallocator];
+    if data.is_null() {
+        // Never observed in practice; leak the Arc clone rather than risk a
+        // double-free if the failed init already consumed the deallocator.
+        return Err(GraphError::CoremlRuntimeFailed {
+            reason: "failed to create NSData for CoreML model bytes".to_string(),
+        });
+    }
+    Ok(data)
+}
+
 /// Create an `MLModelAsset` whose specification and optional external weight blob
-/// are entirely memory-backed. The returned Objective-C objects are retained and
-/// must remain alive for at least as long as the loaded `MLModel`.
+/// are entirely memory-backed (zero-copy views over the given buffers). The
+/// returned Objective-C objects are retained and must remain alive for at least
+/// as long as the loaded `MLModel`.
 unsafe fn create_in_memory_model_asset(
-    model_bytes: &[u8],
-    weights: Option<&[u8]>,
+    model_bytes: &Arc<Vec<u8>>,
+    weights: Option<&Arc<Vec<u8>>>,
 ) -> Result<(*mut Object, *mut Object, Option<*mut Object>), GraphError> {
     let Some(asset_class) = Class::get("MLModelAsset") else {
         return Err(GraphError::CoremlRuntimeFailed {
@@ -436,27 +478,18 @@ unsafe fn create_in_memory_model_asset(
         });
     };
 
-    let specification_data: *mut Object =
-        msg_send![class!(NSData), dataWithBytes: model_bytes.as_ptr() length: model_bytes.len()];
-    if specification_data.is_null() {
-        return Err(GraphError::CoremlRuntimeFailed {
-            reason: "failed to create NSData for CoreML model specification".to_string(),
-        });
-    }
-    let _: *mut Object = msg_send![specification_data, retain];
+    let specification_data: *mut Object = unsafe { nsdata_from_arc(model_bytes)? };
 
     let mut error: *mut Object = ptr::null_mut();
     let (asset, weights_data): (*mut Object, Option<*mut Object>) = match weights {
         Some(weights) => {
-            let weights_data: *mut Object =
-                msg_send![class!(NSData), dataWithBytes: weights.as_ptr() length: weights.len()];
-            if weights_data.is_null() {
-                let _: () = msg_send![specification_data, release];
-                return Err(GraphError::CoremlRuntimeFailed {
-                    reason: "failed to create NSData for CoreML model weights".to_string(),
-                });
-            }
-            let _: *mut Object = msg_send![weights_data, retain];
+            let weights_data: *mut Object = match unsafe { nsdata_from_arc(weights) } {
+                Ok(data) => data,
+                Err(err) => {
+                    let _: () = msg_send![specification_data, release];
+                    return Err(err);
+                }
+            };
 
             // BlobFileValue stores `@model_path/weights/weights.bin`. For an
             // in-memory asset CoreML expects the path relative to `@model_path`.

--- a/src/executors/coreml_shim.mm
+++ b/src/executors/coreml_shim.mm
@@ -36,7 +36,12 @@ static void rustnn_copy_err(char *buf, size_t len, NSString *msg) {
 }
 
 // Compile a `.mlmodel`/`.mlpackage` at `model_url`. On success `*out_url` is a
-// borrowed (autoreleased) NSURL valid for the caller's current autorelease pool.
+// RETAINED NSURL; the caller owns it and must release it when done.
+//
+// Same ownership hazard as `rustnn_coreml_predict` below: the +0 return of
+// `compileModelAtURL:` may never enter an autorelease pool when ARC's
+// return-value hand-off elides the autorelease, so a plain `__bridge` cast can
+// hand the caller an already-deallocated object in optimized builds.
 int rustnn_coreml_compile(void *model_url, void **out_url, char *err, size_t err_len) {
     *out_url = NULL;
     @try {
@@ -47,7 +52,7 @@ int rustnn_coreml_compile(void *model_url, void **out_url, char *err, size_t err
                             nserr ? [nserr localizedDescription] : @"MLModel compile failed");
             return 1;
         }
-        *out_url = (__bridge void *)compiled;
+        *out_url = (__bridge_retained void *)compiled;
         return 0;
     } @catch (NSException *e) {
         rustnn_copy_err(err, err_len,
@@ -60,9 +65,8 @@ int rustnn_coreml_compile(void *model_url, void **out_url, char *err, size_t err
 }
 
 // Load an MLModel from a compiled URL with the given configuration. On success
-// `*out_model` is a borrowed (autoreleased) MLModel valid for the caller's
-// current autorelease pool; callers that need it to outlive the pool must
-// `retain` it themselves (as compile_model does).
+// `*out_model` is a RETAINED MLModel; the caller owns it and must release it
+// when done (see the ownership note on `rustnn_coreml_compile`).
 int rustnn_coreml_load(void *compiled_url, void *config, void **out_model, char *err,
                        size_t err_len) {
     *out_model = NULL;
@@ -76,7 +80,7 @@ int rustnn_coreml_load(void *compiled_url, void *config, void **out_model, char 
                             nserr ? [nserr localizedDescription] : @"MLModel load failed");
             return 1;
         }
-        *out_model = (__bridge void *)model;
+        *out_model = (__bridge_retained void *)model;
         return 0;
     } @catch (NSException *e) {
         rustnn_copy_err(err, err_len,

--- a/src/executors/coreml_shim.mm
+++ b/src/executors/coreml_shim.mm
@@ -88,8 +88,18 @@ int rustnn_coreml_load(void *compiled_url, void *config, void **out_model, char 
     }
 }
 
-// Run a prediction. On success `*out_provider` is a borrowed (autoreleased)
-// output feature provider valid for the caller's current autorelease pool.
+// Run a prediction. On success `*out_provider` is a RETAINED output feature
+// provider; the caller owns it and must release it when done.
+//
+// `-predictionFromFeatures:error:` returns its result at +0 (autoreleased);
+// under ARC, `out` (a strong local) picks up a retain for the duration of this
+// function and ARC releases it again when `out` goes out of scope at `return`.
+// A plain `__bridge` cast here does not add a matching retain of its own, so by
+// the time control returns to the caller the object can already be
+// deallocated -- reproduced 100% of the time in optimized (non-debug) builds as
+// a SIGSEGV (garbage receiver in `objc_msgSend`) on the very next use of
+// `*out_provider`. `__bridge_retained` performs the retain the caller needs to
+// keep the object alive past this function returning.
 int rustnn_coreml_predict(void *model, void *features, void **out_provider, char *err,
                           size_t err_len) {
     *out_provider = NULL;
@@ -103,7 +113,7 @@ int rustnn_coreml_predict(void *model, void *features, void **out_provider, char
                             nserr ? [nserr localizedDescription] : @"prediction returned nil");
             return 1;
         }
-        *out_provider = (__bridge void *)out;
+        *out_provider = (__bridge_retained void *)out;
         return 0;
     } @catch (NSException *e) {
         rustnn_copy_err(err, err_len,

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -2318,14 +2318,28 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         descriptor: &MLOperandDescriptor,
         values: &[T],
     ) -> crate::error::Result<MLOperand> {
+        trace!(
+            "constant_from_slice: {descriptor:?} size={} bytes",
+            descriptor.rustnn_required_bytes()
+        );
+        self.constant_from_bytes(descriptor, bytemuck::cast_slice::<T, u8>(values).to_vec())
+    }
+
+    /// Register a constant from raw little-endian bytes, taking ownership of
+    /// the buffer. Unlike [`Self::constant_from_slice`] this makes no copy:
+    /// weight tensors reach hundreds of MB and every extra copy of them stays
+    /// live for the whole backend compile.
+    pub fn constant_from_bytes(
+        &mut self,
+        descriptor: &MLOperandDescriptor,
+        data: Vec<u8>,
+    ) -> crate::error::Result<MLOperand> {
         let required_size = descriptor.rustnn_required_bytes();
-        let provided_size = std::mem::size_of_val(values);
-        trace!("constant_from_slice: {descriptor:?} size={required_size} bytes");
-        if required_size != provided_size {
+        if required_size != data.len() {
             return Err(GraphBuilderError::WrongConstantSize {
                 descriptor: descriptor.clone(),
                 required_size,
-                provided_size,
+                provided_size: data.len(),
             }
             .into());
         }
@@ -2345,13 +2359,9 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         graph
             .id_to_constant_tensor_operand_map
             .insert(id as u32, format!("{id}"));
-        graph.constant_operand_ids_to_handles.insert(
-            id as u32,
-            crate::ConstantData {
-                data: bytemuck::cast_slice::<T, u8>(values).to_vec(),
-                label: None,
-            },
-        );
+        graph
+            .constant_operand_ids_to_handles
+            .insert(id as u32, crate::ConstantData { data, label: None });
 
         Ok(MLOperand { id })
     }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1453,6 +1453,70 @@ impl Operation {
         self.inputs()
     }
 
+    /// Operand ids passed through options rather than positional arguments
+    /// (e.g. `gemm.c`, `batchNormalization.scale`).
+    pub fn option_operands(&self) -> Vec<OperandIndex> {
+        match self {
+            Operation::BatchNormalization {
+                options: Some(o), ..
+            } => [o.scale, o.bias].into_iter().flatten().collect(),
+            Operation::Conv2d {
+                options: Some(o), ..
+            } => o.bias.into_iter().collect(),
+            Operation::ConvTranspose2d {
+                options: Some(o), ..
+            } => o.bias.into_iter().collect(),
+            Operation::Gemm {
+                options: Some(o), ..
+            } => o.c.into_iter().collect(),
+            Operation::Gru {
+                options: Some(o), ..
+            } => [o.bias, o.recurrent_bias, o.initial_hidden_state]
+                .into_iter()
+                .flatten()
+                .collect(),
+            Operation::GruCell {
+                options: Some(o), ..
+            } => [o.bias, o.recurrent_bias].into_iter().flatten().collect(),
+            Operation::InstanceNormalization {
+                options: Some(o), ..
+            } => [o.scale, o.bias].into_iter().flatten().collect(),
+            Operation::LayerNormalization {
+                options: Some(o), ..
+            } => [o.scale, o.bias].into_iter().flatten().collect(),
+            Operation::Lstm {
+                options: Some(o), ..
+            } => [
+                o.bias,
+                o.recurrent_bias,
+                o.peephole_weight,
+                o.initial_hidden_state,
+                o.initial_cell_state,
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+            Operation::LstmCell {
+                options: Some(o), ..
+            } => [o.bias, o.recurrent_bias, o.peephole_weight]
+                .into_iter()
+                .flatten()
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Every operand this operation reads: [`Self::inputs`] plus [`Self::option_operands`].
+    pub fn all_input_operands(&self) -> Vec<OperandIndex> {
+        let mut ids = self.inputs();
+        for id in self.option_operands() {
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        ids
+    }
+
     /// Legacy attributes. Derived from this operation.
     pub fn attributes(&self) -> OperatorOptions {
         self.to_legacy().2

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -80,7 +80,13 @@ impl<'a> GraphValidator<'a> {
         let mut outputs = HashMap::new();
         let mut graph_inputs = Vec::with_capacity(self.graph.input_operands.len());
         let mut graph_outputs = Vec::with_capacity(self.graph.output_operands.len());
-        let mut constant_handles = self.graph.constant_operand_ids_to_handles.clone();
+        // Borrow, don't clone: the map holds every weight buffer, and cloning
+        // it duplicates the full weight volume just for a presence check.
+        // `seen_constants` replaces the old clone-and-remove bookkeeping:
+        // operand ids are unique per loop iteration, so counting successful
+        // lookups detects map entries with no matching Constant operand.
+        let constant_handles = &self.graph.constant_operand_ids_to_handles;
+        let mut seen_constants = 0usize;
         let tensor_constants = &self.graph.id_to_constant_tensor_operand_map;
         for (idx, operand) in self.graph.operands.iter().enumerate() {
             let operand_id = idx as u32;
@@ -155,7 +161,8 @@ impl<'a> GraphValidator<'a> {
                     }
                 }
                 OperandKind::Constant => {
-                    if let Some(data) = constant_handles.remove(&operand_id) {
+                    if let Some(data) = constant_handles.get(&operand_id) {
+                        seen_constants += 1;
                         if data.data.len() != byte_length {
                             return Err(GraphError::ConstantLengthMismatch {
                                 operand: operand_id,
@@ -180,7 +187,7 @@ impl<'a> GraphValidator<'a> {
         if graph_outputs != self.graph.output_operands {
             return Err(GraphError::OutputOperandListMismatch);
         }
-        if !constant_handles.is_empty() {
+        if seen_constants != constant_handles.len() {
             return Err(GraphError::UnusedConstantHandles);
         }
 


### PR DESCRIPTION
## Summary

This PR combines all the fixes necessary on the rustnn side found while enabling transformer.js models in onnx2webnn.

It fixes the bidirectional LSTM/GRU ops, removes extra explicit fp16 case which breaks in optimized onnxruntime builds (#218), fixes axis inputs for Squeeze (#217), as well as CoreML concurrency issues (#216)
