### PR TITLE
Dynamic shape explainer

### DIFF
--- a/src/backends/cann.rs
+++ b/src/backends/cann.rs
@@ -50,6 +50,10 @@ impl ListDevices for CannContext {
 }
 
 impl<'context> MLBackendContext<'context> for CannContext {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        crate::tensor::BackendKind::Cann
+    }
+
     fn accelerated(&self) -> bool {
         true
     }

--- a/src/backends/coreml.rs
+++ b/src/backends/coreml.rs
@@ -121,6 +121,10 @@ impl CoremlContext {
 }
 
 impl<'context> MLBackendContext<'context> for CoremlContext {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        crate::tensor::BackendKind::CoreML
+    }
+
     fn accelerated(&self) -> bool {
         self.device_type != DeviceType::Cpu
     }

--- a/src/backends/litert.rs
+++ b/src/backends/litert.rs
@@ -881,6 +881,10 @@ impl ListDevices for LiteRtContext {
 }
 
 impl<'context> MLBackendContext<'context> for LiteRtContext {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        crate::tensor::BackendKind::LiteRT
+    }
+
     fn accelerated(&self) -> bool {
         self.device_type != DeviceType::Cpu
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -37,6 +37,10 @@ impl DisabledContext {
 }
 
 impl<'context> mlcontext::MLBackendContext<'context> for DisabledContext {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        panic!("RustNN is expected to never use a disabled backend")
+    }
+
     fn accelerated(&self) -> bool {
         panic!("RustNN is expected to never use a disabled backend")
     }

--- a/src/backends/ort.rs
+++ b/src/backends/ort.rs
@@ -684,6 +684,14 @@ impl ListDevices for OrtContext {
 }
 
 impl<'context> MLBackendContext<'context> for OrtContext {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        let device = self.env.devices().nth(self.device_idx).unwrap();
+        match device.hardware_device().ty() {
+            DeviceType::CPU => crate::tensor::BackendKind::OnnxCpu,
+            DeviceType::GPU | DeviceType::NPU => crate::tensor::BackendKind::OnnxGpu,
+        }
+    }
+
     fn accelerated(&self) -> bool {
         let device = self.env.devices().nth(self.device_idx).unwrap();
         device.hardware_device().ty() != DeviceType::CPU

--- a/src/backends/trtx.rs
+++ b/src/backends/trtx.rs
@@ -624,6 +624,10 @@ impl<'context, 'builder> MLBackendBuilder<'context, 'builder> for TrtxBuilder<'c
 
 #[allow(unused_variables)]
 impl<'context> MLBackendContext<'context> for TrtxContext<'context> {
+    fn backend_kind(&self) -> crate::tensor::BackendKind {
+        crate::tensor::BackendKind::TensorRT
+    }
+
     fn accelerated(&self) -> bool {
         true
     }

--- a/src/dynamic_shapes_explainer.rs
+++ b/src/dynamic_shapes_explainer.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Nvidia
+//
+// SPDX-License-Identifier: Apache-2
+
+// From https://github.com/webmachinelearning/webnn/pull/945.
+pub trait DynamicShapeBuilder {
+    // Read an operand's shape as a runtime uint32 1-D tensor.
+    fn shape(&mut self, input: MLOperand) -> MLOperand {
+        self.shape_with_options(input, MLOperatorOptions::default())
+    }
+    fn shape_with_options(&mut self, input: MLOperand, options: MLOperatorOptions) -> MLOperand;
+
+    // Shape generators / arithmetic on shape tensors.
+    fn range(&mut self, start: MLOperand, limit: MLOperand, delta: MLOperand) -> MLOperand {
+        self.range_with_options(start, limit, delta, MLOperatorOptions::default())
+    }
+    fn range_with_options(
+        &mut self,
+        start: MLOperand,
+        limit: MLOperand,
+        delta: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+    fn modulus_floor(&mut self, a: MLOperand, b: MLOperand) -> MLOperand {
+        self.modulus_floor_with_options(a, b, MLOperatorOptions::default())
+    }
+    fn modulus_floor_with_options(
+        &mut self,
+        a: MLOperand,
+        b: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+    fn modulus_truncate(&mut self, a: MLOperand, b: MLOperand) -> MLOperand {
+        self.modulus_truncate_with_options(a, b, MLOperatorOptions::default())
+    }
+    fn modulus_truncate_with_options(
+        &mut self,
+        a: MLOperand,
+        b: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+
+    // Rank-changing operators (the seam where dynamic rank originates).
+    fn squeeze(&mut self, input: MLOperand) -> MLOperand {
+        self.squeeze_with_options(input, MLSqueezeOptions::default())
+    }
+    fn squeeze_with_options(&mut self, input: MLOperand, options: MLSqueezeOptions) -> MLOperand;
+    fn unsqueeze(&mut self, input: MLOperand, axes: &[u32]) -> MLOperand {
+        self.unsqueeze_with_options(input, axes, MLOperatorOptions::default())
+    }
+    fn unsqueeze_with_options(
+        &mut self,
+        input: MLOperand,
+        axes: &[u32],
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+    fn reshape_to_2d(&mut self, input: MLOperand) -> MLOperand {
+        self.reshape_to_2d_with_options(input, MLReshapeTo2dOptions::default())
+    }
+    fn reshape_to_2d_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLReshapeTo2dOptions,
+    ) -> MLOperand;
+
+    // Dynamic variants: shape parameters are operands, evaluated at dispatch.
+    fn reshape_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> MLOperand {
+        self.reshape_dynamic_with_options(input, new_shape, MLOperatorOptions::default())
+    }
+    fn reshape_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        new_shape: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+    fn expand_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> MLOperand {
+        self.expand_dynamic_with_options(input, new_shape, MLOperatorOptions::default())
+    }
+    fn expand_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        new_shape: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+    fn slice_dynamic(
+        &mut self,
+        input: MLOperand,
+        starts: MLOperand,
+        sizes: MLOperand,
+    ) -> MLOperand {
+        self.slice_dynamic_with_options(input, starts, sizes, MLSliceDynamicOptions::default())
+    }
+    fn slice_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        starts: MLOperand,
+        sizes: MLOperand,
+        options: MLSliceDynamicOptions,
+    ) -> MLOperand;
+    fn pad_dynamic(
+        &mut self,
+        input: MLOperand,
+        beginning_padding: MLOperand,
+        ending_padding: MLOperand,
+    ) -> MLOperand {
+        self.pad_dynamic_with_options(
+            input,
+            beginning_padding,
+            ending_padding,
+            MLOperatorOptions::default(),
+        )
+    }
+    fn pad_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        beginning_padding: MLOperand,
+        ending_padding: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+
+    fn split_dynamic(&mut self, input: MLOperand, splits: MLOperand) -> Vec<MLOperand> {
+        self.split_dynamic_with_options(input, splits, MLSplitOptions::default())
+    }
+    fn split_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        splits: MLOperand,
+        options: MLSplitOptions,
+    ) -> Vec<MLOperand>;
+    fn resample_2d_dynamic(&mut self, input: MLOperand) -> MLOperand {
+        self.resample_2d_dynamic_with_options(input, MLResample2dDynamicOptions::default())
+    }
+    fn resample_2d_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLResample2dDynamicOptions,
+    ) -> MLOperand;
+    fn tile_dynamic(&mut self, input: MLOperand, repetitions: MLOperand) -> MLOperand {
+        self.tile_dynamic_with_options(input, repetitions, MLOperatorOptions::default())
+    }
+    fn tile_dynamic_with_options(
+        &mut self,
+        input: MLOperand,
+        repetitions: MLOperand,
+        options: MLOperatorOptions,
+    ) -> MLOperand;
+}

--- a/src/dynamic_shapes_explainer.rs
+++ b/src/dynamic_shapes_explainer.rs
@@ -153,5 +153,3 @@ pub trait DynamicShapeBuilder {
         options: MLOperatorOptions,
     ) -> MLOperand;
 }
-
-//impl DynamicShapeBuilder for

--- a/src/dynamic_shapes_explainer.rs
+++ b/src/dynamic_shapes_explainer.rs
@@ -2,6 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2
 
+use crate::{
+    mlcontext::MLOperand,
+    operator_options::{
+        MLOperatorOptions, MLResample2dDynamicOptions, MLReshapeTo2dOptions, MLSliceDynamicOptions,
+        MLSplitOptions, MLSqueezeOptions,
+    },
+};
+
 // From https://github.com/webmachinelearning/webnn/pull/945.
 pub trait DynamicShapeBuilder {
     // Read an operand's shape as a runtime uint32 1-D tensor.
@@ -145,3 +153,5 @@ pub trait DynamicShapeBuilder {
         options: MLOperatorOptions,
     ) -> MLOperand;
 }
+
+//impl DynamicShapeBuilder for

--- a/src/dynamic_shapes_explainer.rs
+++ b/src/dynamic_shapes_explainer.rs
@@ -53,6 +53,10 @@ pub trait DynamicShapeBuilder {
         options: MLOperatorOptions,
     ) -> Result<MLOperand>;
 
+    // TODO: the operands below allow to transform data into shape. This requires that
+    // even compute_shape should be capable to run full inference or it defers this to
+    // the backend framework where there might be inconsistent behavio
+
     // Rank-changing operators (the seam where dynamic rank originates).
     fn squeeze(&mut self, input: MLOperand) -> Result<MLOperand> {
         self.squeeze_with_options(input, MLSqueezeOptions::default())

--- a/src/dynamic_shapes_explainer.rs
+++ b/src/dynamic_shapes_explainer.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     mlcontext::MLOperand,
+    mlgraphbuilder::Result,
     operator_options::{
         MLOperatorOptions, MLResample2dDynamicOptions, MLReshapeTo2dOptions, MLSliceDynamicOptions,
         MLSplitOptions, MLSqueezeOptions,
@@ -13,13 +14,17 @@ use crate::{
 // From https://github.com/webmachinelearning/webnn/pull/945.
 pub trait DynamicShapeBuilder {
     // Read an operand's shape as a runtime uint32 1-D tensor.
-    fn shape(&mut self, input: MLOperand) -> MLOperand {
+    fn shape(&mut self, input: MLOperand) -> Result<MLOperand> {
         self.shape_with_options(input, MLOperatorOptions::default())
     }
-    fn shape_with_options(&mut self, input: MLOperand, options: MLOperatorOptions) -> MLOperand;
+    fn shape_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLOperatorOptions,
+    ) -> Result<MLOperand>;
 
     // Shape generators / arithmetic on shape tensors.
-    fn range(&mut self, start: MLOperand, limit: MLOperand, delta: MLOperand) -> MLOperand {
+    fn range(&mut self, start: MLOperand, limit: MLOperand, delta: MLOperand) -> Result<MLOperand> {
         self.range_with_options(start, limit, delta, MLOperatorOptions::default())
     }
     fn range_with_options(
@@ -28,8 +33,8 @@ pub trait DynamicShapeBuilder {
         limit: MLOperand,
         delta: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
-    fn modulus_floor(&mut self, a: MLOperand, b: MLOperand) -> MLOperand {
+    ) -> Result<MLOperand>;
+    fn modulus_floor(&mut self, a: MLOperand, b: MLOperand) -> Result<MLOperand> {
         self.modulus_floor_with_options(a, b, MLOperatorOptions::default())
     }
     fn modulus_floor_with_options(
@@ -37,8 +42,8 @@ pub trait DynamicShapeBuilder {
         a: MLOperand,
         b: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
-    fn modulus_truncate(&mut self, a: MLOperand, b: MLOperand) -> MLOperand {
+    ) -> Result<MLOperand>;
+    fn modulus_truncate(&mut self, a: MLOperand, b: MLOperand) -> Result<MLOperand> {
         self.modulus_truncate_with_options(a, b, MLOperatorOptions::default())
     }
     fn modulus_truncate_with_options(
@@ -46,14 +51,18 @@ pub trait DynamicShapeBuilder {
         a: MLOperand,
         b: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
 
     // Rank-changing operators (the seam where dynamic rank originates).
-    fn squeeze(&mut self, input: MLOperand) -> MLOperand {
+    fn squeeze(&mut self, input: MLOperand) -> Result<MLOperand> {
         self.squeeze_with_options(input, MLSqueezeOptions::default())
     }
-    fn squeeze_with_options(&mut self, input: MLOperand, options: MLSqueezeOptions) -> MLOperand;
-    fn unsqueeze(&mut self, input: MLOperand, axes: &[u32]) -> MLOperand {
+    fn squeeze_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLSqueezeOptions,
+    ) -> Result<MLOperand>;
+    fn unsqueeze(&mut self, input: MLOperand, axes: &[u32]) -> Result<MLOperand> {
         self.unsqueeze_with_options(input, axes, MLOperatorOptions::default())
     }
     fn unsqueeze_with_options(
@@ -61,18 +70,18 @@ pub trait DynamicShapeBuilder {
         input: MLOperand,
         axes: &[u32],
         options: MLOperatorOptions,
-    ) -> MLOperand;
-    fn reshape_to_2d(&mut self, input: MLOperand) -> MLOperand {
+    ) -> Result<MLOperand>;
+    fn reshape_to_2d(&mut self, input: MLOperand) -> Result<MLOperand> {
         self.reshape_to_2d_with_options(input, MLReshapeTo2dOptions::default())
     }
     fn reshape_to_2d_with_options(
         &mut self,
         input: MLOperand,
         options: MLReshapeTo2dOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
 
     // Dynamic variants: shape parameters are operands, evaluated at dispatch.
-    fn reshape_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> MLOperand {
+    fn reshape_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> Result<MLOperand> {
         self.reshape_dynamic_with_options(input, new_shape, MLOperatorOptions::default())
     }
     fn reshape_dynamic_with_options(
@@ -80,8 +89,8 @@ pub trait DynamicShapeBuilder {
         input: MLOperand,
         new_shape: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
-    fn expand_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> MLOperand {
+    ) -> Result<MLOperand>;
+    fn expand_dynamic(&mut self, input: MLOperand, new_shape: MLOperand) -> Result<MLOperand> {
         self.expand_dynamic_with_options(input, new_shape, MLOperatorOptions::default())
     }
     fn expand_dynamic_with_options(
@@ -89,13 +98,13 @@ pub trait DynamicShapeBuilder {
         input: MLOperand,
         new_shape: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
     fn slice_dynamic(
         &mut self,
         input: MLOperand,
         starts: MLOperand,
         sizes: MLOperand,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         self.slice_dynamic_with_options(input, starts, sizes, MLSliceDynamicOptions::default())
     }
     fn slice_dynamic_with_options(
@@ -104,13 +113,13 @@ pub trait DynamicShapeBuilder {
         starts: MLOperand,
         sizes: MLOperand,
         options: MLSliceDynamicOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
     fn pad_dynamic(
         &mut self,
         input: MLOperand,
         beginning_padding: MLOperand,
         ending_padding: MLOperand,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         self.pad_dynamic_with_options(
             input,
             beginning_padding,
@@ -124,9 +133,9 @@ pub trait DynamicShapeBuilder {
         beginning_padding: MLOperand,
         ending_padding: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
 
-    fn split_dynamic(&mut self, input: MLOperand, splits: MLOperand) -> Vec<MLOperand> {
+    fn split_dynamic(&mut self, input: MLOperand, splits: MLOperand) -> Result<Vec<MLOperand>> {
         self.split_dynamic_with_options(input, splits, MLSplitOptions::default())
     }
     fn split_dynamic_with_options(
@@ -134,16 +143,16 @@ pub trait DynamicShapeBuilder {
         input: MLOperand,
         splits: MLOperand,
         options: MLSplitOptions,
-    ) -> Vec<MLOperand>;
-    fn resample_2d_dynamic(&mut self, input: MLOperand) -> MLOperand {
+    ) -> Result<Vec<MLOperand>>;
+    fn resample_2d_dynamic(&mut self, input: MLOperand) -> Result<MLOperand> {
         self.resample_2d_dynamic_with_options(input, MLResample2dDynamicOptions::default())
     }
     fn resample_2d_dynamic_with_options(
         &mut self,
         input: MLOperand,
         options: MLResample2dDynamicOptions,
-    ) -> MLOperand;
-    fn tile_dynamic(&mut self, input: MLOperand, repetitions: MLOperand) -> MLOperand {
+    ) -> Result<MLOperand>;
+    fn tile_dynamic(&mut self, input: MLOperand, repetitions: MLOperand) -> Result<MLOperand> {
         self.tile_dynamic_with_options(input, repetitions, MLOperatorOptions::default())
     }
     fn tile_dynamic_with_options(
@@ -151,5 +160,5 @@ pub trait DynamicShapeBuilder {
         input: MLOperand,
         repetitions: MLOperand,
         options: MLOperatorOptions,
-    ) -> MLOperand;
+    ) -> Result<MLOperand>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::backend_selection::Backend;
+use crate::{backend_selection::Backend, tensor::BackendKind};
 use std::path::PathBuf;
 
 use crate::{
@@ -90,6 +90,8 @@ pub enum ShapeInferenceError {
         operation: Operation,
         input: (MLOperand, Operand),
     },
+    #[error("Backend {backend:?} does not implement MLGraph.compute_shapes")]
+    ComputeShapesNotImplemented { backend: BackendKind },
 }
 
 // TODO: use graph_operation_to_webnn_node for error reporting the problematic node?
@@ -333,6 +335,12 @@ pub enum Error {
     CudaError {
         #[from]
         source: DriverError,
+    },
+
+    #[error("Compute shapes  errror : {source}")]
+    ShapeInferenceError {
+        #[from]
+        source: Box<ShapeInferenceError>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ pub mod shape_inference;
 pub mod tensor;
 pub mod validator;
 pub mod webnn_json;
+
+#[cfg(feature = "dynamic-inputs")]
+pub mod dynamic_shapes_explainer;
 pub(crate) mod webnn_save;
 
 #[cfg(all(target_os = "macos", feature = "coreml-runtime"))]

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -9,6 +9,8 @@ pub use crate::backend_selection::{Backend, BackendDevice, DeviceType};
 use crate::backends::trtx::TrtxGraph;
 use crate::error::Error;
 use crate::error::Result;
+#[cfg(feature = "dynamic-inputs")]
+use crate::error::ShapeInferenceError;
 use crate::graph::DynamicDimension;
 use crate::graph::{DataType, Dimension, Operand, get_static_or_max_size};
 use crate::mlgraphbuilder::get_operand;
@@ -20,6 +22,7 @@ use crate::backends::coreml::CoremlContext;
 use crate::backends::litert::LiteRtContext;
 use crate::backends::ort::OrtContext;
 use crate::backends::trtx::TrtxContext;
+use crate::tensor::BackendKind;
 use std::collections::BTreeMap;
 use std::{collections::HashMap, fmt::Display, marker::PhantomData};
 
@@ -32,6 +35,10 @@ pub use crate::mlcontextoptions::{
 pub type MLNamedTensors<'names> = BTreeMap<&'names str, &'names MLTensor>;
 /// <https://www.w3.org/TR/webnn/#typedefdef-mlnamedoperands>
 pub type MLNamedOperands<'names> = BTreeMap<&'names str, MLOperand>;
+
+#[cfg(feature = "dynamic-inputs")]
+/// This name is an invention of my own
+pub type MLNamedShapes<'names, 'shapes> = BTreeMap<&'names str, &'shapes [u32]>;
 
 pub use crate::mlgraphbuilder::MLGraphBuilder;
 use crate::{
@@ -76,6 +83,18 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
         inputs: &MLNamedTensors,
         outputs: &MLNamedTensors,
     ) -> Result<()>;
+
+    #[cfg(feature = "dynamic-inputs")]
+    fn compute_shapes(
+        &mut self,
+        input_shapes: &mut MLNamedShapes,
+    ) -> Result<MLNamedShapes<'_, '_>> {
+        Err(Box::new(ShapeInferenceError::ComputeShapesNotImplemented {
+            backend: self.backend_kind(),
+        })
+        .into())
+    }
+    fn backend_kind(&self) -> BackendKind;
 }
 
 pub(crate) trait MLBackendBuilder<'context, 'builder>: std::fmt::Debug + Send {
@@ -686,6 +705,15 @@ impl<'context> MLContext<'context> {
         max_shape: &[u64],
     ) -> Result<()> {
         self.backend.rustnn_set_tensor_capacity(tensor, max_shape)
+    }
+
+    #[cfg(feature = "dynamic-inputs")]
+    fn compute_shapes(
+        &mut self,
+        input_shapes: &mut MLNamedShapes,
+    ) -> Result<MLNamedShapes<'_, '_>> {
+        debug!("compute_shapes: {input_shapes:?}");
+        self.backend.compute_shapes(input_shapes)
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -305,6 +305,19 @@ pub struct MLOperandDescriptor {
     shape: Vec<u64>, // TODO: this is u64 instead of WebNN's u32. u32 is screaming for problems on desktop
 }
 
+impl From<&MLOperandDescriptor> for MLDynamicOperandDescriptor {
+    fn from(val: &MLOperandDescriptor) -> Self {
+        MLDynamicOperandDescriptor {
+            data_type: val.data_type,
+            shape: val
+                .shape
+                .iter()
+                .map(|s| MLDimension::Static(*s as u32))
+                .collect(),
+        }
+    }
+}
+
 impl From<&MLOperandDescriptor> for OperandDescriptor {
     fn from(val: &MLOperandDescriptor) -> Self {
         OperandDescriptor {
@@ -344,6 +357,28 @@ impl From<&MLDynamicOperandDescriptor> for OperandDescriptor {
                 .collect(),
             pending_permutation: Default::default(),
         }
+    }
+}
+
+impl MLDynamicOperandDescriptor {
+    pub fn new(data_type: MLOperandDataType, shape: Vec<MLDimension>) -> Self {
+        Self { data_type, shape }
+    }
+
+    pub fn data_type(&self) -> MLOperandDataType {
+        self.data_type
+    }
+
+    pub fn shape(&self) -> &[MLDimension] {
+        &self.shape
+    }
+
+    pub fn set_data_type(&mut self, data_type: MLOperandDataType) {
+        self.data_type = data_type;
+    }
+
+    pub fn set_shape(&mut self, shape: Vec<MLDimension>) {
+        self.shape = shape;
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -9,8 +9,10 @@ pub use crate::backend_selection::{Backend, BackendDevice, DeviceType};
 use crate::backends::trtx::TrtxGraph;
 use crate::error::Error;
 use crate::error::Result;
+use crate::graph::DynamicDimension;
 use crate::graph::{DataType, Dimension, Operand, get_static_or_max_size};
 use crate::mlgraphbuilder::get_operand;
+use crate::operator_options::MLDimension;
 use crate::runtime_checks::{RuntimeShapeState, TensorKind};
 
 use crate::backends::cann::CannContext;
@@ -311,6 +313,34 @@ impl From<&MLOperandDescriptor> for OperandDescriptor {
                 .shape
                 .iter()
                 .map(|s| Dimension::Static(*s as u32))
+                .collect(),
+            pending_permutation: Default::default(),
+        }
+    }
+}
+
+// https://github.com/webmachinelearning/webnn/pull/945
+#[cfg(feature = "dynamic-inputs")]
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+pub struct MLDynamicOperandDescriptor {
+    data_type: MLOperandDataType,
+    shape: Vec<MLDimension>,
+}
+
+impl From<&MLDynamicOperandDescriptor> for OperandDescriptor {
+    fn from(val: &MLDynamicOperandDescriptor) -> Self {
+        OperandDescriptor {
+            data_type: val.data_type.into(),
+            shape: val
+                .shape
+                .iter()
+                .map(|s| match s {
+                    MLDimension::Static(s) => Dimension::Static(*s),
+                    MLDimension::Dynamic(d) => Dimension::Dynamic(DynamicDimension {
+                        name: d.name.clone(),
+                        max_size: u32::MAX,
+                    }),
+                })
                 .collect(),
             pending_permutation: Default::default(),
         }

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -87,8 +87,24 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
     #[cfg(feature = "dynamic-inputs")]
     fn compute_shapes(
         &mut self,
-        input_shapes: &mut MLNamedShapes,
+        graph: &mut MLGraph,
+        input_shapes: &MLNamedShapes,
     ) -> Result<MLNamedShapes<'_, '_>> {
+        // It is very difficult to actually implement MLGraph.compute_shapes:
+        //
+        // TRT provides a function to get output shape given the input shapes without running inference
+        // but ONNX runtime does not (there are even operators like NonZero that require inference
+        // to know the output shape).
+        //
+        // Implementing compute_shapes basically requires to split up the graph
+        // into a inference time part and a shape inference time part.
+        // The logic in shape inference part would be artificially limited to avoid
+        // arbitrary complexity in compute shapes
+        //
+        // https://github.com/webmachinelearning/webnn/pull/945#discussion_r3969524029
+        //
+        // We could do an ad-hoc interpreter of WebNN here with a very limited set of operations
+        // and tensor sizes and use that for all implementations.
         Err(Box::new(ShapeInferenceError::ComputeShapesNotImplemented {
             backend: self.backend_kind(),
         })
@@ -534,7 +550,7 @@ impl MLTensorDescriptor {
     }
 }
 
-// TODO: this is wrong. must be 'context and `for <'builder>` to be valid for each builder lifetime (multiple children!)
+// TODO: this is wrong. Must be 'context and `for <'builder>` to be valid for each builder lifetime (multiple children!)
 #[derive(Debug)]
 pub struct MLContext<'context> {
     pub(crate) backend: Box<dyn MLBackendContext<'context> + 'context>,
@@ -708,12 +724,13 @@ impl<'context> MLContext<'context> {
     }
 
     #[cfg(feature = "dynamic-inputs")]
-    fn compute_shapes(
+    pub fn compute_shapes(
         &mut self,
-        input_shapes: &mut MLNamedShapes,
+        graph: &mut MLGraph,
+        input_shapes: &MLNamedShapes,
     ) -> Result<MLNamedShapes<'_, '_>> {
         debug!("compute_shapes: {input_shapes:?}");
-        self.backend.compute_shapes(input_shapes)
+        self.backend.compute_shapes(graph, input_shapes)
     }
 }
 

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -338,7 +338,7 @@ impl From<&MLDynamicOperandDescriptor> for OperandDescriptor {
                     MLDimension::Static(s) => Dimension::Static(*s),
                     MLDimension::Dynamic(d) => Dimension::Dynamic(DynamicDimension {
                         name: d.name.clone(),
-                        max_size: u32::MAX,
+                        max_size: d.max_size,
                     }),
                 })
                 .collect(),

--- a/src/mlcontext.rs
+++ b/src/mlcontext.rs
@@ -105,6 +105,15 @@ pub(crate) trait MLBackendContext<'context>: std::fmt::Debug + Send + Sync {
         //
         // We could do an ad-hoc interpreter of WebNN here with a very limited set of operations
         // and tensor sizes and use that for all implementations.
+        //
+        // Also, we currently throw away our graph after build.
+        // We would need to keep the parts needed for shape inference,
+        // which also means to preserve all constants that are used in this graph.
+        // An alternative, would be to perform symbolic shape inference and keep
+        // the shape expressions for the outputs.
+        // The dynamic shape variants of the operators that transform data into shape
+        // would require to trace symbols through tensor/array contents which z3
+        // (or our own bespoke symbolic shape inferred could do)
         Err(Box::new(ShapeInferenceError::ComputeShapesNotImplemented {
             backend: self.backend_kind(),
         })

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -2607,12 +2607,12 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         Ok(MLOperand { id })
     }
 
-    pub fn constant_from_value<T>(
+    pub fn constant_from_value<T: bytemuck::Pod>(
         &mut self,
-        _data_type: MLOperandDataType,
-        _value: T,
+        data_type: MLOperandDataType,
+        value: T,
     ) -> crate::error::Result<MLOperand> {
-        todo!()
+        self.constant_from_slice::<T>(&MLOperandDescriptor::new(data_type, vec![]), &[value])
     }
 
     // internal methods

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -1112,7 +1112,7 @@ fn shape_op_shape(input: MLOperand, graph: &GraphInfo) -> Result<OperandDescript
     let operand = get_operand(input, graph)?;
     let rank = operand.descriptor.shape.len() as u32;
     Ok(OperandDescriptor {
-        data_type: DataType::Int64,
+        data_type: DataType::Uint32,
         shape: vec![Dimension::Static(rank)],
         pending_permutation: vec![],
     })
@@ -2997,6 +2997,7 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
     impl_unary_op!(softsign, softsign_with_options, Softsign);
     impl_unary_op!(is_nan, is_nan_with_options, IsNaN);
     impl_unary_op!(is_infinite, is_infinite_with_options, IsInfinite);
+    // TODO: put this under the feature dynamic-inputs and DynamicShapeBuilder?
     impl_unary_op!(shape, shape_with_options, Shape);
     impl_unary_op!(
         triangular,
@@ -3344,6 +3345,52 @@ mod test {
         },
         mlgraphbuilder::MLGraphBuilder,
     };
+
+    #[cfg(feature = "dynamic-inputs")]
+    use crate::{
+        dynamic_shapes_explainer::DynamicShapeBuilder, graph::Dimension, operators::Operation,
+    };
+
+    #[cfg(feature = "dynamic-inputs")]
+    #[test]
+    fn shape_records_shape_operation_and_returns_rank_tensor() {
+        let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
+        if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
+            return;
+        }
+        let mut context = context.unwrap();
+        let descriptor = MLOperandDescriptor::new(
+            crate::operator_enums::MLOperandDataType::Float32,
+            vec![2, 3, 4],
+        );
+        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+        let input = builder.input("input", &descriptor).unwrap();
+        let output = builder.shape(input).unwrap();
+        let two = builder
+            .constant_from_value(crate::operator_enums::MLOperandDataType::Uint32, 2u32)
+            .unwrap();
+        let two_x_output = builder.mul(output, two).unwrap();
+        let graph = builder.graph.as_ref().unwrap();
+
+        assert_eq!(output.id, 1);
+        assert_eq!(
+            graph.operands[output.id].descriptor.data_type,
+            crate::DataType::Uint32
+        );
+        assert_eq!(
+            graph.operands[output.id].descriptor.shape,
+            vec![Dimension::Static(3)]
+        );
+        assert!(matches!(
+            graph.operations.as_slice(),
+            [Operation::Shape { input: 0, options: Some(options), outputs }] if options.label.is_empty() && outputs == &vec![1]
+        ));
+
+        let mut outputs = MLNamedOperands::new();
+        outputs.insert("out1", output);
+        outputs.insert("out2", two_x_output);
+        builder.build(&outputs).unwrap();
+    }
 
     #[test]
     fn add_inputs() {

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -3375,7 +3375,7 @@ mod test {
 
     #[cfg(feature = "dynamic-inputs")]
     use crate::{
-        mlcontext::MLDynamicOperandDescriptor,
+        mlcontext::{MLDynamicOperandDescriptor, MLNamedShapes},
         operator_options::{MLDimension, MLDynamicDimension, MLOperatorOptions},
     };
 
@@ -3433,7 +3433,25 @@ mod test {
             let mut outputs = MLNamedOperands::new();
             outputs.insert("out1", output);
             outputs.insert("out2", two_x_output);
-            builder.build(&outputs).unwrap();
+            let mut graph = builder.build(&outputs).unwrap();
+
+            // transform descriptor into concrete shape. "fritz" is obviously 42
+            let concrete_shape: Vec<_> = descriptor
+                .shape()
+                .iter()
+                .map(|s| match s {
+                    MLDimension::Static(s) => *s,
+                    MLDimension::Dynamic(MLDynamicDimension { name, .. }) if name == "fritz" => 42,
+                    _ => unreachable!(),
+                })
+                .collect();
+
+            let mut shapes = MLNamedShapes::new();
+            shapes.insert("input", &concrete_shape);
+
+            //let output_shapes = context.compute_shapes(&mut graph, &shapes).unwrap();
+            //assert!(output_shapes.contains_key("out1"));
+            //assert!(output_shapes.contains_key("out2"));
         }
     }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -45,7 +45,7 @@ pub type Result<T> = std::result::Result<T, GraphBuilderError>;
 
 #[cfg(feature = "dynamic-inputs")]
 impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'builder> {
-    fn shape_with_options(&mut self, _: MLOperand, _: MLOperatorOptions) -> MLOperand {
+    fn shape_with_options(&mut self, _: MLOperand, _: MLOperatorOptions) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn range_with_options(
@@ -54,7 +54,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn modulus_floor_with_options(
@@ -62,7 +62,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn modulus_truncate_with_options(
@@ -70,10 +70,10 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
-    fn squeeze_with_options(&mut self, _: MLOperand, _: MLSqueezeOptions) -> MLOperand {
+    fn squeeze_with_options(&mut self, _: MLOperand, _: MLSqueezeOptions) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn unsqueeze_with_options(
@@ -81,10 +81,14 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: &[u32],
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
-    fn reshape_to_2d_with_options(&mut self, _: MLOperand, _: MLReshapeTo2dOptions) -> MLOperand {
+    fn reshape_to_2d_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLReshapeTo2dOptions,
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn reshape_dynamic_with_options(
@@ -92,7 +96,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn expand_dynamic_with_options(
@@ -100,7 +104,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn slice_dynamic_with_options(
@@ -109,7 +113,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLSliceDynamicOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn pad_dynamic_with_options(
@@ -118,7 +122,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn split_dynamic_with_options(
@@ -126,14 +130,14 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLSplitOptions,
-    ) -> Vec<MLOperand> {
+    ) -> Result<Vec<MLOperand>> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn resample_2d_dynamic_with_options(
         &mut self,
         _: MLOperand,
         _: MLResample2dDynamicOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
     fn tile_dynamic_with_options(
@@ -141,7 +145,7 @@ impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'build
         _: MLOperand,
         _: MLOperand,
         _: MLOperatorOptions,
-    ) -> MLOperand {
+    ) -> Result<MLOperand> {
         unimplemented!("dynamic-shape operation is not implemented")
     }
 }

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -1995,6 +1995,20 @@ fn shape_inference_single_output(
         Operation::Gru { .. } | Operation::Lstm { .. } | Operation::LstmCell { .. } => {
             panic!("This method only supports single output ops. Use shape_inference_multi_output")
         }
+        #[cfg(feature = "dynamic-inputs")]
+        Operation::Range { .. }
+        | Operation::ModulusFloor { .. }
+        | Operation::ModulusTruncate { .. }
+        | Operation::ReshapeTo2d { .. }
+        | Operation::ReshapeDynamic { .. }
+        | Operation::ExpandDynamic { .. }
+        | Operation::SliceDynamic { .. }
+        | Operation::PadDynamic { .. }
+        | Operation::SplitDynamic { .. }
+        | Operation::Resample2dDynamic { .. }
+        | Operation::TileDynamic { .. } => {
+            unimplemented!("dynamic-shape operation shape inference is not implemented")
+        }
     }
 }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -6,6 +6,8 @@ use webnn_graph::serialize::SerializeOptions;
 
 use crate::error::{GraphBuilderError, GraphError, ShapeInferenceError};
 use crate::graph::{Dimension, get_static_or_max_size, to_dimension_vector};
+#[cfg(feature = "dynamic-inputs")]
+use crate::mlcontext::MLDynamicOperandDescriptor;
 use crate::mlcontext::{MLGraph, MLNamedOperands, MLOperand, MLOperandDescriptor, MLTensor};
 use crate::operator_enums::MLOperandDataType;
 use crate::operator_options::{
@@ -2485,6 +2487,31 @@ impl<'context, 'builder> MLGraphBuilder<'context, 'builder> {
         operand.data_type(graph)
     }
 
+    #[cfg(feature = "dynamic-inputs")]
+    pub fn dynamic_input(
+        &mut self,
+        name: &str,
+        descriptor: &MLDynamicOperandDescriptor,
+    ) -> crate::error::Result<MLOperand> {
+        debug!("Adding dynamic input {name:?} {descriptor:?}");
+        let operand = Operand {
+            descriptor: descriptor.into(),
+            kind: OperandKind::Input,
+            name: Some(name.to_string()),
+        };
+
+        let graph = self
+            .graph
+            .as_mut()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?;
+
+        let id = graph.operands.len();
+        graph.operands.push(operand);
+        graph.input_operands.push(id as u32);
+
+        Ok(MLOperand { id })
+    }
+
     pub fn input(
         &mut self,
         name: &str,
@@ -3347,9 +3374,7 @@ mod test {
     };
 
     #[cfg(feature = "dynamic-inputs")]
-    use crate::{
-        dynamic_shapes_explainer::DynamicShapeBuilder, graph::Dimension, operators::Operation,
-    };
+    use crate::{graph::Dimension, operators::Operation};
 
     #[cfg(feature = "dynamic-inputs")]
     #[test]

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -1114,7 +1114,7 @@ fn shape_op_shape(input: MLOperand, graph: &GraphInfo) -> Result<OperandDescript
     let operand = get_operand(input, graph)?;
     let rank = operand.descriptor.shape.len() as u32;
     Ok(OperandDescriptor {
-        data_type: DataType::Uint32,
+        data_type: DataType::Int64, // TODO: this is different from dynamic shape explainer: there u32
         shape: vec![Dimension::Static(rank)],
         pending_permutation: vec![],
     })
@@ -3374,47 +3374,67 @@ mod test {
     };
 
     #[cfg(feature = "dynamic-inputs")]
-    use crate::{graph::Dimension, operators::Operation};
+    use crate::{
+        mlcontext::MLDynamicOperandDescriptor,
+        operator_options::{MLDimension, MLDynamicDimension, MLOperatorOptions},
+    };
 
     #[cfg(feature = "dynamic-inputs")]
     #[test]
-    fn shape_records_shape_operation_and_returns_rank_tensor() {
+    fn test_dynamic_input() {
         let context = MLContext::create(&MLContextOptions::new(MLPowerPreference::Default, true));
         if matches!(context, Err(crate::error::Error::NoBackendAvailable { .. })) {
             return;
         }
         let mut context = context.unwrap();
-        let descriptor = MLOperandDescriptor::new(
-            crate::operator_enums::MLOperandDataType::Float32,
-            vec![2, 3, 4],
-        );
-        let mut builder = MLGraphBuilder::new(&mut context).unwrap();
-        let input = builder.input("input", &descriptor).unwrap();
-        let output = builder.shape(input).unwrap();
-        let two = builder
-            .constant_from_value(crate::operator_enums::MLOperandDataType::Uint32, 2u32)
-            .unwrap();
-        let two_x_output = builder.mul(output, two).unwrap();
-        let graph = builder.graph.as_ref().unwrap();
 
-        assert_eq!(output.id, 1);
-        assert_eq!(
-            graph.operands[output.id].descriptor.data_type,
-            crate::DataType::Uint32
-        );
-        assert_eq!(
-            graph.operands[output.id].descriptor.shape,
-            vec![Dimension::Static(3)]
-        );
-        assert!(matches!(
-            graph.operations.as_slice(),
-            [Operation::Shape { input: 0, options: Some(options), outputs }] if options.label.is_empty() && outputs == &vec![1]
-        ));
+        for descriptor in [
+            MLDynamicOperandDescriptor::new(
+                crate::operator_enums::MLOperandDataType::Float32,
+                vec![MLDimension::Dynamic(MLDynamicDimension {
+                    name: "fritz".to_string(),
+                    max_size: 10,
+                })],
+            ),
+            MLDynamicOperandDescriptor::new(
+                crate::operator_enums::MLOperandDataType::Float32,
+                vec![
+                    MLDimension::Dynamic(MLDynamicDimension {
+                        name: "fritz".to_string(),
+                        max_size: 10,
+                    }),
+                    MLDimension::Static(0),
+                ],
+            ),
+            (&MLOperandDescriptor::new(
+                crate::operator_enums::MLOperandDataType::Float32,
+                vec![2, 3, 4],
+            ))
+                .into(),
+        ]
+        .iter()
+        {
+            let mut builder = MLGraphBuilder::new(&mut context).unwrap();
+            let input = builder.dynamic_input("input", descriptor).unwrap();
+            let output = builder
+                .shape_with_options(
+                    input,
+                    MLOperatorOptions {
+                        label: "shape_op".to_string(),
+                    },
+                )
+                .unwrap();
+            let two = builder
+                .constant_from_value(crate::operator_enums::MLOperandDataType::Int64, 2u64) // TODO: this is different from dynamic shape explainer: there u32
+                .unwrap();
+            let two_x_output = builder.mul(output, two).unwrap();
+            insta::assert_debug_snapshot!(builder.graph);
 
-        let mut outputs = MLNamedOperands::new();
-        outputs.insert("out1", output);
-        outputs.insert("out2", two_x_output);
-        builder.build(&outputs).unwrap();
+            let mut outputs = MLNamedOperands::new();
+            outputs.insert("out1", output);
+            outputs.insert("out2", two_x_output);
+            builder.build(&outputs).unwrap();
+        }
     }
 
     #[test]

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -44,109 +44,233 @@ use crate::{
 pub type Result<T> = std::result::Result<T, GraphBuilderError>;
 
 #[cfg(feature = "dynamic-inputs")]
+macro_rules! add_dynamic_single_output {
+    ($builder:expr, $operation:ident { $($field:ident: $value:expr),* $(,)? }) => {{
+        let output_id = $builder
+            .graph
+            .as_ref()
+            .ok_or(GraphBuilderError::GraphAlreadyBuilt)?
+            .operands
+            .len() as u32;
+        $builder.add_single_output_operation(Operation::$operation {
+            $($field: $value,)*
+            outputs: vec![output_id],
+        })
+    }};
+}
+
+#[cfg(feature = "dynamic-inputs")]
 impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'builder> {
-    fn shape_with_options(&mut self, _: MLOperand, _: MLOperatorOptions) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+    fn shape_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLOperatorOptions,
+    ) -> Result<MLOperand> {
+        add_dynamic_single_output!(
+            self,
+            Shape {
+                input: input.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn range_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        start: MLOperand,
+        limit: MLOperand,
+        delta: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            Range {
+                start: start.id as u32,
+                limit: limit.id as u32,
+                delta: delta.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn modulus_floor_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        a: MLOperand,
+        b: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            ModulusFloor {
+                a: a.id as u32,
+                b: b.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn modulus_truncate_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        a: MLOperand,
+        b: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            ModulusTruncate {
+                a: a.id as u32,
+                b: b.id as u32,
+                options: Some(options)
+            }
+        )
     }
-    fn squeeze_with_options(&mut self, _: MLOperand, _: MLSqueezeOptions) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+    fn squeeze_with_options(
+        &mut self,
+        input: MLOperand,
+        options: MLSqueezeOptions,
+    ) -> Result<MLOperand> {
+        self.unary_same_shape_operation(input, options, |input, output, options| {
+            Operation::Squeeze {
+                input,
+                options,
+                outputs: vec![output],
+            }
+        })
     }
     fn unsqueeze_with_options(
         &mut self,
-        _: MLOperand,
-        _: &[u32],
-        _: MLOperatorOptions,
+        input: MLOperand,
+        axes: &[u32],
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            Unsqueeze {
+                input: input.id as u32,
+                options: Some(crate::operator_options::MLUnsqueezeOptions {
+                    axes: axes.to_vec(),
+                    label: options.label
+                })
+            }
+        )
     }
     fn reshape_to_2d_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLReshapeTo2dOptions,
+        input: MLOperand,
+        options: MLReshapeTo2dOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            ReshapeTo2d {
+                input: input.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn reshape_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        input: MLOperand,
+        new_shape: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            ReshapeDynamic {
+                input: input.id as u32,
+                new_shape: new_shape.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn expand_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        input: MLOperand,
+        new_shape: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            ExpandDynamic {
+                input: input.id as u32,
+                new_shape: new_shape.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn slice_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLSliceDynamicOptions,
+        input: MLOperand,
+        starts: MLOperand,
+        sizes: MLOperand,
+        options: MLSliceDynamicOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            SliceDynamic {
+                input: input.id as u32,
+                starts: starts.id as u32,
+                sizes: sizes.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn pad_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        input: MLOperand,
+        beginning_padding: MLOperand,
+        ending_padding: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            PadDynamic {
+                input: input.id as u32,
+                beginning_padding: beginning_padding.id as u32,
+                ending_padding: ending_padding.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn split_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLSplitOptions,
+        input: MLOperand,
+        splits: MLOperand,
+        options: MLSplitOptions,
     ) -> Result<Vec<MLOperand>> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            SplitDynamic {
+                input: input.id as u32,
+                splits: splits.id as u32,
+                options: Some(options)
+            }
+        )
+        .map(|output| vec![output])
     }
     fn resample_2d_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLResample2dDynamicOptions,
+        input: MLOperand,
+        options: MLResample2dDynamicOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            Resample2dDynamic {
+                input: input.id as u32,
+                options: Some(options)
+            }
+        )
     }
     fn tile_dynamic_with_options(
         &mut self,
-        _: MLOperand,
-        _: MLOperand,
-        _: MLOperatorOptions,
+        input: MLOperand,
+        repetitions: MLOperand,
+        options: MLOperatorOptions,
     ) -> Result<MLOperand> {
-        unimplemented!("dynamic-shape operation is not implemented")
+        add_dynamic_single_output!(
+            self,
+            TileDynamic {
+                input: input.id as u32,
+                repetitions: repetitions.id as u32,
+                options: Some(options)
+            }
+        )
     }
 }
 

--- a/src/mlgraphbuilder.rs
+++ b/src/mlgraphbuilder.rs
@@ -35,7 +35,116 @@ use crate::{
     mlcontext::{MLBackendBuilder, MLContext},
 };
 
+#[cfg(feature = "dynamic-inputs")]
+use crate::{
+    dynamic_shapes_explainer::DynamicShapeBuilder,
+    operator_options::{MLResample2dDynamicOptions, MLReshapeTo2dOptions, MLSliceDynamicOptions},
+};
+
 pub type Result<T> = std::result::Result<T, GraphBuilderError>;
+
+#[cfg(feature = "dynamic-inputs")]
+impl<'context, 'builder> DynamicShapeBuilder for MLGraphBuilder<'context, 'builder> {
+    fn shape_with_options(&mut self, _: MLOperand, _: MLOperatorOptions) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn range_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn modulus_floor_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn modulus_truncate_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn squeeze_with_options(&mut self, _: MLOperand, _: MLSqueezeOptions) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn unsqueeze_with_options(
+        &mut self,
+        _: MLOperand,
+        _: &[u32],
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn reshape_to_2d_with_options(&mut self, _: MLOperand, _: MLReshapeTo2dOptions) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn reshape_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn expand_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn slice_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLSliceDynamicOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn pad_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn split_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLSplitOptions,
+    ) -> Vec<MLOperand> {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn resample_2d_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLResample2dDynamicOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+    fn tile_dynamic_with_options(
+        &mut self,
+        _: MLOperand,
+        _: MLOperand,
+        _: MLOperatorOptions,
+    ) -> MLOperand {
+        unimplemented!("dynamic-shape operation is not implemented")
+    }
+}
 
 #[derive(Debug)]
 pub struct MLGraphBuilder<'context, 'builder> {

--- a/src/operator_options.rs
+++ b/src/operator_options.rs
@@ -236,6 +236,66 @@ pub struct MLOperatorOptions {
     pub label: String,
 }
 
+// From https://github.com/webmachinelearning/webnn/pull/945.
+#[cfg(feature = "dynamic-inputs")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct MLReshapeTo2dOptions {
+    #[serde(default)]
+    pub label: String,
+    #[serde(default = "default_reshape_to_2d_axis")]
+    pub axis: u32,
+}
+
+#[cfg(feature = "dynamic-inputs")]
+impl Default for MLReshapeTo2dOptions {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            axis: default_reshape_to_2d_axis(),
+        }
+    }
+}
+
+#[cfg(feature = "dynamic-inputs")]
+fn default_reshape_to_2d_axis() -> u32 {
+    1
+}
+
+#[cfg(feature = "dynamic-inputs")]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct MLSliceDynamicOptions {
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub strides: Vec<u32>,
+}
+
+#[cfg(feature = "dynamic-inputs")]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MLResample2dDynamicOptions {
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub mode: String,
+    #[serde(default)]
+    pub scales: Vec<f32>,
+    #[serde(default)]
+    pub axes: Vec<u32>,
+}
+
+#[cfg(feature = "dynamic-inputs")]
+impl std::hash::Hash for MLResample2dDynamicOptions {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.label.hash(state);
+        self.mode.hash(state);
+        bytemuck::cast_slice::<f32, u8>(&self.scales).hash(state);
+        self.axes.hash(state);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Dictionaries extending MLOperatorOptions (spec order)
 // ---------------------------------------------------------------------------

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -54,6 +54,11 @@ use crate::{
     },
 };
 
+#[cfg(feature = "dynamic-inputs")]
+use crate::operator_options::{
+    MLResample2dDynamicOptions, MLReshapeTo2dOptions, MLSliceDynamicOptions,
+};
+
 // ---------------------------------------------------------------------------
 // Operation enum: one variant per WebNN builder
 // ---------------------------------------------------------------------------
@@ -785,8 +790,91 @@ pub enum Operation {
 
     // ---------- Shape (interchange / internal) ----------
     /// Shape operator (interchange / internal; see spec § 7.3).
+    // TODO: Align this existing interchange/internal operation with the dynamic-shape explainer.
+    // From https://github.com/webmachinelearning/webnn/pull/945.
     Shape {
         input: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+
+    // ---------- Dynamic shape ----------
+    // From https://github.com/webmachinelearning/webnn/pull/945.
+    #[cfg(feature = "dynamic-inputs")]
+    Range {
+        start: OperandIndex,
+        limit: OperandIndex,
+        delta: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    ModulusFloor {
+        a: OperandIndex,
+        b: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    ModulusTruncate {
+        a: OperandIndex,
+        b: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    ReshapeTo2d {
+        input: OperandIndex,
+        options: Option<MLReshapeTo2dOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    ReshapeDynamic {
+        input: OperandIndex,
+        new_shape: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    ExpandDynamic {
+        input: OperandIndex,
+        new_shape: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    SliceDynamic {
+        input: OperandIndex,
+        starts: OperandIndex,
+        sizes: OperandIndex,
+        options: Option<MLSliceDynamicOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    PadDynamic {
+        input: OperandIndex,
+        beginning_padding: OperandIndex,
+        ending_padding: OperandIndex,
+        options: Option<MLOperatorOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    SplitDynamic {
+        input: OperandIndex,
+        splits: OperandIndex,
+        options: Option<MLSplitOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    Resample2dDynamic {
+        input: OperandIndex,
+        options: Option<MLResample2dDynamicOptions>,
+        outputs: Vec<OperandIndex>,
+    },
+    #[cfg(feature = "dynamic-inputs")]
+    TileDynamic {
+        input: OperandIndex,
+        repetitions: OperandIndex,
         options: Option<MLOperatorOptions>,
         outputs: Vec<OperandIndex>,
     },
@@ -1019,6 +1107,28 @@ impl Operation {
             Operation::Softsign { .. } => "softsign",
             Operation::Gelu { .. } => "gelu",
             Operation::Shape { .. } => "shape",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Range { .. } => "range",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ModulusFloor { .. } => "modulusFloor",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ModulusTruncate { .. } => "modulusTruncate",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeTo2d { .. } => "reshapeTo2d",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeDynamic { .. } => "reshapeDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ExpandDynamic { .. } => "expandDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SliceDynamic { .. } => "sliceDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::PadDynamic { .. } => "padDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SplitDynamic { .. } => "splitDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Resample2dDynamic { .. } => "resample2dDynamic",
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::TileDynamic { .. } => "tileDynamic",
             Operation::ScatterND { .. } => "scatterND",
             Operation::GatherND { .. } => "gatherND",
             Operation::IsNaN { .. } => "isNaN",
@@ -1212,6 +1322,48 @@ impl Operation {
             Operation::Softsign { input, .. } => vec![*input],
             Operation::Gelu { input, .. } => vec![*input],
             Operation::Shape { input, .. } => vec![*input],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Range {
+                start,
+                limit,
+                delta,
+                ..
+            } => vec![*start, *limit, *delta],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ModulusFloor { a, b, .. } | Operation::ModulusTruncate { a, b, .. } => {
+                vec![*a, *b]
+            }
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeTo2d { input, .. } | Operation::Resample2dDynamic { input, .. } => {
+                vec![*input]
+            }
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeDynamic {
+                input, new_shape, ..
+            }
+            | Operation::ExpandDynamic {
+                input, new_shape, ..
+            } => vec![*input, *new_shape],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SliceDynamic {
+                input,
+                starts,
+                sizes,
+                ..
+            } => vec![*input, *starts, *sizes],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::PadDynamic {
+                input,
+                beginning_padding,
+                ending_padding,
+                ..
+            } => vec![*input, *beginning_padding, *ending_padding],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SplitDynamic { input, splits, .. } => vec![*input, *splits],
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::TileDynamic {
+                input, repetitions, ..
+            } => vec![*input, *repetitions],
             Operation::ScatterND {
                 input,
                 indices,
@@ -1324,6 +1476,18 @@ impl Operation {
             Operation::Softsign { outputs, .. } => outputs,
             Operation::Gelu { outputs, .. } => outputs,
             Operation::Shape { outputs, .. } => outputs,
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Range { outputs, .. }
+            | Operation::ModulusFloor { outputs, .. }
+            | Operation::ModulusTruncate { outputs, .. }
+            | Operation::ReshapeTo2d { outputs, .. }
+            | Operation::ReshapeDynamic { outputs, .. }
+            | Operation::ExpandDynamic { outputs, .. }
+            | Operation::SliceDynamic { outputs, .. }
+            | Operation::PadDynamic { outputs, .. }
+            | Operation::SplitDynamic { outputs, .. }
+            | Operation::Resample2dDynamic { outputs, .. }
+            | Operation::TileDynamic { outputs, .. } => outputs,
             Operation::ScatterND { outputs, .. } => outputs,
             Operation::GatherND { outputs, .. } => outputs,
             Operation::IsNaN { outputs, .. } => outputs,
@@ -1445,6 +1609,22 @@ impl Operation {
             Operation::Unsqueeze { options, .. } => opt_label!(options),
             Operation::Tile { options, .. } => opt_label!(options),
             Operation::Triangular { options, .. } => opt_label!(options),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Range { options, .. }
+            | Operation::ModulusFloor { options, .. }
+            | Operation::ModulusTruncate { options, .. }
+            | Operation::ReshapeDynamic { options, .. }
+            | Operation::ExpandDynamic { options, .. }
+            | Operation::PadDynamic { options, .. }
+            | Operation::TileDynamic { options, .. } => opt_label!(options),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SplitDynamic { options, .. } => opt_label!(options),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeTo2d { options, .. } => opt_label!(options),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SliceDynamic { options, .. } => opt_label!(options),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Resample2dDynamic { options, .. } => opt_label!(options),
         }
     }
 
@@ -2183,6 +2363,115 @@ impl Operation {
             Operation::Gelu { input, options, .. } => (
                 tag.clone(),
                 vec![*input],
+                OO::Operator(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Range {
+                start,
+                limit,
+                delta,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*start, *limit, *delta],
+                OO::Operator(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ModulusFloor { a, b, options, .. }
+            | Operation::ModulusTruncate { a, b, options, .. } => (
+                tag.clone(),
+                vec![*a, *b],
+                OO::Operator(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeTo2d { input, options, .. } => (
+                tag.clone(),
+                vec![*input],
+                OO::Operator(MLOperatorOptions {
+                    label: options
+                        .as_ref()
+                        .map(|options| options.label.clone())
+                        .unwrap_or_default(),
+                }),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::ReshapeDynamic {
+                input,
+                new_shape,
+                options,
+                ..
+            }
+            | Operation::ExpandDynamic {
+                input,
+                new_shape,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*input, *new_shape],
+                OO::Operator(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SliceDynamic {
+                input,
+                starts,
+                sizes,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*input, *starts, *sizes],
+                OO::Operator(MLOperatorOptions {
+                    label: options
+                        .as_ref()
+                        .map(|options| options.label.clone())
+                        .unwrap_or_default(),
+                }),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::PadDynamic {
+                input,
+                beginning_padding,
+                ending_padding,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*input, *beginning_padding, *ending_padding],
+                OO::Operator(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::SplitDynamic {
+                input,
+                splits,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*input, *splits],
+                OO::Split(options.clone().unwrap_or_default()),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::Resample2dDynamic { input, options, .. } => (
+                tag.clone(),
+                vec![*input],
+                OO::Operator(MLOperatorOptions {
+                    label: options
+                        .as_ref()
+                        .map(|options| options.label.clone())
+                        .unwrap_or_default(),
+                }),
+            ),
+            #[cfg(feature = "dynamic-inputs")]
+            Operation::TileDynamic {
+                input,
+                repetitions,
+                options,
+                ..
+            } => (
+                tag.clone(),
+                vec![*input, *repetitions],
                 OO::Operator(options.clone().unwrap_or_default()),
             ),
             Operation::Shape { input, options, .. } => (

--- a/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input-2.snap
+++ b/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input-2.snap
@@ -1,0 +1,116 @@
+---
+source: src/mlgraphbuilder.rs
+expression: builder.graph
+---
+Some(
+    GraphInfo {
+        operands: [
+            Operand {
+                kind: Input,
+                descriptor: OperandDescriptor {
+                    data_type: Float32,
+                    shape: [
+                        Dynamic(
+                            DynamicDimension {
+                                name: "fritz",
+                                max_size: 10,
+                            },
+                        ),
+                        Static(
+                            0,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "input",
+                ),
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            2,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "shape_op",
+                ),
+            },
+            Operand {
+                kind: Constant,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            2,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+        ],
+        input_operands: [
+            0,
+        ],
+        output_operands: [],
+        operations: [
+            Shape {
+                input: 0,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "shape_op",
+                    },
+                ),
+                outputs: [
+                    1,
+                ],
+            },
+            Mul {
+                a: 1,
+                b: 2,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "",
+                    },
+                ),
+                outputs: [
+                    3,
+                ],
+            },
+        ],
+        constant_operand_ids_to_handles: {
+            2: ConstantData {
+                data: [
+                    2,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                label: None,
+            },
+        },
+        id_to_constant_tensor_operand_map: {
+            2: "2",
+        },
+        quantized: false,
+    },
+)

--- a/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input-3.snap
+++ b/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input-3.snap
@@ -1,0 +1,116 @@
+---
+source: src/mlgraphbuilder.rs
+expression: builder.graph
+---
+Some(
+    GraphInfo {
+        operands: [
+            Operand {
+                kind: Input,
+                descriptor: OperandDescriptor {
+                    data_type: Float32,
+                    shape: [
+                        Static(
+                            2,
+                        ),
+                        Static(
+                            3,
+                        ),
+                        Static(
+                            4,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "input",
+                ),
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            3,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "shape_op",
+                ),
+            },
+            Operand {
+                kind: Constant,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            3,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+        ],
+        input_operands: [
+            0,
+        ],
+        output_operands: [],
+        operations: [
+            Shape {
+                input: 0,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "shape_op",
+                    },
+                ),
+                outputs: [
+                    1,
+                ],
+            },
+            Mul {
+                a: 1,
+                b: 2,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "",
+                    },
+                ),
+                outputs: [
+                    3,
+                ],
+            },
+        ],
+        constant_operand_ids_to_handles: {
+            2: ConstantData {
+                data: [
+                    2,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                label: None,
+            },
+        },
+        id_to_constant_tensor_operand_map: {
+            2: "2",
+        },
+        quantized: false,
+    },
+)

--- a/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input.snap
+++ b/src/snapshots/rustnn__mlgraphbuilder__test__dynamic_input.snap
@@ -1,0 +1,113 @@
+---
+source: src/mlgraphbuilder.rs
+expression: builder.graph
+---
+Some(
+    GraphInfo {
+        operands: [
+            Operand {
+                kind: Input,
+                descriptor: OperandDescriptor {
+                    data_type: Float32,
+                    shape: [
+                        Dynamic(
+                            DynamicDimension {
+                                name: "fritz",
+                                max_size: 10,
+                            },
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "input",
+                ),
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            1,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: Some(
+                    "shape_op",
+                ),
+            },
+            Operand {
+                kind: Constant,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+            Operand {
+                kind: Intermediate,
+                descriptor: OperandDescriptor {
+                    data_type: Int64,
+                    shape: [
+                        Static(
+                            1,
+                        ),
+                    ],
+                    pending_permutation: [],
+                },
+                name: None,
+            },
+        ],
+        input_operands: [
+            0,
+        ],
+        output_operands: [],
+        operations: [
+            Shape {
+                input: 0,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "shape_op",
+                    },
+                ),
+                outputs: [
+                    1,
+                ],
+            },
+            Mul {
+                a: 1,
+                b: 2,
+                options: Some(
+                    MLOperatorOptions {
+                        label: "",
+                    },
+                ),
+                outputs: [
+                    3,
+                ],
+            },
+        ],
+        constant_operand_ids_to_handles: {
+            2: ConstantData {
+                data: [
+                    2,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                label: None,
+            },
+        },
+        id_to_constant_tensor_operand_map: {
+            2: "2",
+        },
+        quantized: false,
+    },
+)

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -137,6 +137,10 @@ pub enum BackendKind {
     CoreML,
     /// NVIDIA TensorRT backend
     TensorRT,
+    /// Google LiteRT backend
+    LiteRT,
+    /// Huawei CANN backend
+    Cann,
 }
 
 impl std::fmt::Display for DeviceKind {
@@ -157,6 +161,8 @@ impl std::fmt::Display for BackendKind {
             BackendKind::OnnxGpu => write!(f, "onnx_gpu"),
             BackendKind::CoreML => write!(f, "coreml"),
             BackendKind::TensorRT => write!(f, "tensorrt"),
+            BackendKind::LiteRT => write!(f, "litert"),
+            BackendKind::Cann => write!(f, "cann"),
         }
     }
 }
@@ -195,6 +201,8 @@ mod tests {
         assert_eq!(BackendKind::OnnxGpu.to_string(), "onnx_gpu");
         assert_eq!(BackendKind::CoreML.to_string(), "coreml");
         assert_eq!(BackendKind::TensorRT.to_string(), "tensorrt");
+        assert_eq!(BackendKind::LiteRT.to_string(), "litert");
+        assert_eq!(BackendKind::Cann.to_string(), "cann");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- [x] Describe the user-visible and code-level changes.

WIP implementation of https://github.com/webmachinelearning/webnn/pull/945 basically adding the required API functions.

The `.shape`/`.shape_with_options` function existed already before this PR and where not guarded by `feature = "dynamic-inputs`. The `shape` op currently returns `Vec<i64>` instead of the u32 from the explainer. ORT and we used i64 internally but should probably switch to u32 from WebNN.

This PR will require some kind of shape validation. Either 
- our existing, which may give up on dynamic shape resolution (e.g. yield unknown shape),
- or no build validation for dynamic shapes
- or a simple expression tree that is evaluated on `computeShape`
- or a fully symbolic constraint solver like z3 which is likely overkill but might help us for bring up by being mathematically correct and ready to use

## Validation

- [ ] `make test`
- [ ] Relevant WPT or integration checks

## Documentation

- [ ] Updated docs if behavior changed
- [ ] If backend converter/executor operator support changed, ran `make docs-backend-ops` and committed `docs/development/backend-operator-support.md`

