### PR TITLE
Fix duplicate MLTensor dispatch validation

### DIFF
--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -31,6 +31,23 @@ pub type MLNamedTensors<'names> = BTreeMap<&'names str, &'names MLTensor>;
 /// <https://www.w3.org/TR/webnn/#typedefdef-mlnamedoperands>
 pub type MLNamedOperands<'names> = BTreeMap<&'names str, MLOperand>;
 
+fn validate_unique_tensor_bindings(
+    inputs: &MLNamedTensors,
+    outputs: &MLNamedTensors,
+) -> Result<()> {
+    let mut all_tensor_ids = HashMap::new();
+    for (&name, &tensor) in inputs.iter().chain(outputs.iter()) {
+        if let Some(other_name) = all_tensor_ids.insert(tensor.id, name) {
+            return Err(Error::DuplicateTensorBinding {
+                aliased_tensor: tensor.clone(),
+                first_binding: other_name.to_string(),
+                other_binding: name.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 pub use crate::mlgraphbuilder::MLGraphBuilder;
 use crate::{
     backend_selection::{select_backend, select_backend_by_gpu},
@@ -544,16 +561,7 @@ impl<'context> MLContext<'context> {
         debug!("Dispatch {graph:?}, inputs={inputs:?}, outputs={outputs:?}");
         //https://www.w3.org/TR/webnn/#dom-mlcontext-dispatch
         // spec: 4. If allTensors contains any duplicate items, then throw a TypeError.
-        let mut all_tensor_ids = HashMap::new();
-        for (&name, &tensor) in inputs.iter().chain(outputs.iter()) {
-            if let Some(other_name) = all_tensor_ids.insert(name, tensor.id) {
-                return Err(Error::DuplicateTensorBinding {
-                    aliased_tensor: tensor.clone(),
-                    first_binding: other_name.to_string(),
-                    other_binding: name.to_string(),
-                });
-            }
-        }
+        validate_unique_tensor_bindings(inputs, outputs)?;
 
         graph.verify_dispatch_bindings(inputs, outputs)?;
         self.backend.dispatch(graph, inputs, outputs)
@@ -740,20 +748,45 @@ webnn_graph "sample_graph" v1 {
         dbg!(&context);
         let desc = rw_tensor_desc([2, 2].to_vec());
 
-        let tensor = context.create_tensor(&desc).unwrap();
+        let input_tensor = context.create_tensor(&desc).unwrap();
+        let output_tensor = context.create_tensor(&desc).unwrap();
         let mut inputs = MLNamedTensors::new();
-        inputs.insert("lhs", &tensor);
+        inputs.insert("lhs", &input_tensor);
         let mut outputs = MLNamedTensors::new();
-        outputs.insert("sum", &tensor);
+        outputs.insert("sum", &output_tensor);
 
         let upload = vec![1.0f32, 2., 3., 4.];
         let upload_f64 = vec![1.0, 2., 3., 4.];
         let mut download = vec![0.0f32; 4];
-        context.write_tensor(&tensor, &upload_f64).unwrap_err();
-        context.write_tensor(&tensor, &upload).unwrap();
+        context
+            .write_tensor(&input_tensor, &upload_f64)
+            .unwrap_err();
+        context.write_tensor(&input_tensor, &upload).unwrap();
         context.dispatch(&mut graph, &inputs, &outputs).unwrap();
-        context.read_tensor(&tensor, &mut download).unwrap();
+        context.read_tensor(&output_tensor, &mut download).unwrap();
         assert_eq!(&vec![2.0f32, 3., 4., 5.], &download);
+    }
+
+    #[test]
+    fn test_dispatch_rejects_tensor_bound_as_input_and_output() {
+        let descriptor = MLTensorDescriptor::new(MLOperandDataType::Float32, vec![2, 2]);
+        let tensor = MLTensor {
+            id: 7,
+            constant: false,
+            descriptor,
+        };
+        let inputs = MLNamedTensors::from([("lhs", &tensor)]);
+        let outputs = MLNamedTensors::from([("sum", &tensor)]);
+
+        let err = validate_unique_tensor_bindings(&inputs, &outputs).unwrap_err();
+        std::assert_matches!(
+            err,
+            crate::error::Error::DuplicateTensorBinding {
+                first_binding,
+                other_binding,
+                ..
+            } if first_binding == "lhs" && other_binding == "sum"
+        );
     }
 
     #[cfg(feature = "trtx-runtime")]
@@ -796,11 +829,12 @@ webnn_graph "sample_graph" v1 {
         };
 
         let desc = rw_tensor_desc([2, 2].to_vec());
-        let tensor = context.create_tensor(&desc).unwrap();
+        let input_tensor = context.create_tensor(&desc).unwrap();
+        let output_tensor = context.create_tensor(&desc).unwrap();
         let mut inputs = MLNamedTensors::new();
-        inputs.insert("invalid_input", &tensor);
+        inputs.insert("invalid_input", &input_tensor);
         let mut outputs = MLNamedTensors::new();
-        outputs.insert("sum", &tensor);
+        outputs.insert("sum", &output_tensor);
 
         let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
         std::assert_matches!(
@@ -817,11 +851,12 @@ webnn_graph "sample_graph" v1 {
         };
 
         let desc = rw_tensor_desc([2, 3].to_vec());
-        let tensor = context.create_tensor(&desc).unwrap();
+        let input_tensor = context.create_tensor(&desc).unwrap();
+        let output_tensor = context.create_tensor(&desc).unwrap();
         let mut inputs = MLNamedTensors::new();
-        inputs.insert("lhs", &tensor);
+        inputs.insert("lhs", &input_tensor);
         let mut outputs = MLNamedTensors::new();
-        outputs.insert("sum", &tensor);
+        outputs.insert("sum", &output_tensor);
 
         let err = context.dispatch(&mut graph, &inputs, &outputs).unwrap_err();
         std::assert_matches!(

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -789,6 +789,25 @@ webnn_graph "sample_graph" v1 {
         );
     }
 
+    #[test]
+    fn test_dispatch_allows_same_name_for_distinct_input_and_output_tensors() {
+        let descriptor = MLTensorDescriptor::new(MLOperandDataType::Float32, vec![2, 2]);
+        let input_tensor = MLTensor {
+            id: 7,
+            constant: false,
+            descriptor: descriptor.clone(),
+        };
+        let output_tensor = MLTensor {
+            id: 8,
+            constant: false,
+            descriptor,
+        };
+        let inputs = MLNamedTensors::from([("value", &input_tensor)]);
+        let outputs = MLNamedTensors::from([("value", &output_tensor)]);
+
+        validate_unique_tensor_bindings(&inputs, &outputs).unwrap();
+    }
+
     #[cfg(feature = "trtx-runtime")]
     #[test]
     fn test_trtx_cuda_graph_replay() {


### PR DESCRIPTION
## Summary

- Validate duplicate `MLTensor` dispatch bindings by tensor identity rather than binding name.
- Reject reuse of the same logical tensor across input and output bindings before backend dispatch.
- Update existing dispatch tests so successful and unrelated-error cases use distinct input and output tensors.

The previous map stored `binding name -> tensor id`. Because `MLNamedTensors` already enforces unique names, that check could not detect one tensor bound under different names. This changes the map to `tensor id -> first binding name` and adds backend-independent regression coverage.

## Standards and upstream test coverage

This implements the `MLContext.dispatch()` requirement that the combined input and output tensor list contain no duplicate items.

Chromium currently checks repeated output tensors and input/output reuse by `MLTensor` object membership in [`ValidateMLTensorUsage()`](https://github.com/chromium/chromium/blob/a4224948aecb4020c0efbc1936be667fa1a17fba/third_party/blink/renderer/modules/ml/ml_context.cc#L296-L318). Its [`WebNNGraphDispatchTest`](https://github.com/chromium/chromium/blob/a4224948aecb4020c0efbc1936be667fa1a17fba/third_party/blink/renderer/modules/ml/webnn/ml_graph_test.cc#L1209-L1267) exercises successful repeated dispatch, but I could not find an alias-rejection assertion there. I also could not find a corresponding dispatch/`MLTensor` alias case in the current WPT [`webnn/validation_tests`](https://github.com/web-platform-tests/wpt/tree/master/webnn/validation_tests) directory or another conformance suite in the WebNN standards repository.

Would you all prefer a follow-up WPT validation test covering duplicate inputs, duplicate outputs, and input/output reuse, or is there another WebNN conformance suite where these cases belong? (or is this not really a problem?)

## Validation

- `make fmt-check`
- Focused regression: 1 passed, 0 failed
- `cargo test --lib`: 341 passed, 0 failed
- `make docs-backend-ops-check`

`make test` reaches the existing Rust 1.97 Clippy gate and stops on 48 diagnostics in unchanged files. The changed file introduces no new diagnostic; formatting, focused coverage, the complete library suite, and the documentation drift check pass.
